### PR TITLE
fix(cockpit): resolve Tauri DMG bundling failure on macOS CI

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
+          - platform: macos-14
             args: --target aarch64-apple-darwin
-          - platform: macos-latest
+          - platform: macos-14
             args: --target x86_64-apple-darwin
           - platform: windows-latest
             args: ''
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-14' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2

--- a/apps/cockpit/src-tauri/tauri.conf.json
+++ b/apps/cockpit/src-tauri/tauri.conf.json
@@ -42,6 +42,27 @@
         "displayLanguageSelector": false
       }
     },
+    "macOS": {
+      "dmg": {
+        "windowSize": {
+          "width": 660,
+          "height": 400
+        },
+        "windowPosition": {
+          "x": 400,
+          "y": 400
+        },
+        "appPosition": {
+          "x": 180,
+          "y": 170
+        },
+        "applicationFolderPosition": {
+          "x": 480,
+          "y": 170
+        }
+      },
+      "minimumSystemVersion": "10.13"
+    },
     "linux": {
       "deb": {
         "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]


### PR DESCRIPTION
This PR fixes the  failure during the macOS build process in GitHub Actions by pinning the macOS runner to  and adding explicit DMG configuration to .