### PR TITLE
fix(ci): increase Node.js heap limit for macOS build

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -95,6 +95,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           tagName: cockpit-v__VERSION__
           releaseName: 'devdrivr Cockpit v__VERSION__'


### PR DESCRIPTION
Increases the Node.js memory limit to 4GB (`--max-old-space-size=4096`) for the Cockpit build job. This resolves the `JavaScript heap out of memory` error encountered during the `vite build` step on macOS runners.