### PR TITLE
Improve 6 cockpit tools: UUID, XML, Color, Specificity, Schema, HTML

### DIFF
--- a/apps/cockpit/src/app/tool-registry.ts
+++ b/apps/cockpit/src/app/tool-registry.ts
@@ -36,21 +36,21 @@ export const TOOLS: ToolDefinition[] = [
   { id: 'refactoring-toolkit', name: 'Refactoring Toolkit', group: 'code', icon: '♻', description: 'Regex code transforms with diff preview (12 transforms, JS/TS)', component: RefactoringToolkit },
   // --- Data ---
   { id: 'json-tools', name: 'JSON Tools', group: 'data', icon: '{}', description: 'Validate, format, minify, sort keys, path query, and tree view for JSON', component: JsonTools },
-  { id: 'xml-tools', name: 'XML Tools', group: 'data', icon: '<>', description: 'Validate and format XML', component: XmlTools },
-  { id: 'json-schema-validator', name: 'JSON Schema Validator', group: 'data', icon: '✓{', description: 'Validate JSON against a schema', component: JsonSchemaValidator },
+  { id: 'xml-tools', name: 'XML Tools', group: 'data', icon: '<>', description: 'Validate, format, minify XML with tree view, JSON conversion, XPath, and stats', component: XmlTools },
+  { id: 'json-schema-validator', name: 'JSON Schema Validator', group: 'data', icon: '✓{', description: 'Validate JSON against schemas with 7 templates, inference, sample generation, and strict mode', component: JsonSchemaValidator },
   // --- Web ---
   { id: 'css-validator', name: 'CSS Validator', group: 'web', icon: '#', description: 'Validate CSS syntax', component: CssValidator },
-  { id: 'html-validator', name: 'HTML Validator', group: 'web', icon: '<h>', description: 'Validate HTML structure and accessibility', component: HtmlValidator },
-  { id: 'css-specificity', name: 'CSS Specificity', group: 'web', icon: '!#', description: 'Calculate CSS selector specificity', component: CssSpecificity },
+  { id: 'html-validator', name: 'HTML Validator', group: 'web', icon: '<h>', description: 'Validate HTML with live preview, configurable rules, heading outline, and starter templates', component: HtmlValidator },
+  { id: 'css-specificity', name: 'CSS Specificity', group: 'web', icon: '!#', description: 'Calculate specificity with segmented bars, component breakdown, winner detection, and !important', component: CssSpecificity },
   { id: 'css-to-tailwind', name: 'CSS → Tailwind', group: 'web', icon: '→T', description: 'Convert CSS rules to Tailwind classes', component: CssToTailwind },
   // --- Convert ---
   { id: 'case-converter', name: 'Case Converter', group: 'convert', icon: 'Aa', description: 'Convert between 12 cases with detection, word splitting, and chaining', component: CaseConverter },
-  { id: 'color-converter', name: 'Color Converter', group: 'convert', icon: '🎨', description: 'Convert between hex, rgb, hsl, oklch', component: ColorConverter },
+  { id: 'color-converter', name: 'Color Converter', group: 'convert', icon: '🎨', description: 'Convert hex/rgb/hsl/hsb/oklch with 148 named colors, shade scale, harmony, and history', component: ColorConverter },
   { id: 'timestamp-converter', name: 'Timestamp Converter', group: 'convert', icon: '⏱', description: 'Timestamps with presets, date picker, timezone, day/week info', component: TimestampConverter },
   { id: 'base64', name: 'Base64', group: 'convert', icon: 'B64', description: 'Encode/decode Base64 with URL-safe, line wrap, image preview, data URIs', component: Base64Tool },
   { id: 'url-codec', name: 'URL Encode/Decode', group: 'convert', icon: '%', description: 'URL encode/decode with swap, double-encode detection, color-coded parts', component: UrlCodec },
   { id: 'curl-to-fetch', name: 'cURL → Fetch', group: 'convert', icon: '→f', description: 'Convert cURL to fetch, axios, ky, XHR, Node.js with syntax highlighting', component: CurlToFetch },
-  { id: 'uuid-generator', name: 'UUID Generator', group: 'convert', icon: '#!', description: 'Generate and validate UUIDs', component: UuidGenerator },
+  { id: 'uuid-generator', name: 'UUID Generator', group: 'convert', icon: '#!', description: 'Generate v1/v4/v7 UUIDs with universal validation, parsing, and bulk export', component: UuidGenerator },
   { id: 'hash-generator', name: 'Hash Generator', group: 'convert', icon: '##', description: 'Generate hashes and HMAC with comparison and export', component: HashGenerator },
   // --- Test ---
   { id: 'regex-tester', name: 'Regex Tester', group: 'test', icon: '.*', description: 'Test and replace with match highlighting, groups, and export', component: RegexTester },

--- a/apps/cockpit/src/tools/__tests__/json-schema-validator.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-schema-validator.test.tsx
@@ -24,6 +24,6 @@ describe('JsonSchemaValidator', () => {
 
   it('shows template buttons', () => {
     renderTool(JsonSchemaValidator)
-    expect(screen.getByText('basic')).toBeInTheDocument()
+    expect(screen.getByText('Basic')).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -1,66 +1,132 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { useUiStore } from '@/stores/ui.store'
+
+// ── Types ────────────────────────────────────────────────────────────
+
+type RGB = { r: number; g: number; b: number }
+type HSL = { h: number; s: number; l: number }
+type HSB = { h: number; s: number; b: number }
 
 type ColorConverterState = {
   input: string
   contrastFg: string
   contrastBg: string
+  history: string[]
 }
 
-type RGB = { r: number; g: number; b: number }
-type HSL = { h: number; s: number; l: number }
+// ── CSS Named Colors (full 148) ──────────────────────────────────────
 
-// Parse any color string to RGB
+const CSS_NAMED_COLORS: Record<string, string> = {
+  aliceblue: 'f0f8ff', antiquewhite: 'faebd7', aqua: '00ffff', aquamarine: '7fffd4',
+  azure: 'f0ffff', beige: 'f5f5dc', bisque: 'ffe4c4', black: '000000',
+  blanchedalmond: 'ffebcd', blue: '0000ff', blueviolet: '8a2be2', brown: 'a52a2a',
+  burlywood: 'deb887', cadetblue: '5f9ea0', chartreuse: '7fff00', chocolate: 'd2691e',
+  coral: 'ff7f50', cornflowerblue: '6495ed', cornsilk: 'fff8dc', crimson: 'dc143c',
+  cyan: '00ffff', darkblue: '00008b', darkcyan: '008b8b', darkgoldenrod: 'b8860b',
+  darkgray: 'a9a9a9', darkgreen: '006400', darkgrey: 'a9a9a9', darkkhaki: 'bdb76b',
+  darkmagenta: '8b008b', darkolivegreen: '556b2f', darkorange: 'ff8c00', darkorchid: '9932cc',
+  darkred: '8b0000', darksalmon: 'e9967a', darkseagreen: '8fbc8f', darkslateblue: '483d8b',
+  darkslategray: '2f4f4f', darkslategrey: '2f4f4f', darkturquoise: '00ced1', darkviolet: '9400d3',
+  deeppink: 'ff1493', deepskyblue: '00bfff', dimgray: '696969', dimgrey: '696969',
+  dodgerblue: '1e90ff', firebrick: 'b22222', floralwhite: 'fffaf0', forestgreen: '228b22',
+  fuchsia: 'ff00ff', gainsboro: 'dcdcdc', ghostwhite: 'f8f8ff', gold: 'ffd700',
+  goldenrod: 'daa520', gray: '808080', green: '008000', greenyellow: 'adff2f',
+  grey: '808080', honeydew: 'f0fff0', hotpink: 'ff69b4', indianred: 'cd5c5c',
+  indigo: '4b0082', ivory: 'fffff0', khaki: 'f0e68c', lavender: 'e6e6fa',
+  lavenderblush: 'fff0f5', lawngreen: '7cfc00', lemonchiffon: 'fffacd', lightblue: 'add8e6',
+  lightcoral: 'f08080', lightcyan: 'e0ffff', lightgoldenrodyellow: 'fafad2', lightgray: 'd3d3d3',
+  lightgreen: '90ee90', lightgrey: 'd3d3d3', lightpink: 'ffb6c1', lightsalmon: 'ffa07a',
+  lightseagreen: '20b2aa', lightskyblue: '87cefa', lightslategray: '778899', lightslategrey: '778899',
+  lightsteelblue: 'b0c4de', lightyellow: 'ffffe0', lime: '00ff00', limegreen: '32cd32',
+  linen: 'faf0e6', magenta: 'ff00ff', maroon: '800000', mediumaquamarine: '66cdaa',
+  mediumblue: '0000cd', mediumorchid: 'ba55d3', mediumpurple: '9370db', mediumseagreen: '3cb371',
+  mediumslateblue: '7b68ee', mediumspringgreen: '00fa9a', mediumturquoise: '48d1cc',
+  mediumvioletred: 'c71585', midnightblue: '191970', mintcream: 'f5fffa', mistyrose: 'ffe4e1',
+  moccasin: 'ffe4b5', navajowhite: 'ffdead', navy: '000080', oldlace: 'fdf5e6',
+  olive: '808000', olivedrab: '6b8e23', orange: 'ffa500', orangered: 'ff4500',
+  orchid: 'da70d6', palegoldenrod: 'eee8aa', palegreen: '98fb98', paleturquoise: 'afeeee',
+  palevioletred: 'db7093', papayawhip: 'ffefd5', peachpuff: 'ffdab9', peru: 'cd853f',
+  pink: 'ffc0cb', plum: 'dda0dd', powderblue: 'b0e0e6', purple: '800080',
+  rebeccapurple: '663399', red: 'ff0000', rosybrown: 'bc8f8f', royalblue: '4169e1',
+  saddlebrown: '8b4513', salmon: 'fa8072', sandybrown: 'f4a460', seagreen: '2e8b57',
+  seashell: 'fff5ee', sienna: 'a0522d', silver: 'c0c0c0', skyblue: '87ceeb',
+  slateblue: '6a5acd', slategray: '708090', slategrey: '708090', snow: 'fffafa',
+  springgreen: '00ff7f', steelblue: '4682b4', tan: 'd2b48c', teal: '008080',
+  thistle: 'd8bfd8', tomato: 'ff6347', turquoise: '40e0d0', violet: 'ee82ee',
+  wheat: 'f5deb3', white: 'ffffff', whitesmoke: 'f5f5f5', yellow: 'ffff00',
+  yellowgreen: '9acd32',
+}
+
+// ── Color Math ───────────────────────────────────────────────────────
+
 function parseColor(input: string): RGB | null {
   const trimmed = input.trim().toLowerCase()
 
-  // Hex: #rgb, #rrggbb
+  // Hex: #rgb, #rrggbb, #rrggbbaa
   const hexMatch = trimmed.match(/^#([0-9a-f]{3,8})$/)
   if (hexMatch?.[1]) {
     const hex = hexMatch[1]
     if (hex.length === 3) {
-      return { r: parseInt(hex[0]! + hex[0]!, 16), g: parseInt(hex[1]! + hex[1]!, 16), b: parseInt(hex[2]! + hex[2]!, 16) }
+      return {
+        r: parseInt(hex[0]! + hex[0]!, 16),
+        g: parseInt(hex[1]! + hex[1]!, 16),
+        b: parseInt(hex[2]! + hex[2]!, 16),
+      }
     }
     if (hex.length >= 6) {
-      return { r: parseInt(hex.slice(0, 2), 16), g: parseInt(hex.slice(2, 4), 16), b: parseInt(hex.slice(4, 6), 16) }
+      return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16),
+      }
     }
   }
 
-  // rgb(r, g, b) or rgba(r, g, b, a)
-  const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/)
+  // rgb(r, g, b) or rgba(r, g, b, a) — also modern space syntax
+  const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)/)
   if (rgbMatch) {
     return { r: Number(rgbMatch[1]), g: Number(rgbMatch[2]), b: Number(rgbMatch[3]) }
   }
 
-  // hsl(h, s%, l%)
-  const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%/)
+  // hsl(h, s%, l%) — also modern space syntax
+  const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%/)
   if (hslMatch) {
     return hslToRgb({ h: Number(hslMatch[1]), s: Number(hslMatch[2]), l: Number(hslMatch[3]) })
   }
 
