### PR TITLE
fix(ci): upgrade GitHub Actions runners to latest versions

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -51,14 +51,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-14
+          - platform: macos-26
             args: --target aarch64-apple-darwin
-          - platform: macos-14
+            description: 'macOS Apple Silicon'
+          - platform: macos-26-intel
             args: --target x86_64-apple-darwin
+            description: 'macOS Intel'
           - platform: windows-latest
             args: ''
-          - platform: ubuntu-22.04
+            description: 'Windows'
+          - platform: ubuntu-24.04
             args: ''
+            description: 'Linux'
 
     runs-on: ${{ matrix.platform }}
 
@@ -70,7 +74,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-14' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ startsWith(matrix.platform, 'macos') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -78,7 +82,7 @@ jobs:
           workspaces: apps/cockpit/src-tauri -> target
 
       - name: Install dependencies (Ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf


### PR DESCRIPTION
Upgrades GitHub Actions runners to the latest available versions as of March 2026:
- macOS 14 -> macOS 26 (Apple Silicon)
- macOS 14 -> macOS 26 Intel (for x86_64 target)
- Ubuntu 22.04 -> Ubuntu 24.04

Using the native Intel runner for the `x86_64` target resolves the architectural compatibility issues encountered during the DMG bundling step (`bundle_dmg.sh`) on Apple Silicon runners.