-  // Named CSS colors (common ones)
-  const NAMED: Record<string, RGB> = {
-    red: { r: 255, g: 0, b: 0 }, green: { r: 0, g: 128, b: 0 }, blue: { r: 0, g: 0, b: 255 },
-    white: { r: 255, g: 255, b: 255 }, black: { r: 0, g: 0, b: 0 },
-    yellow: { r: 255, g: 255, b: 0 }, cyan: { r: 0, g: 255, b: 255 }, magenta: { r: 255, g: 0, b: 255 },
-    orange: { r: 255, g: 165, b: 0 }, purple: { r: 128, g: 0, b: 128 }, pink: { r: 255, g: 192, b: 203 },
-    gray: { r: 128, g: 128, b: 128 }, grey: { r: 128, g: 128, b: 128 },
+  // oklch(L C H) — parse and convert
+  const oklchMatch = trimmed.match(/oklch\(\s*([\d.]+)%?\s+([\d.]+)\s+([\d.]+)/)
+  if (oklchMatch) {
+    const L = Number(oklchMatch[1]) > 1 ? Number(oklchMatch[1]) / 100 : Number(oklchMatch[1])
+    return oklchToRgb(L, Number(oklchMatch[2]), Number(oklchMatch[3]))
   }
-  const named = NAMED[trimmed]
-  if (named) return named
+
+  // Named CSS colors
+  const named = CSS_NAMED_COLORS[trimmed]
+  if (named) {
+    return {
+      r: parseInt(named.slice(0, 2), 16),
+      g: parseInt(named.slice(2, 4), 16),
+      b: parseInt(named.slice(4, 6), 16),
+    }
+  }
 
   return null
 }
 
 function rgbToHex(rgb: RGB): string {
-  const hex = (n: number) => n.toString(16).padStart(2, '0')
+  const hex = (n: number) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0')
   return `#${hex(rgb.r)}${hex(rgb.g)}${hex(rgb.b)}`
 }
 
 function rgbToHsl(rgb: RGB): HSL {
-  const r = rgb.r / 255, g = rgb.g / 255, b = rgb.b / 255
-  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  const r = rgb.r / 255
+  const g = rgb.g / 255
+  const b = rgb.b / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
   const l = (max + min) / 2
   if (max === min) return { h: 0, s: 0, l: Math.round(l * 100) }
   const d = max - min
@@ -73,26 +139,106 @@ function rgbToHsl(rgb: RGB): HSL {
 }
 
 function hslToRgb(hsl: HSL): RGB {
-  const s = hsl.s / 100, l = hsl.l / 100
-  if (s === 0) { const v = Math.round(l * 255); return { r: v, g: v, b: v } }
+  const s = hsl.s / 100
+  const l = hsl.l / 100
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return { r: v, g: v, b: v }
+  }
   const h = hsl.h / 360
   const q = l < 0.5 ? l * (1 + s) : l + s - l * s
   const p = 2 * l - q
   const hue2rgb = (t: number) => {
-    if (t < 0) t += 1; if (t > 1) t -= 1
-    if (t < 1/6) return p + (q - p) * 6 * t
-    if (t < 1/2) return q
-    if (t < 2/3) return p + (q - p) * (2/3 - t) * 6
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
     return p
   }
   return {
-    r: Math.round(hue2rgb(h + 1/3) * 255),
+    r: Math.round(hue2rgb(h + 1 / 3) * 255),
     g: Math.round(hue2rgb(h) * 255),
-    b: Math.round(hue2rgb(h - 1/3) * 255),
+    b: Math.round(hue2rgb(h - 1 / 3) * 255),
   }
 }
 
-// WCAG relative luminance
+function rgbToHsb(rgb: RGB): HSB {
+  const r = rgb.r / 255
+  const g = rgb.g / 255
+  const b = rgb.b / 255
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const d = max - min
+  let h = 0
+  if (d !== 0) {
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+    else if (max === g) h = ((b - r) / d + 2) / 6
+    else h = ((r - g) / d + 4) / 6
+  }
+  const s = max === 0 ? 0 : d / max
+  return { h: Math.round(h * 360), s: Math.round(s * 100), b: Math.round(max * 100) }
+}
+
+// ── OKLCH conversion (approximate) ───────────────────────────────────
+
+function rgbToOklch(rgb: RGB): { l: number; c: number; h: number } {
+  // sRGB → linear
+  const toLinear = (v: number) => {
+    const s = v / 255
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+  }
+  const lr = toLinear(rgb.r)
+  const lg = toLinear(rgb.g)
+  const lb = toLinear(rgb.b)
+
+  // Linear sRGB → OKLab via LMS
+  const l_ = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb)
+  const m_ = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb)
+  const s_ = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb)
+
+  const L = 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_
+  const a = 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_
+  const bVal = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_
+
+  const C = Math.sqrt(a * a + bVal * bVal)
+  let H = (Math.atan2(bVal, a) * 180) / Math.PI
+  if (H < 0) H += 360
+
+  return {
+    l: Math.round(L * 1000) / 10,
+    c: Math.round(C * 1000) / 1000,
+    h: Math.round(H * 10) / 10,
+  }
+}
+
+function oklchToRgb(L: number, C: number, H: number): RGB {
+  const hRad = (H * Math.PI) / 180
+  const a = C * Math.cos(hRad)
+  const b = C * Math.sin(hRad)
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b
+
+  const l3 = l_ * l_ * l_
+  const m3 = m_ * m_ * m_
+  const s3 = s_ * s_ * s_
+
+  const lr = 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3
+  const lg = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3
+  const lb = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3
+
+  const toSrgb = (v: number) => {
+    const c = Math.max(0, Math.min(1, v))
+    return Math.round((c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055) * 255)
+  }
+
+  return { r: toSrgb(lr), g: toSrgb(lg), b: toSrgb(lb) }
+}
+
+// ── WCAG ─────────────────────────────────────────────────────────────
+
 function luminance(rgb: RGB): number {
   const [rs, gs, bs] = [rgb.r, rgb.g, rgb.b].map((c) => {
     const s = c / 255
@@ -107,23 +253,162 @@ function contrastRatio(fg: RGB, bg: RGB): number {
   return (l1 + 0.05) / (l2 + 0.05)
 }
 
+// ── Shade/Tint Generator ─────────────────────────────────────────────
+
+function generateScale(rgb: RGB): { label: string; hex: string; rgb: RGB }[] {
+  const hsl = rgbToHsl(rgb)
+  const steps = [5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95]
+  return steps.map((l) => {
+    const stepRgb = hslToRgb({ h: hsl.h, s: hsl.s, l })
+    return { label: `${l}%`, hex: rgbToHex(stepRgb), rgb: stepRgb }
+  })
+}
+
+// ── Color Harmonies ──────────────────────────────────────────────────
+
+function harmonies(rgb: RGB): { label: string; hex: string }[] {
+  const hsl = rgbToHsl(rgb)
+  const make = (offset: number) => rgbToHex(hslToRgb({ h: (hsl.h + offset) % 360, s: hsl.s, l: hsl.l }))
+  return [
+    { label: 'Complementary', hex: make(180) },
+    { label: 'Analogous −30°', hex: make(330) },
+    { label: 'Analogous +30°', hex: make(30) },
+    { label: 'Triadic +120°', hex: make(120) },
+    { label: 'Triadic −120°', hex: make(240) },
+    { label: 'Split-comp +150°', hex: make(150) },
+    { label: 'Split-comp −150°', hex: make(210) },
+  ]
+}
+
+// ── Find CSS name ────────────────────────────────────────────────────
+
+function findCssName(hex: string): string | null {
+  const h = hex.replace('#', '').toLowerCase()
+  for (const [name, val] of Object.entries(CSS_NAMED_COLORS)) {
+    if (val === h) return name
+  }
+  return null
+}
+
+// ── Contrast Inputs (avoids double parseColor calls) ─────────────────
+
+function ContrastInputs({
+  contrastFg,
+  contrastBg,
+  onFgChange,
+  onBgChange,
+  onSwap,
+}: {
+  contrastFg: string
+  contrastBg: string
+  onFgChange: (v: string) => void
+  onBgChange: (v: string) => void
+  onSwap: () => void
+}) {
+  const fgRgb = useMemo(() => parseColor(contrastFg), [contrastFg])
+  const bgRgb = useMemo(() => parseColor(contrastBg), [contrastBg])
+  const fgHex = fgRgb ? rgbToHex(fgRgb) : '#ffffff'
+  const bgHex = bgRgb ? rgbToHex(bgRgb) : '#000000'
+
+  return (
+    <div className="flex items-end gap-4">
+      <div className="flex-1">
+        <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Foreground</label>
+        <div className="flex items-center gap-2">
+          <input
+            value={contrastFg}
+            onChange={(e) => onFgChange(e.target.value)}
+            className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+          />
+          <input
+            type="color"
+            value={fgHex}
+            onChange={(e) => onFgChange(e.target.value)}
+            className="h-8 w-8 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
+          />
+        </div>
+      </div>
+      <button
+        onClick={onSwap}
+        className="mb-1 rounded border border-[var(--color-border)] px-2 py-1.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+        title="Swap foreground and background"
+      >
+        ⇄
+      </button>
+      <div className="flex-1">
+        <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Background</label>
+        <div className="flex items-center gap-2">
+          <input
+            value={contrastBg}
+            onChange={(e) => onBgChange(e.target.value)}
+            className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+          />
+          <input
+            type="color"
+            value={bgHex}
+            onChange={(e) => onBgChange(e.target.value)}
+            className="h-8 w-8 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
 export default function ColorConverter() {
   const [state, updateState] = useToolState<ColorConverterState>('color-converter', {
     input: '#39ff14',
     contrastFg: '#ffffff',
     contrastBg: '#000000',
+    history: [],
   })
+
+  const setLastAction = useUiStore((s) => s.setLastAction)
+  const [activeSection, setActiveSection] = useState<'formats' | 'scale' | 'harmony'>('formats')
+
   const color = useMemo(() => {
     const rgb = parseColor(state.input)
     if (!rgb) return null
     const hsl = rgbToHsl(rgb)
-    return {
-      rgb,
-      hex: rgbToHex(rgb),
-      rgbStr: `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`,
-      hslStr: `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`,
-    }
+    const hsb = rgbToHsb(rgb)
+    const oklch = rgbToOklch(rgb)
+    const cssName = findCssName(rgbToHex(rgb))
+    return { rgb, hsl, hsb, oklch, hex: rgbToHex(rgb), cssName }
   }, [state.input])
+
+  const historyRef = useRef(state.history)
+  historyRef.current = state.history
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      updateState({ input: value })
+      const rgb = parseColor(value)
+      if (rgb) {
+        const hex = rgbToHex(rgb)
+        const prev = historyRef.current.filter((h) => h !== hex)
+        const next = [hex, ...prev].slice(0, 12)
+        updateState({ history: next })
+      }
+    },
+    [updateState]
+  )
+
+  const formats = useMemo(() => {
+    if (!color) return []
+    return [
+      { label: 'Hex', value: color.hex },
+      { label: 'RGB', value: `rgb(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b})` },
+      { label: 'HSL', value: `hsl(${color.hsl.h}, ${color.hsl.s}%, ${color.hsl.l}%)` },
+      { label: 'HSB', value: `hsb(${color.hsb.h}, ${color.hsb.s}%, ${color.hsb.b}%)` },
+      { label: 'OKLCH', value: `oklch(${color.oklch.l}% ${color.oklch.c} ${color.oklch.h})` },
+      ...(color.cssName ? [{ label: 'CSS Name', value: color.cssName }] : []),
+    ]
+  }, [color])
+
+  const scale = useMemo(() => (color ? generateScale(color.rgb) : []), [color])
+  const harmony = useMemo(() => (color ? harmonies(color.rgb) : []), [color])
 
   const contrast = useMemo(() => {
     const fg = parseColor(state.contrastFg)
@@ -138,87 +423,167 @@ export default function ColorConverter() {
     }
   }, [state.contrastFg, state.contrastBg])
 
-  const formats = color
-    ? [
-        { label: 'Hex', value: color.hex },
-        { label: 'RGB', value: color.rgbStr },
-        { label: 'HSL', value: color.hslStr },
-      ]
-    : []
+  const swapContrast = useCallback(() => {
+    updateState({ contrastFg: state.contrastBg, contrastBg: state.contrastFg })
+    setLastAction('Swapped contrast colors', 'info')
+  }, [state.contrastFg, state.contrastBg, updateState, setLastAction])
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-auto p-4">
+      {/* ── Input ──────────────────────────────────────── */}
       <section>
         <h2 className="mb-2 font-pixel text-sm text-[var(--color-text)]">Color Input</h2>
         <div className="flex items-center gap-3">
           <input
             value={state.input}
-            onChange={(e) => updateState({ input: e.target.value })}
-            placeholder="#39ff14, rgb(255,0,0), hsl(120,100%,50%), red"
+            onChange={(e) => handleInputChange(e.target.value)}
+            placeholder="#39ff14, rgb(255,0,0), hsl(120,100%,50%), oklch(87% 0.35 145), red"
             className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
           />
           <input
             type="color"
             value={color?.hex ?? '#000000'}
-            onChange={(e) => updateState({ input: e.target.value })}
+            onChange={(e) => handleInputChange(e.target.value)}
             title="Pick a color"
             className="h-10 w-10 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
           />
+          {color && (
+            <div
+              className="h-10 w-10 shrink-0 rounded border border-[var(--color-border)]"
+              style={{ backgroundColor: color.hex }}
+              title={color.hex}
+            />
+          )}
         </div>
-      </section>
 
-      {formats.length > 0 && (
-        <section>
-          <h2 className="mb-2 font-pixel text-sm text-[var(--color-text)]">Formats</h2>
-          <div className="flex flex-col gap-2">
-            {formats.map((f) => (
-              <div key={f.label} className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
-                <div>
-                  <span className="text-xs text-[var(--color-text-muted)]">{f.label}: </span>
-                  <span className="font-mono text-sm text-[var(--color-text)]">{f.value}</span>
-                </div>
-                <CopyButton text={f.value} />
-              </div>
+        {/* History */}
+        {state.history.length > 0 && (
+          <div className="mt-2 flex items-center gap-1.5">
+            <span className="text-xs text-[var(--color-text-muted)]">Recent:</span>
+            {state.history.map((hex) => (
+              <button
+                key={hex}
+                onClick={() => updateState({ input: hex })}
+                className="h-5 w-5 rounded border border-[var(--color-border)] transition-transform hover:scale-125"
+                style={{ backgroundColor: hex }}
+                title={hex}
+              />
             ))}
           </div>
-        </section>
+        )}
+      </section>
+
+      {/* ── Section Tabs ──────────────────────────────── */}
+      {color && (
+        <>
+          <div className="flex gap-2 border-b border-[var(--color-border)] pb-1">
+            {(['formats', 'scale', 'harmony'] as const).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setActiveSection(tab)}
+                className={`px-3 py-1 text-xs font-pixel rounded-t ${
+                  activeSection === tab
+                    ? 'text-[var(--color-accent)] border-b-2 border-[var(--color-accent)]'
+                    : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
+                }`}
+              >
+                {tab === 'formats' ? 'Formats' : tab === 'scale' ? 'Shades & Tints' : 'Harmony'}
+              </button>
+            ))}
+          </div>
+
+          {/* ── Formats ─────────────────────────────────── */}
+          {activeSection === 'formats' && (
+            <section className="flex flex-col gap-2">
+              {formats.map((f) => (
+                <div
+                  key={f.label}
+                  className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2"
+                >
+                  <div>
+                    <span className="text-xs text-[var(--color-text-muted)]">{f.label}: </span>
+                    <span className="font-mono text-sm text-[var(--color-text)]">{f.value}</span>
+                  </div>
+                  <CopyButton text={f.value} />
+                </div>
+              ))}
+            </section>
+          )}
+
+          {/* ── Shades & Tints ──────────────────────────── */}
+          {activeSection === 'scale' && (
+            <section>
+              <div className="flex flex-wrap gap-2">
+                {scale.map((step) => (
+                  <button
+                    key={step.label}
+                    onClick={() => updateState({ input: step.hex })}
+                    className="group flex flex-col items-center gap-1"
+                    title={step.hex}
+                  >
+                    <div
+                      className="h-10 w-10 rounded border border-[var(--color-border)] transition-transform group-hover:scale-110"
+                      style={{ backgroundColor: step.hex }}
+                    />
+                    <span className="text-[10px] text-[var(--color-text-muted)]">{step.label}</span>
+                    <span className="text-[10px] font-mono text-[var(--color-text-muted)] opacity-0 group-hover:opacity-100 transition-opacity">
+                      {step.hex}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* ── Harmony ─────────────────────────────────── */}
+          {activeSection === 'harmony' && (
+            <section>
+              <div className="flex flex-col gap-2">
+                {harmony.map((h) => (
+                  <div
+                    key={h.label}
+                    className="flex items-center gap-3 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2"
+                  >
+                    <div
+                      className="h-8 w-8 shrink-0 rounded border border-[var(--color-border)]"
+                      style={{ backgroundColor: h.hex }}
+                    />
+                    <div className="flex-1">
+                      <span className="text-xs text-[var(--color-text-muted)]">{h.label}</span>
+                      <span className="ml-2 font-mono text-sm text-[var(--color-text)]">{h.hex}</span>
+                    </div>
+                    <button
+                      onClick={() => updateState({ input: h.hex })}
+                      className="rounded border border-[var(--color-border)] px-2 py-0.5 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+                    >
+                      Use
+                    </button>
+                    <CopyButton text={h.hex} />
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+        </>
       )}
 
+      {/* ── Contrast Ratio ─────────────────────────────── */}
       <section>
         <h2 className="mb-2 font-pixel text-sm text-[var(--color-text)]">Contrast Ratio (WCAG)</h2>
-        <div className="flex items-end gap-4">
-          <div className="flex-1">
-            <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Foreground</label>
-            <div className="flex items-center gap-2">
-              <input
-                value={state.contrastFg}
-                onChange={(e) => updateState({ contrastFg: e.target.value })}
-                className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
-              />
-              {parseColor(state.contrastFg) && (
-                <div className="h-6 w-6 shrink-0 rounded border border-[var(--color-border)]" style={{ backgroundColor: state.contrastFg }} />
-              )}
-            </div>
-          </div>
-          <div className="flex-1">
-            <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Background</label>
-            <div className="flex items-center gap-2">
-              <input
-                value={state.contrastBg}
-                onChange={(e) => updateState({ contrastBg: e.target.value })}
-                className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
-              />
-              {parseColor(state.contrastBg) && (
-                <div className="h-6 w-6 shrink-0 rounded border border-[var(--color-border)]" style={{ backgroundColor: state.contrastBg }} />
-              )}
-            </div>
-          </div>
-        </div>
+        <ContrastInputs
+          contrastFg={state.contrastFg}
+          contrastBg={state.contrastBg}
+          onFgChange={(v) => updateState({ contrastFg: v })}
+          onBgChange={(v) => updateState({ contrastBg: v })}
+          onSwap={swapContrast}
+        />
         {contrast && (
           <div className="mt-3 flex items-center gap-4">
             <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
               <div className="text-xs text-[var(--color-text-muted)]">Ratio</div>
-              <div className="font-mono text-lg font-bold text-[var(--color-text)]">{contrast.ratio}:1</div>
+              <div className="font-mono text-lg font-bold text-[var(--color-text)]">
+                {contrast.ratio}:1
+              </div>
             </div>
             <div
               className="flex h-12 items-center justify-center rounded border border-[var(--color-border)] px-6 text-sm font-bold"

--- a/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
+++ b/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
@@ -1,57 +1,137 @@
 import { useMemo, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
+import { CopyButton } from '@/components/shared/CopyButton'
+
+// ── Types ────────────────────────────────────────────────────────────
 
 type CssSpecificityState = {
   input: string
 }
 
+type SpecPart = {
+  text: string
+  type: 'id' | 'class' | 'element'
+}
+
 type SpecResult = {
   selector: string
-  a: number  // IDs
-  b: number  // Classes, attributes, pseudo-classes
-  c: number  // Elements, pseudo-elements
+  a: number // IDs
+  b: number // Classes, attributes, pseudo-classes
+  c: number // Elements, pseudo-elements
   score: number
+  parts: SpecPart[]
+  hasImportant: boolean
 }
 
-function computeSpecificity(selector: string): { a: number; b: number; c: number } {
-  let a = 0, b = 0, c = 0
-  // Remove :not() content but count its contents
+// ── Specificity Computation ──────────────────────────────────────────
+
+function computeSpecificity(selector: string): { a: number; b: number; c: number; parts: SpecPart[] } {
+  let a = 0
+  let b = 0
+  let c = 0
+  const parts: SpecPart[] = []
+
+  // Handle :not() — its contents count but not the pseudo-class itself
   let s = selector.replace(/:not\(([^)]+)\)/g, (_, inner: string) => {
-    const inner_spec = computeSpecificity(inner)
-    a += inner_spec.a; b += inner_spec.b; c += inner_spec.c
+    const innerSpec = computeSpecificity(inner)
+    a += innerSpec.a
+    b += innerSpec.b
+    c += innerSpec.c
+    parts.push({ text: `:not(${inner})`, type: innerSpec.a > 0 ? 'id' : innerSpec.b > 0 ? 'class' : 'element' })
     return ''
   })
-  // Remove strings and attribute values
-  s = s.replace(/\[[^\]]*\]/g, () => { b++; return '' })
-  // IDs
-  a += (s.match(/#[a-zA-Z_-][\w-]*/g) ?? []).length
-  // Classes, pseudo-classes (but not pseudo-elements)
-  b += (s.match(/\.[a-zA-Z_-][\w-]*/g) ?? []).length
-  b += (s.match(/:[a-zA-Z][\w-]*(?!\()/g) ?? []).filter((p) => !p.startsWith('::')).length
-  // Elements and pseudo-elements
-  c += (s.match(/::[a-zA-Z][\w-]*/g) ?? []).length
-  // Remove already-counted items, then count remaining element names
-  s = s.replace(/#[a-zA-Z_-][\w-]*/g, '').replace(/\.[a-zA-Z_-][\w-]*/g, '').replace(/:+[a-zA-Z][\w-]*/g, '')
-  c += (s.match(/[a-zA-Z][\w-]*/g) ?? []).length
 
-  return { a, b, c }
+  // Attribute selectors [...]
+  s = s.replace(/\[[^\]]*\]/g, (match) => {
+    b++
+    parts.push({ text: match, type: 'class' })
+    return ''
+  })
+
+  // IDs
+  const ids = s.match(/#[a-zA-Z_-][\w-]*/g) ?? []
+  for (const id of ids) {
+    a++
+    parts.push({ text: id, type: 'id' })
+  }
+
+  // Classes
+  const classes = s.match(/\.[a-zA-Z_-][\w-]*/g) ?? []
+  for (const cls of classes) {
+    b++
+    parts.push({ text: cls, type: 'class' })
+  }
+
+  // Pseudo-elements (::before, ::after, etc.)
+  const pseudoElements = s.match(/::[a-zA-Z][\w-]*/g) ?? []
+  for (const pe of pseudoElements) {
+    c++
+    parts.push({ text: pe, type: 'element' })
+  }
+
+  // Pseudo-classes (:hover, :focus, etc.) — but not pseudo-elements
+  const pseudoClasses = (s.match(/:[a-zA-Z][\w-]*/g) ?? []).filter((p) => !p.startsWith('::'))
+  for (const pc of pseudoClasses) {
+    b++
+    parts.push({ text: pc, type: 'class' })
+  }
+
+  // Remove counted items, count remaining element names
+  s = s
+    .replace(/#[a-zA-Z_-][\w-]*/g, '')
+    .replace(/\.[a-zA-Z_-][\w-]*/g, '')
+    .replace(/:+[a-zA-Z][\w-]*/g, '')
+  const elements = s.match(/[a-zA-Z][\w-]*/g) ?? []
+  for (const el of elements) {
+    c++
+    parts.push({ text: el, type: 'element' })
+  }
+
+  return { a, b, c, parts }
 }
+
+// ── Examples ─────────────────────────────────────────────────────────
+
+const EXAMPLES = [
+  { label: 'Basic', selectors: 'h1\np\ndiv' },
+  { label: 'Classes', selectors: '.card\n.card .title\n.card .title:hover' },
+  { label: 'IDs', selectors: '#main\n#main .content p\n#nav ul li.active' },
+  { label: 'Complex', selectors: 'div > p:first-child\n.sidebar a:hover::before\n#app [data-role="admin"]' },
+  { label: 'Battle', selectors: '.a .b .c\n#x\ndiv div div div div' },
+]
+
+// ── Color tokens per type ────────────────────────────────────────────
+
+const TYPE_COLORS = {
+  id: { bar: 'var(--color-error)', text: 'var(--color-error)', label: 'IDs (a)' },
+  class: { bar: 'var(--color-warning)', text: 'var(--color-warning)', label: 'Classes (b)' },
+  element: { bar: 'var(--color-info)', text: 'var(--color-info)', label: 'Elements (c)' },
+} as const
+
+// ── Component ────────────────────────────────────────────────────────
 
 export default function CssSpecificity() {
   const [state, updateState] = useToolState<CssSpecificityState>('css-specificity', {
     input: '',
   })
   const [sorted, setSorted] = useState(false)
+  const [showBreakdown, setShowBreakdown] = useState(true)
 
   const results = useMemo(() => {
     if (!state.input.trim()) return []
-    const lines = state.input.split('\n').map((l) => l.trim()).filter(Boolean)
+    const lines = state.input
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
     const res: SpecResult[] = lines.map((selector) => {
-      const spec = computeSpecificity(selector)
+      const hasImportant = selector.includes('!important')
+      const cleanSelector = selector.replace(/!important/g, '').trim()
+      const spec = computeSpecificity(cleanSelector)
       return {
         selector,
         ...spec,
         score: spec.a * 100 + spec.b * 10 + spec.c,
+        hasImportant,
       }
     })
     return sorted ? [...res].sort((x, y) => y.score - x.score) : res
@@ -59,8 +139,32 @@ export default function CssSpecificity() {
 
   const maxScore = useMemo(() => Math.max(...results.map((r) => r.score), 1), [results])
 
+  const winnerIdx = useMemo(() => {
+    if (results.length < 2) return -1
+    let maxS = -1
+    let idx = -1
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]!
+      const effective = r.hasImportant ? r.score + 10000 : r.score
+      if (effective > maxS) {
+        maxS = effective
+        idx = i
+      }
+    }
+    return idx
+  }, [results])
+
+  const exportText = useMemo(() => {
+    if (results.length === 0) return ''
+    const lines = results.map(
+      (r) => `${r.selector.padEnd(40)} (${r.a},${r.b},${r.c})  score=${r.score}${r.hasImportant ? ' !important' : ''}`
+    )
+    return lines.join('\n')
+  }, [results])
+
   return (
     <div className="flex h-full flex-col">
+      {/* Toolbar */}
       <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
         <button
           onClick={() => setSorted(!sorted)}
@@ -72,47 +176,164 @@ export default function CssSpecificity() {
         >
           Sort by specificity
         </button>
+        <button
+          onClick={() => setShowBreakdown(!showBreakdown)}
+          className={`rounded border px-3 py-1 text-xs ${
+            showBreakdown
+              ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+              : 'border-[var(--color-border)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
+          }`}
+        >
+          Breakdown
+        </button>
         {results.length > 0 && (
-          <span className="text-xs text-[var(--color-text-muted)]">{results.length} selector(s)</span>
+          <>
+            <span className="text-xs text-[var(--color-text-muted)]">{results.length} selector(s)</span>
+            <CopyButton text={exportText} label="Export" />
+          </>
         )}
+        <div className="ml-auto flex items-center gap-2">
+          {EXAMPLES.map((ex) => (
+            <button
+              key={ex.label}
+              onClick={() => updateState({ input: ex.selectors })}
+              className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+            >
+              {ex.label}
+            </button>
+          ))}
+        </div>
       </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1">
+        {Object.values(TYPE_COLORS).map((tc) => (
+          <div key={tc.label} className="flex items-center gap-1">
+            <div className="h-2 w-4 rounded" style={{ backgroundColor: tc.bar }} />
+            <span className="text-[10px]" style={{ color: tc.text }}>{tc.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+        {/* Input */}
+        <div className="flex w-2/5 flex-col border-r border-[var(--color-border)]">
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
             Selectors (one per line)
           </div>
           <textarea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
-            placeholder={"#main .content p\n.sidebar a:hover\ndiv > p:first-child\n#nav ul li.active"}
+            placeholder={'#main .content p\n.sidebar a:hover\ndiv > p:first-child\n#nav ul li.active'}
             className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
           />
         </div>
-        <div className="flex w-1/2 flex-col overflow-auto p-4">
+
+        {/* Results */}
+        <div className="flex w-3/5 flex-col overflow-auto p-4">
           {results.length > 0 ? (
             <div className="flex flex-col gap-3">
-              {results.map((r, i) => (
-                <div key={i} className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-                  <div className="mb-1 flex items-center justify-between">
-                    <code className="text-xs text-[var(--color-text)]">{r.selector}</code>
-                    <span className="font-mono text-xs font-bold text-[var(--color-accent)]">
-                      ({r.a}, {r.b}, {r.c})
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <div className="h-2 flex-1 rounded bg-[var(--color-bg)]">
-                      <div
-                        className="h-2 rounded bg-[var(--color-accent)]"
-                        style={{ width: `${(r.score / maxScore) * 100}%` }}
-                      />
+              {results.map((r, i) => {
+                const isWinner = i === winnerIdx && results.length > 1
+                return (
+                  <div
+                    key={i}
+                    className={`rounded border p-3 ${
+                      isWinner
+                        ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)]'
+                        : 'border-[var(--color-border)] bg-[var(--color-surface)]'
+                    }`}
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        {isWinner && (
+                          <span className="rounded bg-[var(--color-accent)] px-1.5 py-0.5 text-[10px] font-bold text-[var(--color-bg)]">
+                            WINS
+                          </span>
+                        )}
+                        <code className="text-xs text-[var(--color-text)]">{r.selector}</code>
+                        {r.hasImportant && (
+                          <span className="rounded bg-[var(--color-error)] px-1.5 py-0.5 text-[10px] font-bold text-white">
+                            !important
+                          </span>
+                        )}
+                      </div>
+                      <span className="shrink-0 font-mono text-xs font-bold text-[var(--color-accent)]">
+                        ({r.a}, {r.b}, {r.c})
+                      </span>
                     </div>
-                    <span className="w-8 text-right text-xs text-[var(--color-text-muted)]">{r.score}</span>
+
+                    {/* Segmented bar */}
+                    <div className="flex items-center gap-2">
+                      <div className="h-2.5 flex-1 flex rounded bg-[var(--color-bg)] overflow-hidden">
+                        {r.a > 0 && (
+                          <div
+                            className="h-full"
+                            style={{
+                              width: `${(r.a * 100 * 100) / maxScore}%`,
+                              backgroundColor: TYPE_COLORS.id.bar,
+                            }}
+                            title={`IDs: ${r.a}`}
+                          />
+                        )}
+                        {r.b > 0 && (
+                          <div
+                            className="h-full"
+                            style={{
+                              width: `${(r.b * 10 * 100) / maxScore}%`,
+                              backgroundColor: TYPE_COLORS.class.bar,
+                            }}
+                            title={`Classes: ${r.b}`}
+                          />
+                        )}
+                        {r.c > 0 && (
+                          <div
+                            className="h-full"
+                            style={{
+                              width: `${(r.c * 100) / maxScore}%`,
+                              backgroundColor: TYPE_COLORS.element.bar,
+                            }}
+                            title={`Elements: ${r.c}`}
+                          />
+                        )}
+                      </div>
+                      <span className="w-8 text-right text-xs text-[var(--color-text-muted)]">{r.score}</span>
+                    </div>
+
+                    {/* Breakdown */}
+                    {showBreakdown && r.parts.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        {r.parts.map((part, j) => {
+                          const color =
+                            part.type === 'id'
+                              ? TYPE_COLORS.id.text
+                              : part.type === 'class'
+                                ? TYPE_COLORS.class.text
+                                : TYPE_COLORS.element.text
+                          return (
+                            <span
+                              key={j}
+                              className="rounded border px-1.5 py-0.5 font-mono text-[10px]"
+                              style={{
+                                color,
+                                borderColor: color,
+                              }}
+                            >
+                              {part.text}
+                            </span>
+                          )
+                        })}
+                      </div>
+                    )}
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           ) : (
-            <div className="text-sm text-[var(--color-text-muted)]">Enter CSS selectors on the left</div>
+            <div className="text-sm text-[var(--color-text-muted)]">
+              Enter CSS selectors on the left — try one of the examples above
+            </div>
           )}
         </div>
       </div>

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, EDITOR_OPTIONS } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { useUiStore } from '@/stores/ui.store'
 
+// ── Types ────────────────────────────────────────────────────────────
+
+type ViewMode = 'split' | 'edit' | 'preview'
+
 type HtmlValidatorState = {
   input: string
+  viewMode: ViewMode
+  showRules: boolean
+  disabledRules: string[]
 }
 
 type HtmlError = {
@@ -17,46 +24,197 @@ type HtmlError = {
   rule: string
 }
 
-// HTMLHint has its own ruleset — import dynamically to avoid bundling issues
-async function validateHtml(html: string): Promise<HtmlError[]> {
-  const { HTMLHint } = await import('htmlhint')
-  const results = HTMLHint.verify(html, {
-    'tagname-lowercase': true,
-    'attr-lowercase': true,
-    'attr-value-double-quotes': true,
-    'doctype-first': false,
-    'tag-pair': true,
-    'spec-char-escape': true,
-    'id-unique': true,
-    'src-not-empty': true,
-    'attr-no-duplication': true,
-    'title-require': true,
-    'alt-require': true,
-    'id-class-value': 'dash',
-    'tag-self-close': false,
-    'head-script-disabled': false,
-    'attr-unsafe-chars': true,
-  })
+// ── HTMLHint Rules ───────────────────────────────────────────────────
 
+type RuleConfig = {
+  id: string
+  label: string
+  category: 'structure' | 'attributes' | 'accessibility' | 'style'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultValue: any
+}
+
+const ALL_RULES: RuleConfig[] = [
+  { id: 'tagname-lowercase', label: 'Tag names lowercase', category: 'structure', defaultValue: true },
+  { id: 'tag-pair', label: 'Tag pairs must match', category: 'structure', defaultValue: true },
+  { id: 'spec-char-escape', label: 'Special chars escaped', category: 'structure', defaultValue: true },
+  { id: 'attr-lowercase', label: 'Attribute names lowercase', category: 'attributes', defaultValue: true },
+  { id: 'attr-value-double-quotes', label: 'Double quotes for values', category: 'attributes', defaultValue: true },
+  { id: 'attr-no-duplication', label: 'No duplicate attributes', category: 'attributes', defaultValue: true },
+  { id: 'attr-unsafe-chars', label: 'No unsafe chars in attrs', category: 'attributes', defaultValue: true },
+  { id: 'id-unique', label: 'IDs must be unique', category: 'attributes', defaultValue: true },
+  { id: 'id-class-value', label: 'ID/class naming: dash-case', category: 'attributes', defaultValue: 'dash' },
+  { id: 'src-not-empty', label: 'src not empty', category: 'attributes', defaultValue: true },
+  { id: 'title-require', label: 'Title tag required', category: 'accessibility', defaultValue: true },
+  { id: 'alt-require', label: 'Alt text on images', category: 'accessibility', defaultValue: true },
+  { id: 'doctype-first', label: 'Doctype required', category: 'structure', defaultValue: false },
+  { id: 'tag-self-close', label: 'Self-closing tags', category: 'style', defaultValue: false },
+  { id: 'head-script-disabled', label: 'No scripts in head', category: 'style', defaultValue: false },
+]
+
+const RULE_CATEGORIES = ['structure', 'attributes', 'accessibility', 'style'] as const
+
+// ── Validation ───────────────────────────────────────────────────────
+
+async function validateHtml(html: string, disabledRules: string[]): Promise<HtmlError[]> {
+  const { HTMLHint } = await import('htmlhint')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ruleset: Record<string, any> = {}
+  for (const rule of ALL_RULES) {
+    ruleset[rule.id] = disabledRules.includes(rule.id) ? false : rule.defaultValue
+  }
+  const results = HTMLHint.verify(html, ruleset)
   return results.map((r) => ({
     message: r.message,
     line: r.line,
     col: r.col,
-    // ReportType is a const enum — compare against the string values at runtime
     type: (r.type as string) === 'error' ? ('error' as const) : ('warning' as const),
     rule: r.rule.id,
   }))
 }
 
+// ── HTML Stats ───────────────────────────────────────────────────────
+
+type HtmlStats = {
+  tags: number
+  depth: number
+  inlineStyles: number
+  inlineScripts: number
+  headings: { level: number; text: string }[]
+}
+
+function computeStats(html: string): HtmlStats {
+  const tags = (html.match(/<[a-zA-Z][\w-]*/g) ?? []).length
+  const inlineStyles = (html.match(/style\s*=/gi) ?? []).length
+  const inlineScripts = (html.match(/<script[\s>]/gi) ?? []).length
+
+  // Compute nesting depth
+  let depth = 0
+  let maxDepth = 0
+  const tagPattern = /<\/?([a-zA-Z][\w-]*)[^>]*\/?>/g
+  const selfClosing = new Set(['br', 'hr', 'img', 'input', 'meta', 'link', 'area', 'base', 'col', 'embed', 'source', 'track', 'wbr'])
+  let match: RegExpExecArray | null
+  while ((match = tagPattern.exec(html)) !== null) {
+    const full = match[0]!
+    const tag = match[1]!.toLowerCase()
+    if (selfClosing.has(tag) || full.endsWith('/>')) continue
+    if (full.startsWith('</')) {
+      depth--
+    } else {
+      depth++
+      maxDepth = Math.max(maxDepth, depth)
+    }
+  }
+
+  // Extract headings
+  const headings: { level: number; text: string }[] = []
+  const headingRe = /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi
+  let hMatch: RegExpExecArray | null
+  while ((hMatch = headingRe.exec(html)) !== null) {
+    headings.push({
+      level: parseInt(hMatch[1]!),
+      text: hMatch[2]!.replace(/<[^>]+>/g, '').trim(),
+    })
+  }
+
+  return { tags, depth: maxDepth, inlineStyles, inlineScripts, headings }
+}
+
+// ── Starter Templates ────────────────────────────────────────────────
+
+const STARTERS: Record<string, { label: string; html: string }> = {
+  minimal: {
+    label: 'Minimal',
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Title</title>
+</head>
+<body>
+  <h1>Hello World</h1>
+  <p>Start editing to see validation results.</p>
+</body>
+</html>`,
+  },
+  article: {
+    label: 'Article',
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>My Article</title>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/">Home</a>
+      <a href="/about">About</a>
+    </nav>
+  </header>
+  <main>
+    <article>
+      <h1>Article Title</h1>
+      <p>Published on <time datetime="2026-03-23">March 23, 2026</time></p>
+      <p>Article content goes here.</p>
+      <h2>Section One</h2>
+      <p>Section one content.</p>
+      <h2>Section Two</h2>
+      <p>Section two content.</p>
+    </article>
+  </main>
+  <footer>
+    <p>&copy; 2026</p>
+  </footer>
+</body>
+</html>`,
+  },
+  form: {
+    label: 'Form',
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Contact Form</title>
+</head>
+<body>
+  <h1>Contact Us</h1>
+  <form action="/submit" method="post">
+    <div>
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required>
+    </div>
+    <div>
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required>
+    </div>
+    <div>
+      <label for="message">Message</label>
+      <textarea id="message" name="message" rows="4"></textarea>
+    </div>
+    <button type="submit">Send</button>
+  </form>
+</body>
+</html>`,
+  },
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
 export default function HtmlValidator() {
   useMonacoTheme()
   const [state, updateState] = useToolState<HtmlValidatorState>('html-validator', {
     input: '',
+    viewMode: 'split',
+    showRules: false,
+    disabledRules: [],
   })
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [errors, setErrors] = useState<HtmlError[]>([])
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Live validation
   useEffect(() => {
     if (!state.input.trim()) {
       setErrors([])
@@ -64,7 +222,7 @@ export default function HtmlValidator() {
     }
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(async () => {
-      const errs = await validateHtml(state.input)
+      const errs = await validateHtml(state.input, state.disabledRules)
       setErrors(errs)
       const errorCount = errs.filter((e) => e.type === 'error').length
       const warnCount = errs.filter((e) => e.type === 'warning').length
@@ -77,40 +235,218 @@ export default function HtmlValidator() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
-  }, [state.input, setLastAction])
+  }, [state.input, state.disabledRules, setLastAction])
+
+  const stats = useMemo(() => {
+    if (!state.input.trim()) return null
+    return computeStats(state.input)
+  }, [state.input])
 
   const errorCount = errors.filter((e) => e.type === 'error').length
   const warnCount = errors.filter((e) => e.type === 'warning').length
 
+  const toggleRule = useCallback(
+    (ruleId: string) => {
+      const disabled = state.disabledRules.includes(ruleId)
+        ? state.disabledRules.filter((r) => r !== ruleId)
+        : [...state.disabledRules, ruleId]
+      updateState({ disabledRules: disabled })
+    },
+    [state.disabledRules, updateState]
+  )
+
+  const showEditor = state.viewMode === 'split' || state.viewMode === 'edit'
+  const showPreview = state.viewMode === 'split' || state.viewMode === 'preview'
+
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
-        {state.input.trim() && errors.length === 0 && (
-          <span className="text-xs text-[var(--color-success)]">✓ Valid HTML</span>
-        )}
-        {errorCount > 0 && <span className="text-xs text-[var(--color-error)]">✗ {errorCount} error(s)</span>}
-        {warnCount > 0 && <span className="text-xs text-[var(--color-warning)]">⚠ {warnCount} warning(s)</span>}
-        <div className="ml-auto">
-          <CopyButton text={state.input} />
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
+        {/* View mode */}
+        {(['edit', 'split', 'preview'] as const).map((mode) => (
+          <button
+            key={mode}
+            onClick={() => updateState({ viewMode: mode })}
+            className={`rounded border px-2 py-0.5 text-xs ${
+              state.viewMode === mode
+                ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+                : 'border-[var(--color-border)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
+            }`}
+          >
+            {mode === 'edit' ? 'Edit' : mode === 'split' ? 'Split' : 'Preview'}
+          </button>
+        ))}
+
+        <div className="mx-1 h-4 w-px bg-[var(--color-border)]" />
+
+        {/* Starters */}
+        <span className="text-xs text-[var(--color-text-muted)]">Start:</span>
+        {Object.entries(STARTERS).map(([key, s]) => (
+          <button
+            key={key}
+            onClick={() => {
+              updateState({ input: s.html })
+              setLastAction(`Loaded "${s.label}" template`, 'info')
+            }}
+            className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+          >
+            {s.label}
+          </button>
+        ))}
+
+        <div className="mx-1 h-4 w-px bg-[var(--color-border)]" />
+
+        {/* Rules toggle */}
+        <button
+          onClick={() => updateState({ showRules: !state.showRules })}
+          className={`rounded border px-2 py-0.5 text-xs ${
+            state.showRules
+              ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+              : 'border-[var(--color-border)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
+          }`}
+        >
+          Rules
+        </button>
+
+        <CopyButton text={state.input} />
+
+        {/* Status */}
+        <div className="ml-auto flex items-center gap-2">
+          {state.input.trim() && errors.length === 0 && (
+            <span className="rounded bg-[var(--color-success)] px-2 py-0.5 text-[10px] font-bold text-[var(--color-bg)]">
+              ✓ Valid HTML
+            </span>
+          )}
+          {errorCount > 0 && (
+            <span className="rounded bg-[var(--color-error)] px-2 py-0.5 text-[10px] font-bold text-white">
+              ✗ {errorCount} error{errorCount !== 1 ? 's' : ''}
+            </span>
+          )}
+          {warnCount > 0 && (
+            <span className="rounded bg-[var(--color-warning)] px-2 py-0.5 text-[10px] font-bold text-[var(--color-bg)]">
+              ⚠ {warnCount} warning{warnCount !== 1 ? 's' : ''}
+            </span>
+          )}
         </div>
       </div>
+
+      {/* Stats bar */}
+      {stats && (
+        <div className="flex items-center gap-4 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1 text-xs text-[var(--color-text-muted)]">
+          <span>{stats.tags} tags</span>
+          <span>depth {stats.depth}</span>
+          {stats.inlineStyles > 0 && (
+            <span className="text-[var(--color-warning)]">{stats.inlineStyles} inline style{stats.inlineStyles !== 1 ? 's' : ''}</span>
+          )}
+          {stats.inlineScripts > 0 && (
+            <span className="text-[var(--color-warning)]">{stats.inlineScripts} script{stats.inlineScripts !== 1 ? 's' : ''}</span>
+          )}
+          {stats.headings.length > 0 && <span>{stats.headings.length} heading{stats.headings.length !== 1 ? 's' : ''}</span>}
+        </div>
+      )}
+
+      {/* Rules panel */}
+      {state.showRules && (
+        <div className="max-h-40 overflow-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
+          <div className="grid grid-cols-2 gap-x-8 gap-y-1">
+            {RULE_CATEGORIES.map((cat) => (
+              <div key={cat}>
+                <div className="mb-1 text-[10px] font-bold uppercase text-[var(--color-text-muted)]">{cat}</div>
+                {ALL_RULES.filter((r) => r.category === cat).map((rule) => {
+                  const disabled = state.disabledRules.includes(rule.id)
+                  return (
+                    <label key={rule.id} className="flex cursor-pointer items-center gap-1.5 py-0.5 text-xs">
+                      <input
+                        type="checkbox"
+                        checked={!disabled}
+                        onChange={() => toggleRule(rule.id)}
+                        className="accent-[var(--color-accent)]"
+                      />
+                      <span className={disabled ? 'text-[var(--color-text-muted)] line-through' : 'text-[var(--color-text)]'}>
+                        {rule.label}
+                      </span>
+                    </label>
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Errors */}
       {errors.length > 0 && (
-        <div className="max-h-32 overflow-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
+        <div className="max-h-28 overflow-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
           {errors.map((e, i) => (
-            <div key={i} className={`text-xs ${e.type === 'error' ? 'text-[var(--color-error)]' : 'text-[var(--color-warning)]'}`}>
-              <span className="text-[var(--color-text-muted)]">Line {e.line}:{e.col}</span>{' '}
-              <span className="text-[var(--color-text-muted)]">[{e.rule}]</span> {e.message}
+            <div
+              key={i}
+              className={`flex items-start gap-2 py-0.5 text-xs ${
+                e.type === 'error' ? 'text-[var(--color-error)]' : 'text-[var(--color-warning)]'
+              }`}
+            >
+              <span className="shrink-0 rounded bg-[var(--color-surface-hover)] px-1 py-0 text-[10px] text-[var(--color-text-muted)]">
+                L{e.line}:{e.col}
+              </span>
+              <span className="shrink-0 rounded border border-current px-1 py-0 text-[10px]">
+                {e.rule}
+              </span>
+              <span>{e.message}</span>
             </div>
           ))}
         </div>
       )}
-      <div className="flex-1">
-        <Editor
-          language="html"
-          value={state.input}
-          onChange={(v) => updateState({ input: v ?? '' })}
-          options={EDITOR_OPTIONS}
-        />
+
+      {/* Heading outline */}
+      {stats && stats.headings.length > 0 && state.viewMode !== 'preview' && (
+        <div className="flex items-center gap-2 overflow-x-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1">
+          <span className="shrink-0 text-[10px] text-[var(--color-text-muted)]">Outline:</span>
+          {stats.headings.map((h, i) => (
+            <span
+              key={i}
+              className="shrink-0 text-[10px] text-[var(--color-text)]"
+              style={{ paddingLeft: (h.level - 1) * 8 }}
+            >
+              <span className="text-[var(--color-accent)]">h{h.level}</span> {h.text}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="flex flex-1 overflow-hidden">
+        {showEditor && (
+          <div className={`flex flex-col ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'}`}>
+            <div className="flex-1">
+              <Editor
+                language="html"
+                value={state.input}
+                onChange={(v) => updateState({ input: v ?? '' })}
+                options={EDITOR_OPTIONS}
+              />
+            </div>
+          </div>
+        )}
+        {showPreview && (
+          <div className={`flex flex-col ${showEditor ? 'w-1/2' : 'w-full'}`}>
+            <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
+              Preview
+            </div>
+            <div className="flex-1 bg-white">
+              {state.input.trim() ? (
+                <iframe
+                  title="HTML Preview"
+                  sandbox=""
+                  srcDoc={state.input}
+                  className="h-full w-full border-none"
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-gray-400">
+                  Enter HTML to see a live preview
+                </div>
+              )}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -4,41 +4,212 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, EDITOR_OPTIONS } from '@/hooks/useMonaco'
+import { CopyButton } from '@/components/shared/CopyButton'
 import { useUiStore } from '@/stores/ui.store'
+
+// ── Types ────────────────────────────────────────────────────────────
 
 type JsonSchemaState = {
   data: string
   schema: string
+  strict: boolean
 }
 
 type ValidationError = {
   path: string
   message: string
+  keyword?: string
 }
 
-const TEMPLATES: Record<string, string> = {
-  basic: JSON.stringify({
-    type: 'object',
-    properties: {
-      name: { type: 'string' },
-      age: { type: 'integer', minimum: 0 },
-      email: { type: 'string', format: 'email' },
+// ── Templates ────────────────────────────────────────────────────────
+
+const TEMPLATES: Record<string, { label: string; schema: object; sample: object }> = {
+  basic: {
+    label: 'Basic',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer', minimum: 0 },
+        email: { type: 'string', format: 'email' },
+      },
+      required: ['name', 'email'],
     },
-    required: ['name', 'email'],
-  }, null, 2),
+    sample: { name: 'Alice', age: 30, email: 'alice@example.com' },
+  },
+  array: {
+    label: 'Array',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          title: { type: 'string', minLength: 1 },
+          done: { type: 'boolean' },
+        },
+        required: ['id', 'title'],
+      },
+      minItems: 1,
+    },
+    sample: [
+      { id: 1, title: 'Buy groceries', done: false },
+      { id: 2, title: 'Walk the dog', done: true },
+    ],
+  },
+  nested: {
+    label: 'Nested',
+    schema: {
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            address: {
+              type: 'object',
+              properties: {
+                street: { type: 'string' },
+                city: { type: 'string' },
+                zip: { type: 'string', pattern: '^\\d{5}$' },
+              },
+              required: ['street', 'city'],
+            },
+          },
+          required: ['name'],
+        },
+      },
+    },
+    sample: {
+      user: {
+        name: 'Bob',
+        address: { street: '123 Main St', city: 'Springfield', zip: '62704' },
+      },
+    },
+  },
+  enum: {
+    label: 'Enum / oneOf',
+    schema: {
+      type: 'object',
+      properties: {
+        status: { enum: ['active', 'inactive', 'pending'] },
+        priority: { oneOf: [{ type: 'integer', minimum: 1, maximum: 5 }, { type: 'string', enum: ['low', 'medium', 'high'] }] },
+      },
+      required: ['status'],
+    },
+    sample: { status: 'active', priority: 3 },
+  },
+  formats: {
+    label: 'Formats',
+    schema: {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        website: { type: 'string', format: 'uri' },
+        created: { type: 'string', format: 'date-time' },
+        ip: { type: 'string', format: 'ipv4' },
+        uuid: { type: 'string', format: 'uuid' },
+      },
+    },
+    sample: {
+      email: 'test@example.com',
+      website: 'https://example.com',
+      created: '2026-03-23T12:00:00Z',
+      ip: '192.168.1.1',
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+    },
+  },
+  allOf: {
+    label: 'allOf',
+    schema: {
+      allOf: [
+        {
+          type: 'object',
+          properties: { id: { type: 'integer' } },
+          required: ['id'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            role: { type: 'string', enum: ['admin', 'user', 'guest'] },
+          },
+          required: ['name', 'role'],
+        },
+      ],
+    },
+    sample: { id: 1, name: 'Admin', role: 'admin' },
+  },
+  conditional: {
+    label: 'Conditional',
+    schema: {
+      type: 'object',
+      properties: {
+        type: { enum: ['personal', 'business'] },
+        company: { type: 'string' },
+        name: { type: 'string' },
+      },
+      required: ['type', 'name'],
+      if: { properties: { type: { const: 'business' } } },
+      then: { required: ['company'] },
+    },
+    sample: { type: 'business', name: 'Bob', company: 'Acme Corp' },
+  },
 }
+
+// ── Schema Inference ─────────────────────────────────────────────────
+
+function inferSchema(data: unknown): object {
+  if (data === null) return { type: 'null' }
+  if (Array.isArray(data)) {
+    if (data.length === 0) return { type: 'array' }
+    // Infer from first item
+    return { type: 'array', items: inferSchema(data[0]) }
+  }
+  if (typeof data === 'object') {
+    const obj = data as Record<string, unknown>
+    const properties: Record<string, object> = {}
+    const required: string[] = []
+    for (const [key, val] of Object.entries(obj)) {
+      properties[key] = inferSchema(val)
+      required.push(key)
+    }
+    return { type: 'object', properties, required }
+  }
+  if (typeof data === 'number') {
+    return Number.isInteger(data) ? { type: 'integer' } : { type: 'number' }
+  }
+  if (typeof data === 'boolean') return { type: 'boolean' }
+  if (typeof data === 'string') {
+    // Detect common formats
+    if (/^[\w.+-]+@[\w.-]+\.\w+$/.test(data)) return { type: 'string', format: 'email' }
+    if (/^\d{4}-\d{2}-\d{2}T/.test(data)) return { type: 'string', format: 'date-time' }
+    if (/^https?:\/\//.test(data)) return { type: 'string', format: 'uri' }
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data)) {
+      return { type: 'string', format: 'uuid' }
+    }
+    return { type: 'string' }
+  }
+  return {}
+}
+
+// ── Component ────────────────────────────────────────────────────────
 
 export default function JsonSchemaValidator() {
   useMonacoTheme()
   const [state, updateState] = useToolState<JsonSchemaState>('json-schema-validator', {
     data: '',
-    schema: TEMPLATES['basic'] ?? '',
+    schema: JSON.stringify(TEMPLATES['basic']!.schema, null, 2),
+    strict: false,
   })
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [errors, setErrors] = useState<ValidationError[]>([])
   const [valid, setValid] = useState<boolean | null>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const ajvRef = useRef<Ajv | null>(null)
+  const ajvStrictRef = useRef(state.strict)
 
+  // Live validation
   useEffect(() => {
     if (!state.data.trim() || !state.schema.trim()) {
       setErrors([])
@@ -51,9 +222,16 @@ export default function JsonSchemaValidator() {
       try {
         const data = JSON.parse(state.data)
         const schema = JSON.parse(state.schema)
-        const ajv = new Ajv({ allErrors: true, verbose: true })
-        addFormats(ajv)
-        const validate = ajv.compile(schema)
+
+        // Reuse Ajv instance, only recreate when strict mode changes
+        if (!ajvRef.current || ajvStrictRef.current !== state.strict) {
+          ajvRef.current = new Ajv({ allErrors: true, verbose: true, strict: state.strict })
+          addFormats(ajvRef.current)
+          ajvStrictRef.current = state.strict
+        }
+        // removeSchema to allow recompilation with different schemas
+        ajvRef.current.removeSchema()
+        const validate = ajvRef.current.compile(schema)
         const isValid = validate(data)
 
         if (isValid) {
@@ -65,6 +243,7 @@ export default function JsonSchemaValidator() {
           const errs = (validate.errors ?? []).map((e) => ({
             path: e.instancePath || '/',
             message: e.message ?? 'Unknown error',
+            keyword: e.keyword,
           }))
           setErrors(errs)
           setLastAction(`${errs.length} error(s)`, 'error')
@@ -78,43 +257,130 @@ export default function JsonSchemaValidator() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
-  }, [state.data, state.schema, setLastAction])
+  }, [state.data, state.schema, state.strict, setLastAction])
 
-  const loadTemplate = useCallback((name: string) => {
-    const tmpl = TEMPLATES[name]
-    if (tmpl) updateState({ schema: tmpl })
-  }, [updateState])
+  const loadTemplate = useCallback(
+    (key: string) => {
+      const tmpl = TEMPLATES[key]
+      if (tmpl) {
+        updateState({
+          schema: JSON.stringify(tmpl.schema, null, 2),
+          data: JSON.stringify(tmpl.sample, null, 2),
+        })
+        setLastAction(`Loaded "${tmpl.label}" template`, 'info')
+      }
+    },
+    [updateState, setLastAction]
+  )
+
+  const generateSchema = useCallback(() => {
+    if (!state.data.trim()) return
+    try {
+      const data = JSON.parse(state.data)
+      const schema = inferSchema(data)
+      updateState({ schema: JSON.stringify(schema, null, 2) })
+      setLastAction('Schema inferred from data', 'success')
+    } catch {
+      setLastAction('Could not parse JSON data', 'error')
+    }
+  }, [state.data, updateState, setLastAction])
+
+  const generateSample = useCallback(() => {
+    // Try to find current template match and load its sample
+    try {
+      const currentSchema = JSON.parse(state.schema)
+      for (const tmpl of Object.values(TEMPLATES)) {
+        if (JSON.stringify(tmpl.schema) === JSON.stringify(currentSchema)) {
+          updateState({ data: JSON.stringify(tmpl.sample, null, 2) })
+          setLastAction('Loaded template sample data', 'success')
+          return
+        }
+      }
+      // If no template match, generate minimal sample
+      const sample = generateMinimalSample(currentSchema)
+      updateState({ data: JSON.stringify(sample, null, 2) })
+      setLastAction('Generated sample data', 'success')
+    } catch {
+      setLastAction('Could not parse schema', 'error')
+    }
+  }, [state.schema, updateState, setLastAction])
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
         <span className="font-pixel text-xs text-[var(--color-text-muted)]">Templates:</span>
-        {Object.keys(TEMPLATES).map((name) => (
+        {Object.entries(TEMPLATES).map(([key, tmpl]) => (
           <button
-            key={name}
-            onClick={() => loadTemplate(name)}
-            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
+            key={key}
+            onClick={() => loadTemplate(key)}
+            className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
           >
-            {name}
+            {tmpl.label}
           </button>
         ))}
-        <div className="ml-auto">
-          {valid === true && <span className="text-xs text-[var(--color-success)]">✓ Valid</span>}
-          {valid === false && <span className="text-xs text-[var(--color-error)]">✗ Invalid ({errors.length} errors)</span>}
+        <div className="mx-1 h-4 w-px bg-[var(--color-border)]" />
+        <button
+          onClick={generateSchema}
+          className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-info)] hover:bg-[var(--color-surface-hover)]"
+          title="Infer a schema from the current JSON data"
+        >
+          Infer Schema
+        </button>
+        <button
+          onClick={generateSample}
+          className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-info)] hover:bg-[var(--color-surface-hover)]"
+          title="Generate sample data from the current schema"
+        >
+          Generate Sample
+        </button>
+        <button
+          onClick={() => updateState({ strict: !state.strict })}
+          className={`rounded border px-2 py-0.5 text-[10px] ${
+            state.strict
+              ? 'border-[var(--color-warning)] text-[var(--color-warning)]'
+              : 'border-[var(--color-border)] text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]'
+          }`}
+          title="Strict mode catches schema authoring errors"
+        >
+          Strict
+        </button>
+        <div className="ml-auto flex items-center gap-2">
+          {valid === true && (
+            <span className="rounded bg-[var(--color-success)] px-2 py-0.5 text-[10px] font-bold text-[var(--color-bg)]">
+              ✓ Valid
+            </span>
+          )}
+          {valid === false && (
+            <span className="rounded bg-[var(--color-error)] px-2 py-0.5 text-[10px] font-bold text-white">
+              ✗ {errors.length} error{errors.length !== 1 ? 's' : ''}
+            </span>
+          )}
         </div>
       </div>
+
+      {/* Error panel */}
       {errors.length > 0 && (
-        <div className="max-h-24 overflow-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
+        <div className="max-h-28 overflow-auto border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
           {errors.map((e, i) => (
-            <div key={i} className="text-xs text-[var(--color-error)]">
-              <span className="text-[var(--color-text-muted)]">{e.path}</span> {e.message}
+            <div key={i} className="flex items-start gap-2 py-0.5 text-xs">
+              <span className="shrink-0 rounded bg-[var(--color-error)] px-1 py-0 text-[10px] font-bold text-white">
+                {e.keyword ?? 'error'}
+              </span>
+              <code className="shrink-0 text-[var(--color-accent)]">{e.path}</code>
+              <span className="text-[var(--color-error)]">{e.message}</span>
             </div>
           ))}
         </div>
       )}
+
+      {/* Editors */}
       <div className="flex flex-1 overflow-hidden">
         <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">JSON Data</div>
+          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
+            <span className="text-xs text-[var(--color-text-muted)]">JSON Data</span>
+            <CopyButton text={state.data} />
+          </div>
           <div className="flex-1">
             <Editor
               language="json"
@@ -125,7 +391,10 @@ export default function JsonSchemaValidator() {
           </div>
         </div>
         <div className="flex w-1/2 flex-col">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">JSON Schema</div>
+          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
+            <span className="text-xs text-[var(--color-text-muted)]">JSON Schema</span>
+            <CopyButton text={state.schema} />
+          </div>
           <div className="flex-1">
             <Editor
               language="json"
@@ -138,4 +407,60 @@ export default function JsonSchemaValidator() {
       </div>
     </div>
   )
+}
+
+// ── Minimal sample generator ─────────────────────────────────────────
+
+function generateMinimalSample(schema: Record<string, unknown>): unknown {
+  const type = schema['type'] as string | undefined
+  if (type === 'object') {
+    const props = (schema['properties'] ?? {}) as Record<string, Record<string, unknown>>
+    const obj: Record<string, unknown> = {}
+    for (const [key, propSchema] of Object.entries(props)) {
+      obj[key] = generateMinimalSample(propSchema)
+    }
+    return obj
+  }
+  if (type === 'array') {
+    const items = schema['items'] as Record<string, unknown> | undefined
+    return items ? [generateMinimalSample(items)] : []
+  }
+  if (type === 'string') {
+    const fmt = schema['format'] as string | undefined
+    const enumVals = schema['enum'] as string[] | undefined
+    if (enumVals) return enumVals[0] ?? ''
+    if (fmt === 'email') return 'user@example.com'
+    if (fmt === 'uri') return 'https://example.com'
+    if (fmt === 'date-time') return new Date().toISOString()
+    if (fmt === 'uuid') return '00000000-0000-0000-0000-000000000000'
+    if (fmt === 'ipv4') return '127.0.0.1'
+    return 'string'
+  }
+  if (type === 'integer' || type === 'number') {
+    const min = schema['minimum'] as number | undefined
+    return min ?? 0
+  }
+  if (type === 'boolean') return true
+  if (type === 'null') return null
+
+  // Handle enum at top level
+  const enumVals = schema['enum'] as unknown[] | undefined
+  if (enumVals) return enumVals[0] ?? null
+
+  // Handle allOf
+  const allOf = schema['allOf'] as Record<string, unknown>[] | undefined
+  if (allOf) {
+    const merged: Record<string, unknown> = {}
+    for (const sub of allOf) {
+      const sample = generateMinimalSample(sub)
+      if (typeof sample === 'object' && sample !== null) Object.assign(merged, sample)
+    }
+    return merged
+  }
+
+  // Handle oneOf — pick first
+  const oneOf = (schema['oneOf'] ?? schema['anyOf']) as Record<string, unknown>[] | undefined
+  if (oneOf?.[0]) return generateMinimalSample(oneOf[0])
+
+  return null
 }

--- a/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
+++ b/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
@@ -1,18 +1,155 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { useToolState } from '@/hooks/useToolState'
 import { useUiStore } from '@/stores/ui.store'
 
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+// ── UUID Generation ──────────────────────────────────────────────────
 
-function generateUuid(): string {
+function generateV4(): string {
   return crypto.randomUUID()
 }
+
+function generateV1(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+
+  // Timestamp: 100ns intervals since 1582-10-15
+  const now = BigInt(Date.now()) * 10000n + 122192928000000000n
+  const timeLow = Number(now & 0xffffffffn)
+  const timeMid = Number((now >> 32n) & 0xffffn)
+  const timeHi = Number((now >> 48n) & 0x0fffn) | 0x1000 // version 1
+
+  bytes[0] = (timeLow >>> 24) & 0xff
+  bytes[1] = (timeLow >>> 16) & 0xff
+  bytes[2] = (timeLow >>> 8) & 0xff
+  bytes[3] = timeLow & 0xff
+  bytes[4] = (timeMid >>> 8) & 0xff
+  bytes[5] = timeMid & 0xff
+  bytes[6] = (timeHi >>> 8) & 0xff
+  bytes[7] = timeHi & 0xff
+
+  // Variant bits (RFC 4122)
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80
+
+  return formatUuid(bytes)
+}
+
+function generateV7(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+
+  // 48-bit unix timestamp in ms
+  const now = Date.now()
+  bytes[0] = (now / 2 ** 40) & 0xff
+  bytes[1] = (now / 2 ** 32) & 0xff
+  bytes[2] = (now / 2 ** 24) & 0xff
+  bytes[3] = (now / 2 ** 16) & 0xff
+  bytes[4] = (now / 2 ** 8) & 0xff
+  bytes[5] = now & 0xff
+
+  // Version 7
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70
+  // Variant bits
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80
+
+  return formatUuid(bytes)
+}
+
+function formatUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+const GENERATORS: Record<UuidVersion, () => string> = {
+  v1: generateV1,
+  v4: generateV4,
+  v7: generateV7,
+}
+
+// ── UUID Parsing & Validation ────────────────────────────────────────
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const NIL_UUID = '00000000-0000-0000-0000-000000000000'
+const MAX_UUID = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+
+type UuidInfo = {
+  valid: true
+  version: number
+  variant: string
+  timestamp?: string
+  node?: string
+}
+
+function parseUuid(input: string): UuidInfo | { valid: false; message: string } {
+  const trimmed = input.trim()
+  if (!UUID_REGEX.test(trimmed)) {
+    return { valid: false, message: 'Not a valid UUID format' }
+  }
+
+  if (trimmed === NIL_UUID) {
+    return { valid: true, version: 0, variant: 'Nil UUID' }
+  }
+  if (trimmed.toLowerCase() === MAX_UUID) {
+    return { valid: true, version: 0, variant: 'Max UUID' }
+  }
+
+  const hex = trimmed.replace(/-/g, '')
+  const versionNibble = parseInt(hex[12]!, 16)
+  const variantNibble = parseInt(hex[16]!, 16)
+
+  const variant =
+    (variantNibble & 0x8) === 0
+      ? 'NCS (reserved)'
+      : (variantNibble & 0xc) === 0x8
+        ? 'RFC 4122'
+        : (variantNibble & 0xe) === 0xc
+          ? 'Microsoft (reserved)'
+          : 'Future (reserved)'
+
+  const info: UuidInfo = { valid: true, version: versionNibble, variant }
+
+  // Extract timestamp for v1
+  if (versionNibble === 1) {
+    const timeHi = hex.slice(12, 16).replace(/^1/, '')
+    const timeMid = hex.slice(8, 12)
+    const timeLow = hex.slice(0, 8)
+    const timestamp100ns = BigInt(`0x${timeHi}${timeMid}${timeLow}`)
+    const unixMs = Number((timestamp100ns - 122192928000000000n) / 10000n)
+    if (unixMs > 0 && unixMs < 4102444800000) {
+      info.timestamp = new Date(unixMs).toISOString()
+    }
+    info.node = hex.slice(20).match(/.{2}/g)!.join(':')
+  }
+
+  // Extract timestamp for v7
+  if (versionNibble === 7) {
+    const timestampHex = hex.slice(0, 12)
+    const unixMs = parseInt(timestampHex, 16)
+    if (unixMs > 0 && unixMs < 4102444800000) {
+      info.timestamp = new Date(unixMs).toISOString()
+    }
+  }
+
+  return info
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+type UuidVersion = 'v1' | 'v4' | 'v7'
+type BulkFormat = 'lines' | 'json' | 'csv'
 
 type UuidState = {
   lastGenerated: string
   bulkCount: number
   validateInput: string
+  version: UuidVersion
+  bulkFormat: BulkFormat
+}
+
+const VERSION_LABELS: Record<UuidVersion, string> = {
+  v1: 'v1 — Time-based',
+  v4: 'v4 — Random',
+  v7: 'v7 — Time-ordered',
 }
 
 export default function UuidGenerator() {
@@ -20,35 +157,61 @@ export default function UuidGenerator() {
     lastGenerated: '',
     bulkCount: 10,
     validateInput: '',
+    version: 'v4',
+    bulkFormat: 'lines',
   })
 
   const [bulkUuids, setBulkUuids] = useState<string[]>([])
   const setLastAction = useUiStore((s) => s.setLastAction)
 
   const generate = useCallback(() => {
-    const uuid = generateUuid()
+    const uuid = GENERATORS[state.version]()
     updateState({ lastGenerated: uuid })
-    setLastAction('Generated UUID', 'success')
-  }, [updateState, setLastAction])
+    setLastAction(`Generated UUID ${state.version}`, 'success')
+  }, [state.version, updateState, setLastAction])
 
   const generateBulk = useCallback(() => {
     const count = Math.min(Math.max(1, state.bulkCount), 100)
-    const uuids = Array.from({ length: count }, () => generateUuid())
+    const gen = GENERATORS[state.version]
+    const uuids = Array.from({ length: count }, () => gen())
     setBulkUuids(uuids)
-    setLastAction(`Generated ${count} UUIDs`, 'success')
-  }, [state.bulkCount, setLastAction])
+    setLastAction(`Generated ${count} UUIDs (${state.version})`, 'success')
+  }, [state.bulkCount, state.version, setLastAction])
 
-  const validateResult = state.validateInput.trim()
-    ? UUID_V4_REGEX.test(state.validateInput.trim())
-      ? { valid: true, message: '✓ Valid UUID v4' }
-      : { valid: false, message: '✗ Not a valid UUID v4' }
-    : null
+  const bulkOutput = useMemo(() => {
+    if (bulkUuids.length === 0) return ''
+    switch (state.bulkFormat) {
+      case 'json':
+        return JSON.stringify(bulkUuids, null, 2)
+      case 'csv':
+        return bulkUuids.join(',')
+      default:
+        return bulkUuids.join('\n')
+    }
+  }, [bulkUuids, state.bulkFormat])
+
+  const parsed = useMemo(() => {
+    if (!state.validateInput.trim()) return null
+    return parseUuid(state.validateInput)
+  }, [state.validateInput])
 
   return (
-    <div className="flex h-full flex-col gap-4 p-4">
+    <div className="flex h-full flex-col gap-4 overflow-auto p-4">
+      {/* ── Generate ─────────────────────────────────────── */}
       <section className="flex flex-col gap-3">
         <h2 className="font-pixel text-sm text-[var(--color-text)]">Generate</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={state.version}
+            onChange={(e) => updateState({ version: e.target.value as UuidVersion })}
+            className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5 text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+          >
+            {(Object.keys(VERSION_LABELS) as UuidVersion[]).map((v) => (
+              <option key={v} value={v}>
+                {VERSION_LABELS[v]}
+              </option>
+            ))}
+          </select>
           <button
             onClick={generate}
             className="rounded border border-[var(--color-accent)] px-4 py-2 font-pixel text-xs text-[var(--color-accent)] hover:bg-[var(--color-accent-dim)]"
@@ -66,9 +229,31 @@ export default function UuidGenerator() {
         </div>
       </section>
 
+      {/* ── Constants ────────────────────────────────────── */}
+      <section className="flex flex-col gap-3">
+        <h2 className="font-pixel text-sm text-[var(--color-text)]">Constants</h2>
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2">
+            <code className="rounded bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
+              {NIL_UUID}
+            </code>
+            <span className="text-xs text-[var(--color-text-muted)]">Nil</span>
+            <CopyButton text={NIL_UUID} />
+          </div>
+          <div className="flex items-center gap-2">
+            <code className="rounded bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
+              {MAX_UUID}
+            </code>
+            <span className="text-xs text-[var(--color-text-muted)]">Max</span>
+            <CopyButton text={MAX_UUID} />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Bulk Generate ────────────────────────────────── */}
       <section className="flex flex-col gap-3">
         <h2 className="font-pixel text-sm text-[var(--color-text)]">Bulk Generate</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <input
             type="number"
             min={1}
@@ -77,43 +262,76 @@ export default function UuidGenerator() {
             onChange={(e) => updateState({ bulkCount: parseInt(e.target.value) || 1 })}
             className="w-20 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
           />
+          <select
+            value={state.bulkFormat}
+            onChange={(e) => updateState({ bulkFormat: e.target.value as BulkFormat })}
+            className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1.5 text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+          >
+            <option value="lines">One per line</option>
+            <option value="json">JSON array</option>
+            <option value="csv">CSV</option>
+          </select>
           <button
             onClick={generateBulk}
             className="rounded border border-[var(--color-accent)] px-4 py-2 font-pixel text-xs text-[var(--color-accent)] hover:bg-[var(--color-accent-dim)]"
           >
             Generate
           </button>
-          {bulkUuids.length > 0 && (
-            <CopyButton text={bulkUuids.join('\n')} label="Copy All" />
-          )}
+          {bulkUuids.length > 0 && <CopyButton text={bulkOutput} label="Copy All" />}
         </div>
-        {bulkUuids.length > 0 && (
+        {bulkOutput && (
           <pre className="max-h-60 overflow-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs text-[var(--color-text)]">
-            {bulkUuids.join('\n')}
+            {bulkOutput}
           </pre>
         )}
       </section>
 
+      {/* ── Validate & Parse ─────────────────────────────── */}
       <section className="flex flex-col gap-3">
-        <h2 className="font-pixel text-sm text-[var(--color-text)]">Validate</h2>
-        <div className="flex items-center gap-3">
-          <input
-            type="text"
-            value={state.validateInput}
-            onChange={(e) => updateState({ validateInput: e.target.value })}
-            placeholder="Paste a UUID to validate..."
-            className="w-96 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
-          />
-          {validateResult && (
-            <span
-              className={`text-sm ${
-                validateResult.valid ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-              }`}
-            >
-              {validateResult.message}
-            </span>
-          )}
-        </div>
+        <h2 className="font-pixel text-sm text-[var(--color-text)]">Validate & Parse</h2>
+        <input
+          type="text"
+          value={state.validateInput}
+          onChange={(e) => updateState({ validateInput: e.target.value })}
+          placeholder="Paste a UUID to validate and parse..."
+          className="w-full max-w-xl rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+        />
+        {parsed && (
+          <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
+            {parsed.valid ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-[var(--color-success)]">✓ Valid UUID</span>
+                  <span className="rounded bg-[var(--color-accent-dim)] px-2 py-0.5 text-xs text-[var(--color-accent)]">
+                    {parsed.version === 0 ? parsed.variant : `Version ${parsed.version}`}
+                  </span>
+                </div>
+                <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+                  {parsed.version > 0 && (
+                    <>
+                      <span className="text-[var(--color-text-muted)]">Variant</span>
+                      <span className="text-[var(--color-text)]">{parsed.variant}</span>
+                    </>
+                  )}
+                  {parsed.timestamp && (
+                    <>
+                      <span className="text-[var(--color-text-muted)]">Timestamp</span>
+                      <span className="text-[var(--color-info)]">{parsed.timestamp}</span>
+                    </>
+                  )}
+                  {parsed.node && (
+                    <>
+                      <span className="text-[var(--color-text-muted)]">Node</span>
+                      <span className="font-mono text-[var(--color-text)]">{parsed.node}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <span className="text-sm text-[var(--color-error)]">✗ {parsed.message}</span>
+            )}
+          </div>
+        )}
       </section>
     </div>
   )

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, EDITOR_OPTIONS } from '@/hooks/useMonaco'
@@ -19,8 +19,151 @@ type XmlToolsState = {
 const TABS = [
   { id: 'lint', label: 'Lint & Format' },
   { id: 'tree', label: 'Tree View' },
+  { id: 'json', label: 'XML → JSON' },
   { id: 'xpath', label: 'XPath' },
 ]
+
+// ── Tree View types ──────────────────────────────────────────────────
+
+type TreeNode =
+  | { type: 'element'; name: string; attributes: Record<string, string>; children: TreeNode[] }
+  | { type: 'text'; value: string }
+  | { type: 'comment'; value: string }
+  | { type: 'cdata'; value: string }
+  | { type: 'pi'; name: string; value: string }
+
+function parseXmlToTree(xml: string): TreeNode | null {
+  try {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(xml, 'text/xml')
+    const parseError = doc.querySelector('parsererror')
+    if (parseError) return null
+    return domToTreeNode(doc.documentElement)
+  } catch {
+    return null
+  }
+}
+
+function domToTreeNode(node: Node): TreeNode | null {
+  if (node.nodeType === 1) {
+    const el = node as Element
+    const attrs: Record<string, string> = {}
+    for (let i = 0; i < el.attributes.length; i++) {
+      const a = el.attributes.item(i)
+      if (a) attrs[a.name] = a.value
+    }
+    const children: TreeNode[] = []
+    for (let i = 0; i < el.childNodes.length; i++) {
+      const child = domToTreeNode(el.childNodes[i]!)
+      if (child) children.push(child)
+    }
+    return { type: 'element', name: el.tagName, attributes: attrs, children }
+  }
+  if (node.nodeType === 3) {
+    const text = (node.textContent ?? '').trim()
+    if (!text) return null
+    return { type: 'text', value: text }
+  }
+  if (node.nodeType === 8) {
+    return { type: 'comment', value: node.textContent ?? '' }
+  }
+  if (node.nodeType === 4) {
+    return { type: 'cdata', value: node.textContent ?? '' }
+  }
+  if (node.nodeType === 7) {
+    return { type: 'pi', name: node.nodeName, value: node.textContent ?? '' }
+  }
+  return null
+}
+
+// ── Tree Node Component ──────────────────────────────────────────────
+
+function TreeNodeRow({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
+  const [expanded, setExpanded] = useState(depth < 3)
+  const indent = depth * 16
+
+  if (node.type === 'text') {
+    return (
+      <div style={{ paddingLeft: indent }} className="flex items-center gap-1 py-0.5 text-xs">
+        <span className="text-[var(--color-success)]">&quot;{node.value}&quot;</span>
+      </div>
+    )
+  }
+
+  if (node.type === 'comment') {
+    return (
+      <div style={{ paddingLeft: indent }} className="py-0.5 text-xs text-[var(--color-text-muted)]">
+        &lt;!-- {node.value} --&gt;
+      </div>
+    )
+  }
+
+  if (node.type === 'cdata') {
+    return (
+      <div style={{ paddingLeft: indent }} className="py-0.5 text-xs text-[var(--color-warning)]">
+        &lt;![CDATA[{node.value}]]&gt;
+      </div>
+    )
+  }
+
+  if (node.type === 'pi') {
+    return (
+      <div style={{ paddingLeft: indent }} className="py-0.5 text-xs text-[var(--color-text-muted)]">
+        &lt;?{node.name} {node.value}?&gt;
+      </div>
+    )
+  }
+
+  const hasChildren = node.children.length > 0
+
+  return (
+    <div>
+      <div
+        style={{ paddingLeft: indent }}
+        className="flex cursor-pointer items-center gap-1 py-0.5 text-xs hover:bg-[var(--color-surface-hover)]"
+        onClick={() => hasChildren && setExpanded(!expanded)}
+      >
+        {hasChildren ? (
+          <span className="w-3 text-center text-[var(--color-text-muted)]">
+            {expanded ? '▾' : '▸'}
+          </span>
+        ) : (
+          <span className="w-3" />
+        )}
+        <span className="text-[var(--color-accent)]">&lt;{node.name}</span>
+        {Object.entries(node.attributes).map(([k, v]) => (
+          <span key={k}>
+            <span className="text-[var(--color-info)]"> {k}</span>
+            <span className="text-[var(--color-text-muted)]">=</span>
+            <span className="text-[var(--color-warning)]">&quot;{v}&quot;</span>
+          </span>
+        ))}
+        <span className="text-[var(--color-accent)]">
+          {hasChildren ? '>' : ' />'}
+        </span>
+        {!hasChildren && (
+          <span className="ml-1 text-[var(--color-text-muted)]">(empty)</span>
+        )}
+      </div>
+      {expanded &&
+        hasChildren &&
+        node.children.map((child, i) => (
+          <TreeNodeRow key={i} node={child} depth={depth + 1} />
+        ))}
+      {expanded && hasChildren && (
+        <div
+          style={{ paddingLeft: indent }}
+          className="py-0.5 text-xs text-[var(--color-accent)]"
+        >
+          <span className="w-3 inline-block" />
+          &lt;/{node.name}&gt;
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main Component ───────────────────────────────────────────────────
 
 export default function XmlTools() {
   useMonacoTheme()
@@ -33,12 +176,35 @@ export default function XmlTools() {
 
   const worker = useWorker<XmlWorker>(
     () => new XmlWorkerFactory(),
-    ['validate', 'format', 'queryXPath']
+    ['validate', 'format', 'minify', 'toJson', 'stats', 'queryXPath']
   )
 
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [error, setError] = useState<string | null>(null)
   const [xpathResults, setXpathResults] = useState<string[]>([])
+  const [jsonOutput, setJsonOutput] = useState<string>('')
+  const [jsonError, setJsonError] = useState<string | null>(null)
+  const [stats, setStats] = useState<{ elements: number; attributes: number; textNodes: number; depth: number } | null>(null)
+
+  // Debounced stats computation
+  const statsTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (!worker || !state.input.trim()) {
+      setStats(null)
+      return
+    }
+    if (statsTimer.current) clearTimeout(statsTimer.current)
+    let cancelled = false
+    statsTimer.current = setTimeout(() => {
+      worker.stats(state.input).then((s) => {
+        if (!cancelled) setStats(s)
+      }).catch(() => {})
+    }, 500)
+    return () => {
+      cancelled = true
+      if (statsTimer.current) clearTimeout(statsTimer.current)
+    }
+  }, [worker, state.input])
 
   const handleFormat = useCallback(async () => {
     if (!worker || !state.input.trim()) return
@@ -53,6 +219,19 @@ export default function XmlTools() {
     }
   }, [worker, state.input, state.indent, updateState, setLastAction])
 
+  const handleMinify = useCallback(async () => {
+    if (!worker || !state.input.trim()) return
+    const result = await worker.minify(state.input)
+    if (result.valid && result.formatted) {
+      updateState({ input: result.formatted })
+      setError(null)
+      setLastAction('Minified XML', 'success')
+    } else {
+      setError(result.errors.join('\n'))
+      setLastAction(`${result.errors.length} error(s)`, 'error')
+    }
+  }, [worker, state.input, updateState, setLastAction])
+
   const handleValidate = useCallback(async () => {
     if (!worker || !state.input.trim()) return
     const result = await worker.validate(state.input)
@@ -65,12 +244,31 @@ export default function XmlTools() {
     }
   }, [worker, state.input, setLastAction])
 
+  const handleToJson = useCallback(async () => {
+    if (!worker || !state.input.trim()) return
+    const result = await worker.toJson(state.input)
+    if (result.valid && result.json) {
+      setJsonOutput(result.json)
+      setJsonError(null)
+      setLastAction('Converted to JSON', 'success')
+    } else {
+      setJsonError(result.error ?? 'Conversion failed')
+      setJsonOutput('')
+      setLastAction('Conversion failed', 'error')
+    }
+  }, [worker, state.input, setLastAction])
+
   const handleXPath = useCallback(async () => {
     if (!worker || !state.input.trim() || !state.xpathQuery.trim()) return
     const result = await worker.queryXPath(state.input, state.xpathQuery)
     setXpathResults(result.matches)
     setLastAction(`${result.count} match(es)`, result.count > 0 ? 'success' : 'info')
   }, [worker, state.input, state.xpathQuery, setLastAction])
+
+  const tree = useMemo(() => {
+    if (!state.input.trim()) return null
+    return parseXmlToTree(state.input)
+  }, [state.input])
 
   return (
     <div className="flex h-full flex-col">
@@ -79,7 +277,19 @@ export default function XmlTools() {
         activeTab={state.activeTab}
         onTabChange={(id) => updateState({ activeTab: id })}
       />
+
+      {/* Stats bar */}
+      {stats && state.input.trim() && (
+        <div className="flex items-center gap-4 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1.5 text-xs text-[var(--color-text-muted)]">
+          <span>{stats.elements} elements</span>
+          <span>{stats.attributes} attributes</span>
+          <span>{stats.textNodes} text nodes</span>
+          <span>depth {stats.depth}</span>
+        </div>
+      )}
+
       <div className="flex-1 overflow-hidden">
+        {/* ── Lint & Format ─────────────────────────────── */}
         {state.activeTab === 'lint' && (
           <div className="flex h-full flex-col">
             <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
@@ -88,6 +298,12 @@ export default function XmlTools() {
                 className="rounded border border-[var(--color-accent)] px-3 py-1 font-pixel text-xs text-[var(--color-accent)] hover:bg-[var(--color-accent-dim)]"
               >
                 Format
+              </button>
+              <button
+                onClick={handleMinify}
+                className="rounded border border-[var(--color-border)] px-3 py-1 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)]"
+              >
+                Minify
               </button>
               <button
                 onClick={handleValidate}
@@ -124,16 +340,59 @@ export default function XmlTools() {
           </div>
         )}
 
+        {/* ── Tree View ─────────────────────────────────── */}
         {state.activeTab === 'tree' && (
           <div className="flex h-full flex-col">
-            <div className="flex-1 overflow-auto p-4 text-xs">
-              <pre className="whitespace-pre-wrap text-[var(--color-text)]">
-                {state.input.trim() ? state.input : 'Enter XML in the Lint & Format tab'}
-              </pre>
+            <div className="flex-1 overflow-auto p-4">
+              {tree ? (
+                <TreeNodeRow node={tree} />
+              ) : state.input.trim() ? (
+                <div className="text-sm text-[var(--color-error)]">
+                  Could not parse XML — check for errors in Lint & Format tab
+                </div>
+              ) : (
+                <div className="text-sm text-[var(--color-text-muted)]">
+                  Enter XML in the Lint & Format tab
+                </div>
+              )}
             </div>
           </div>
         )}
 
+        {/* ── XML → JSON ────────────────────────────────── */}
+        {state.activeTab === 'json' && (
+          <div className="flex h-full flex-col">
+            <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
+              <button
+                onClick={handleToJson}
+                className="rounded border border-[var(--color-accent)] px-3 py-1 font-pixel text-xs text-[var(--color-accent)] hover:bg-[var(--color-accent-dim)]"
+              >
+                Convert
+              </button>
+              {jsonOutput && <CopyButton text={jsonOutput} label="Copy JSON" />}
+            </div>
+            {jsonError && (
+              <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-xs text-[var(--color-error)]">
+                {jsonError}
+              </div>
+            )}
+            <div className="flex-1 overflow-auto">
+              {jsonOutput ? (
+                <Editor
+                  language="json"
+                  value={jsonOutput}
+                  options={{ ...EDITOR_OPTIONS, readOnly: true }}
+                />
+              ) : (
+                <div className="p-4 text-sm text-[var(--color-text-muted)]">
+                  Enter XML in the Lint & Format tab, then click Convert
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ── XPath ─────────────────────────────────────── */}
         {state.activeTab === 'xpath' && (
           <div className="flex h-full flex-col">
             <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
@@ -142,6 +401,9 @@ export default function XmlTools() {
                 onChange={(e) => updateState({ xpathQuery: e.target.value })}
                 placeholder="Enter XPath expression (e.g. /root/child)"
                 className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleXPath()
+                }}
               />
               <button
                 onClick={handleXPath}
@@ -157,17 +419,20 @@ export default function XmlTools() {
                     {xpathResults.length} match(es)
                   </div>
                   {xpathResults.map((r, i) => (
-                    <pre
+                    <div
                       key={i}
-                      className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs text-[var(--color-text)]"
+                      className="group flex items-start gap-2"
                     >
-                      {r}
-                    </pre>
+                      <pre className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs text-[var(--color-text)]">
+                        {r}
+                      </pre>
+                      <CopyButton text={r} className="opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </div>
                   ))}
                 </div>
               ) : (
                 <div className="text-sm text-[var(--color-text-muted)]">
-                  Enter an XPath expression and click Query
+                  Enter an XPath expression and click Query (or press Enter)
                 </div>
               )}
             </div>

--- a/apps/cockpit/src/workers/xml.worker.ts
+++ b/apps/cockpit/src/workers/xml.worker.ts
@@ -19,6 +19,19 @@ function makeErrorHandler(errors: string[]) {
   }
 }
 
+type XmlStats = {
+  elements: number
+  attributes: number
+  textNodes: number
+  depth: number
+}
+
+type JsonResult = {
+  valid: boolean
+  json?: string
+  error?: string
+}
+
 const api = {
   validate(xml: string): XmlResult {
     const errors: string[] = []
@@ -40,6 +53,47 @@ const api = {
     const raw = serializer.serializeToString(doc)
     const formatted = formatXmlString(raw, indent)
     return { valid: true, errors: [], formatted }
+  },
+
+  minify(xml: string): XmlResult {
+    const errors: string[] = []
+    const parser = new DOMParser({ errorHandler: makeErrorHandler(errors) })
+    const doc = parser.parseFromString(xml, 'text/xml')
+    if (errors.length > 0) {
+      return { valid: false, errors }
+    }
+    const serializer = new XMLSerializer()
+    const raw = serializer.serializeToString(doc)
+    // Strip whitespace between tags
+    const minified = raw.replace(/>\s+</g, '><').trim()
+    return { valid: true, errors: [], formatted: minified }
+  },
+
+  toJson(xml: string): JsonResult {
+    try {
+      const errors: string[] = []
+      const parser = new DOMParser({ errorHandler: makeErrorHandler(errors) })
+      const doc = parser.parseFromString(xml, 'text/xml')
+      if (errors.length > 0) {
+        return { valid: false, error: errors.join('\n') }
+      }
+      const json = nodeToJson(doc.documentElement)
+      return { valid: true, json: JSON.stringify(json, null, 2) }
+    } catch (e) {
+      return { valid: false, error: (e as Error).message }
+    }
+  },
+
+  stats(xml: string): XmlStats {
+    try {
+      const errors: string[] = []
+      const parser = new DOMParser({ errorHandler: makeErrorHandler(errors) })
+      const doc = parser.parseFromString(xml, 'text/xml')
+      if (errors.length > 0) return { elements: 0, attributes: 0, textNodes: 0, depth: 0 }
+      return collectStats(doc.documentElement)
+    } catch {
+      return { elements: 0, attributes: 0, textNodes: 0, depth: 0 }
+    }
   },
 
   queryXPath(xml: string, expression: string): XPathResult {
@@ -83,6 +137,84 @@ function formatXmlString(xml: string, indent: number): string {
     }
   }
   return formatted.trimEnd()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function nodeToJson(node: any): any {
+  if (!node) return null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj: any = {}
+
+  // Attributes
+  if (node.attributes && node.attributes.length > 0) {
+    for (let i = 0; i < node.attributes.length; i++) {
+      const attr = node.attributes.item(i)
+      if (attr) obj[`@${attr.name}`] = attr.value
+    }
+  }
+
+  // Child nodes
+  const children = node.childNodes
+  if (children && children.length > 0) {
+    const textParts: string[] = []
+    for (let i = 0; i < children.length; i++) {
+      const child = children.item(i)
+      if (!child) continue
+      // Text node (nodeType 3) or CDATA (nodeType 4)
+      if (child.nodeType === 3 || child.nodeType === 4) {
+        const txt = (child.textContent ?? '').trim()
+        if (txt) textParts.push(txt)
+      } else if (child.nodeType === 1 && child.tagName) {
+        const tag = child.tagName
+        const value = nodeToJson(child)
+        if (obj[tag] !== undefined) {
+          if (!Array.isArray(obj[tag])) obj[tag] = [obj[tag]]
+          obj[tag].push(value)
+        } else {
+          obj[tag] = value
+        }
+      }
+    }
+    if (textParts.length > 0 && Object.keys(obj).filter((k) => !k.startsWith('@')).length === 0) {
+      // Leaf element — if only text content and possibly attributes
+      const text = textParts.join('')
+      if (Object.keys(obj).length === 0) return text
+      obj['#text'] = text
+    }
+  }
+
+  return Object.keys(obj).length === 0 ? '' : obj
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function collectStats(node: any, depth = 0): { elements: number; attributes: number; textNodes: number; depth: number } {
+  let elements = 0
+  let attributes = 0
+  let textNodes = 0
+  let maxDepth = depth
+
+  if (!node) return { elements, attributes, textNodes, depth: maxDepth }
+
+  if (node.nodeType === 1) {
+    elements++
+    if (node.attributes) attributes += node.attributes.length
+  }
+  if ((node.nodeType === 3 || node.nodeType === 4) && (node.textContent ?? '').trim()) {
+    textNodes++
+  }
+
+  if (node.childNodes) {
+    for (let i = 0; i < node.childNodes.length; i++) {
+      const child = node.childNodes.item(i)
+      const childStats = collectStats(child, depth + (node.nodeType === 1 ? 1 : 0))
+      elements += childStats.elements
+      attributes += childStats.attributes
+      textNodes += childStats.textNodes
+      maxDepth = Math.max(maxDepth, childStats.depth)
+    }
+  }
+
+  return { elements, attributes, textNodes, depth: maxDepth }
 }
 
 // Use `any` types for xmldom nodes since they don't match the DOM lib types


### PR DESCRIPTION
## Summary
- **UUID Generator** — v1/v4/v7 generation, universal validation with parsed components (timestamp, node), Nil/Max constants, bulk export as lines/JSON/CSV
- **XML Tools** — interactive tree view with expand/collapse, XML→JSON conversion tab, minify, live stats bar (elements/attributes/depth), per-result XPath copy
- **Color Converter** — HSB + OKLCH formats, full 148 CSS named colors, shade/tint scale, color harmony (7 types), 12-color history, native color pickers on contrast checker
- **CSS Specificity** — segmented bar (ID/class/element in distinct colors), component breakdown tags, winner badge, !important detection, 5 preset examples, export
- **JSON Schema Validator** — 7 templates with sample data, schema inference from data, sample generation from schema, strict mode, memoized Ajv, keyword badges
- **HTML Validator** — live preview pane (sandboxed iframe), split/edit/preview modes, 15 configurable rules, heading outline, stats bar, 3 starter templates

## Code review fixes included
- XSS-safe iframe: `sandbox=""` + `srcDoc` instead of `doc.write()` with `allow-same-origin`
- Division by zero guard in specificity bar width calculation
- Memoized Ajv instance (avoids reconstruction on every keystroke)
- Stale closure fix in color history via ref
- Promise rejection handling in XML stats effect
- Removed unused `'other'` type variant from SpecPart

## Stats
+2131 / -269 across 9 files. Types clean, 145 tests passing.

## Test plan
- [ ] Verify UUID v1/v4/v7 all generate valid UUIDs
- [ ] Verify XML tree view renders nested elements with expand/collapse
- [ ] Verify Color Converter OKLCH round-trips correctly
- [ ] Verify CSS Specificity segmented bar renders proportionally
- [ ] Verify JSON Schema inference produces valid schemas
- [ ] Verify HTML preview renders in sandboxed iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)