### PR TITLE
feat(cockpit): expand test coverage + CSS-to-Tailwind mappings

### DIFF
--- a/apps/cockpit/src/stores/__tests__/history.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/history.store.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { useHistoryStore } from '../history.store'
+import { loadHistory, addHistoryEntry, pruneHistory, clearAllHistory } from '@/lib/db'
+import { useUiStore } from '@/stores/ui.store'
+
+vi.mock('@/lib/db', () => ({
+  loadHistory: vi.fn(),
+  addHistoryEntry: vi.fn(),
+  pruneHistory: vi.fn(),
+  clearAllHistory: vi.fn(),
+}))
+
+vi.mock('@/stores/ui.store', () => {
+  const addToast = vi.fn()
+  return {
+    useUiStore: { getState: vi.fn(() => ({ addToast })) },
+  }
+})
+
+beforeEach(() => {
+  useHistoryStore.setState({ entries: [], initialized: false })
+  ;(loadHistory as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  ;(addHistoryEntry as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(pruneHistory as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(clearAllHistory as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  vi.clearAllMocks()
+})
+
+describe('history store', () => {
+  it('starts with empty entries and initialized: false', () => {
+    const state = useHistoryStore.getState()
+    expect(state.entries).toEqual([])
+    expect(state.initialized).toBe(false)
+  })
+
+  it('add() creates entry with correct fields (id, tool, input, output, timestamp), calls addHistoryEntry and pruneHistory', async () => {
+    await useHistoryStore.getState().add('tool-A', 'input-A', 'output-A')
+
+    const { entries } = useHistoryStore.getState()
+    expect(entries).toHaveLength(1)
+
+    const entry = entries[0]!
+    expect(entry.id).toBeTruthy()
+    expect(entry.tool).toBe('tool-A')
+    expect(entry.input).toBe('input-A')
+    expect(entry.output).toBe('output-A')
+    expect(entry.timestamp).toBeTypeOf('number')
+    expect(entry.subTab).toBeUndefined()
+
+    expect(addHistoryEntry).toHaveBeenCalledWith(entry)
+    expect(pruneHistory).toHaveBeenCalledWith('tool-A', 500)
+  })
+
+  it('add() prepends entry to local state (newest first), caps local state at 200', async () => {
+    const initialEntries = Array.from({ length: 200 }, (_, i) => ({
+      id: `id-${i}`,
+      tool: 'test',
+      input: 'in',
+      output: 'out',
+      timestamp: Date.now() - i * 1000,
+    }))
+    useHistoryStore.setState({ entries: initialEntries })
+
+    await useHistoryStore.getState().add('new-tool', 'new-in', 'new-out')
+
+    const { entries } = useHistoryStore.getState()
+    expect(entries).toHaveLength(200)
+    expect(entries[0]!.tool).toBe('new-tool')
+    expect(entries[0]!.input).toBe('new-in')
+    expect(entries[1]!.id).toBe('id-0')
+  })
+
+  it('add() includes subTab in entry only when provided', async () => {
+    await useHistoryStore.getState().add('tool-B', 'in', 'out', 'my-subtab')
+
+    const { entries } = useHistoryStore.getState()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.subTab).toBe('my-subtab')
+  })
+
+  it('add() calls addToast on addHistoryEntry failure but still updates local state', async () => {
+    ;(addHistoryEntry as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('DB Error'))
+
+    await useHistoryStore.getState().add('fail-tool', 'in', 'out')
+
+    const { entries } = useHistoryStore.getState()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.tool).toBe('fail-tool')
+
+    const { addToast } = useUiStore.getState()
+    expect(addToast).toHaveBeenCalledWith('Failed to save history: DB Error', 'error')
+  })
+
+  it('loadForTool() calls loadHistory with the tool id and limit 100', async () => {
+    ;(loadHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{ id: 'loaded' }])
+
+    const res = await useHistoryStore.getState().loadForTool('some-tool')
+
+    expect(loadHistory).toHaveBeenCalledWith('some-tool', 100)
+    expect(res).toEqual([{ id: 'loaded' }])
+  })
+
+  it('reload() calls loadHistory with undefined tool and limit 200, updates entries', async () => {
+    const mockEntries = [{ id: '1', tool: 't1', input: 'i1', output: 'o1', timestamp: 123 }]
+    ;(loadHistory as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockEntries)
+
+    await useHistoryStore.getState().reload()
+
+    expect(loadHistory).toHaveBeenCalledWith(undefined, 200)
+    expect(useHistoryStore.getState().entries).toEqual(mockEntries)
+  })
+
+  it('clearAll() calls clearAllHistory and resets entries to []', async () => {
+    useHistoryStore.setState({
+      entries: [{ id: '1', tool: 't1', input: 'i1', output: 'o1', timestamp: 123 }],
+    })
+
+    await useHistoryStore.getState().clearAll()
+
+    expect(clearAllHistory).toHaveBeenCalledOnce()
+    expect(useHistoryStore.getState().entries).toEqual([])
+  })
+})

--- a/apps/cockpit/src/stores/__tests__/settings.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/settings.store.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { useSettingsStore } from '../settings.store'
+import { getSetting, setSetting } from '@/lib/db'
+import { applyTheme } from '@/lib/theme'
+import { useUiStore } from '@/stores/ui.store'
+import { DEFAULT_SETTINGS } from '@/types/models'
+
+vi.mock('@/lib/db', () => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+}))
+vi.mock('@/lib/theme', () => ({ applyTheme: vi.fn() }))
+vi.mock('@/stores/ui.store', () => ({
+  useUiStore: { getState: vi.fn(() => ({ addToast: vi.fn() })) },
+}))
+
+beforeEach(() => {
+  useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: false })
+  vi.clearAllMocks()
+})
+
+describe('settings store initialization', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('starts with DEFAULT_SETTINGS and initialized: false', async () => {
+    const { useSettingsStore } = await import('../settings.store')
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: false })
+    const state = useSettingsStore.getState()
+    expect(state.initialized).toBe(false)
+    expect(state.theme).toBe(DEFAULT_SETTINGS.theme)
+  })
+
+  it('init() loads from getSetting, merges with DEFAULT_SETTINGS, sets initialized: true, calls applyTheme', async () => {
+    const { useSettingsStore } = await import('../settings.store')
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: false })
+    
+    ;(getSetting as any).mockResolvedValue({ editorFontSize: 16 })
+    
+    await useSettingsStore.getState().init()
+
+    const state = useSettingsStore.getState()
+    expect(state.initialized).toBe(true)
+    expect(state.editorFontSize).toBe(16)
+    expect(state.theme).toBe(DEFAULT_SETTINGS.theme)
+    
+    expect(getSetting).toHaveBeenCalledWith('appSettings', {})
+    expect(applyTheme).toHaveBeenCalledWith(DEFAULT_SETTINGS.theme)
+  })
+
+  it('init() is idempotent — calling it twice only calls getSetting once', async () => {
+    const { useSettingsStore } = await import('../settings.store')
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: false })
+    
+    ;(getSetting as any).mockResolvedValue({ editorFontSize: 16 })
+    
+    const p1 = useSettingsStore.getState().init()
+    const p2 = useSettingsStore.getState().init()
+    
+    await Promise.all([p1, p2])
+
+    expect(getSetting).toHaveBeenCalledOnce()
+  })
+})
+
+describe('settings store updates', () => {
+  it('update() applies the change to store state immediately (optimistic)', async () => {
+    ;(setSetting as any).mockResolvedValue(undefined)
+    
+    const promise = useSettingsStore.getState().update('editorFontSize', 18)
+    
+    // Check state before promise resolves (optimistic update)
+    expect(useSettingsStore.getState().editorFontSize).toBe(18)
+    
+    await promise
+  })
+
+  it('update() persists full AppSettings object to setSetting', async () => {
+    ;(setSetting as any).mockResolvedValue(undefined)
+    
+    await useSettingsStore.getState().update('editorFontSize', 18)
+    
+    expect(setSetting).toHaveBeenCalledWith('appSettings', {
+      theme: DEFAULT_SETTINGS.theme,
+      alwaysOnTop: DEFAULT_SETTINGS.alwaysOnTop,
+      sidebarCollapsed: DEFAULT_SETTINGS.sidebarCollapsed,
+      notesDrawerOpen: DEFAULT_SETTINGS.notesDrawerOpen,
+      notesDrawerWidth: DEFAULT_SETTINGS.notesDrawerWidth,
+      defaultIndentSize: DEFAULT_SETTINGS.defaultIndentSize,
+      defaultTimezone: DEFAULT_SETTINGS.defaultTimezone,
+      editorFontSize: 18,
+      editorTheme: DEFAULT_SETTINGS.editorTheme,
+      editorKeybindingMode: DEFAULT_SETTINGS.editorKeybindingMode,
+      historyRetentionPerTool: DEFAULT_SETTINGS.historyRetentionPerTool,
+      formatOnPaste: DEFAULT_SETTINGS.formatOnPaste,
+    })
+  })
+
+  it("update('theme', value) calls applyTheme with the new theme", async () => {
+    ;(setSetting as any).mockResolvedValue(undefined)
+    
+    await useSettingsStore.getState().update('theme', 'midnight')
+    
+    expect(applyTheme).toHaveBeenCalledWith('midnight')
+  })
+
+  it('update() reverts the optimistic change and calls addToast when setSetting throws', async () => {
+    const mockAddToast = vi.fn()
+    ;(useUiStore.getState as any).mockReturnValue({ addToast: mockAddToast })
+    
+    ;(setSetting as any).mockRejectedValue(new Error('DB Error'))
+    
+    const previousSize = useSettingsStore.getState().editorFontSize
+    
+    await useSettingsStore.getState().update('editorFontSize', 18)
+    
+    // State should be reverted
+    expect(useSettingsStore.getState().editorFontSize).toBe(previousSize)
+    expect(mockAddToast).toHaveBeenCalledWith('Failed to save setting: DB Error', 'error')
+  })
+
+  it('update() reverts theme and calls applyTheme with previous theme when setSetting throws', async () => {
+    const mockAddToast = vi.fn()
+    ;(useUiStore.getState as any).mockReturnValue({ addToast: mockAddToast })
+    
+    ;(setSetting as any).mockRejectedValue(new Error('DB Error'))
+    
+    const previousTheme = useSettingsStore.getState().theme
+    
+    await useSettingsStore.getState().update('theme', 'neon-brutalist')
+    
+    // applyTheme should be called with new theme first, then reverted
+    expect(applyTheme).toHaveBeenNthCalledWith(1, 'neon-brutalist')
+    expect(applyTheme).toHaveBeenNthCalledWith(2, previousTheme)
+    
+    expect(useSettingsStore.getState().theme).toBe(previousTheme)
+  })
+
+  it('toggleTheme() cycles through all themes in order, wrapping around', async () => {
+    ;(setSetting as any).mockResolvedValue(undefined)
+    
+    // Set to 'system'
+    useSettingsStore.setState({ theme: 'system' })
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('midnight')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('warm-terminal')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('neon-brutalist')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('earth-code')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('cyber-luxe')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('soft-focus')
+    
+    await useSettingsStore.getState().toggleTheme()
+    expect(useSettingsStore.getState().theme).toBe('system')
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/css-to-tailwind.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/css-to-tailwind.test.tsx
@@ -17,6 +17,16 @@ describe('CssToTailwind', () => {
     expect(screen.getByText('flex')).toBeInTheDocument()
   })
 
+  it('converts new properties correctly', () => {
+    renderTool(CssToTailwind)
+    const editor = screen.getByTestId('monaco-editor')
+    fireEvent.change(editor, { target: { value: 'text-transform: uppercase;\nobject-fit: cover;\nmargin-inline: 1rem;\npadding-block: 2rem;' } })
+    expect(screen.getByText('uppercase')).toBeInTheDocument()
+    expect(screen.getByText('object-cover')).toBeInTheDocument()
+    expect(screen.getByText('mx-[1rem]')).toBeInTheDocument()
+    expect(screen.getByText('py-[2rem]')).toBeInTheDocument()
+  })
+
   it('shows empty state when no input', () => {
     renderTool(CssToTailwind)
     expect(screen.getByText('Enter CSS on the left to convert')).toBeInTheDocument()

--- a/apps/cockpit/src/tools/__tests__/useToolState.test.ts
+++ b/apps/cockpit/src/tools/__tests__/useToolState.test.ts
@@ -1,0 +1,212 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useToolState } from '@/hooks/useToolState'
+import { loadToolState, saveToolState } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  loadToolState: vi.fn(),
+  saveToolState: vi.fn(),
+}))
+
+const cacheStore: Record<string, unknown> = {}
+vi.mock('@/stores/tool-state.store', () => ({
+  useToolStateCache: (
+    selector: (s: { get: (id: string) => unknown; set: (id: string, v: unknown) => void }) => unknown
+  ) =>
+    selector({
+      get: (id) => cacheStore[id],
+      set: (id, v) => {
+        cacheStore[id] = v
+      },
+    }),
+}))
+
+type ToolState = { value: string }
+
+describe('useToolState', () => {
+  const TOOL_ID = 'test-tool'
+  const DEFAULT_STATE: ToolState = { value: 'default' }
+
+  beforeEach(() => {
+    Object.keys(cacheStore).forEach((k) => delete cacheStore[k])
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('returns defaultState when cache is empty and SQLite returns nothing', async () => {
+    vi.mocked(loadToolState).mockResolvedValue(null)
+
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    expect(result.current[0]).toEqual(DEFAULT_STATE)
+
+    // Wait for the useEffect to settle
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current[0]).toEqual(DEFAULT_STATE)
+    expect(loadToolState).toHaveBeenCalledWith(TOOL_ID)
+  })
+
+  it('initialises synchronously from cache when a cached value exists (loadToolState not called)', () => {
+    cacheStore[TOOL_ID] = { value: 'cached' }
+
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    expect(result.current[0]).toEqual({ value: 'cached' })
+    expect(loadToolState).not.toHaveBeenCalled()
+  })
+
+  it('loads from SQLite on cold start (cache miss), merges with defaultState', async () => {
+    let resolveDb: (val: any) => void = () => {}
+    vi.mocked(loadToolState).mockReturnValue(new Promise((resolve) => { resolveDb = resolve }))
+
+    const { result } = renderHook(() =>
+      useToolState<{ value: string; extra?: string }>(TOOL_ID, {
+        value: 'default',
+        extra: 'defaultExtra',
+      })
+    )
+
+    // Initial state is default
+    expect(result.current[0]).toEqual({ value: 'default', extra: 'defaultExtra' })
+
+    // Resolve the DB load
+    await act(async () => {
+      resolveDb({ value: 'sqlite' })
+    })
+
+    expect(result.current[0]).toEqual({ value: 'sqlite', extra: 'defaultExtra' })
+    expect(cacheStore[TOOL_ID]).toEqual({ value: 'sqlite', extra: 'defaultExtra' })
+  })
+
+  it('update() merges patch into state immediately', () => {
+    vi.mocked(loadToolState).mockResolvedValue(null)
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    act(() => {
+      result.current[1]({ value: 'updated' })
+    })
+
+    expect(result.current[0]).toEqual({ value: 'updated' })
+  })
+
+  it('update() writes to cache synchronously (before debounce fires)', () => {
+    vi.mocked(loadToolState).mockResolvedValue(null)
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    act(() => {
+      result.current[1]({ value: 'updated' })
+    })
+
+    expect(cacheStore[TOOL_ID]).toEqual({ value: 'updated' })
+    expect(saveToolState).not.toHaveBeenCalled() // since it's debounced
+  })
+
+  it('update() debounces saveToolState — not called before 2000ms, called after', () => {
+    vi.useFakeTimers()
+    vi.mocked(loadToolState).mockResolvedValue(null)
+
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    act(() => {
+      result.current[1]({ value: 'updated' })
+    })
+
+    expect(saveToolState).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1999)
+    })
+    expect(saveToolState).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(saveToolState).toHaveBeenCalledWith(TOOL_ID, { value: 'updated' })
+    expect(saveToolState).toHaveBeenCalledTimes(1)
+  })
+
+  it('rapid updates only trigger one saveToolState call (debounce resets)', () => {
+    vi.useFakeTimers()
+    vi.mocked(loadToolState).mockResolvedValue(null)
+
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    act(() => {
+      result.current[1]({ value: 'first' })
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    act(() => {
+      result.current[1]({ value: 'second' })
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    // First update would have fired at 2000, but we reset it, so 1000 + 1500 = 2500 is only 1500 after second update
+    expect(saveToolState).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(saveToolState).toHaveBeenCalledWith(TOOL_ID, { value: 'second' })
+    expect(saveToolState).toHaveBeenCalledTimes(1)
+  })
+
+  it('on unmount, saveToolState is called immediately (bypasses debounce)', async () => {
+    vi.useFakeTimers()
+    let resolveDb: (val: any) => void = () => {}
+    vi.mocked(loadToolState).mockReturnValue(new Promise((resolve) => { resolveDb = resolve }))
+
+    const { result, unmount } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    await act(async () => {
+      resolveDb({ value: 'loaded' })
+      // Yield to microtask queue for the promise to settle and state to update
+      await Promise.resolve()
+    })
+
+    act(() => {
+      result.current[1]({ value: 'unmount-test' })
+    })
+
+    expect(saveToolState).not.toHaveBeenCalled()
+
+    act(() => {
+      unmount()
+    })
+
+    expect(saveToolState).toHaveBeenCalledWith(TOOL_ID, { value: 'unmount-test' })
+
+    // ensure debounce timer doesn't fire again
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(saveToolState).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancelled load: if component unmounts before SQLite load resolves, state is not updated', async () => {
+    let resolveDb: (val: any) => void = () => {}
+    vi.mocked(loadToolState).mockReturnValue(new Promise((resolve) => { resolveDb = resolve }))
+
+    const { result, unmount } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    unmount()
+
+    await act(async () => {
+      resolveDb({ value: 'late-sqlite-data' })
+    })
+
+    // State wasn't updated with late-sqlite-data
+    expect(result.current[0]).toEqual(DEFAULT_STATE)
+    expect(cacheStore[TOOL_ID]).toBeUndefined()
+  })
+})

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -36,6 +36,20 @@ const PROPERTY_MAP: Record<string, Record<string, string>> = {
   'box-sizing': { 'border-box': 'box-border', 'content-box': 'box-content' },
   visibility: { hidden: 'invisible', visible: 'visible' },
   'list-style-type': { none: 'list-none', disc: 'list-disc', decimal: 'list-decimal' },
+  'text-transform': { uppercase: 'uppercase', lowercase: 'lowercase', capitalize: 'capitalize', none: 'normal-case' },
+  'text-overflow': { ellipsis: 'truncate', clip: 'overflow-hidden' },
+  'vertical-align': { top: 'align-top', middle: 'align-middle', bottom: 'align-bottom', baseline: 'align-baseline', 'text-top': 'align-text-top', 'text-bottom': 'align-text-bottom' },
+  'object-fit': { contain: 'object-contain', cover: 'object-cover', fill: 'object-fill', none: 'object-none', 'scale-down': 'object-scale-down' },
+  float: { left: 'float-left', right: 'float-right', none: 'float-none' },
+  clear: { left: 'clear-left', right: 'clear-right', both: 'clear-both', none: 'clear-none' },
+  'border-style': { solid: 'border-solid', dashed: 'border-dashed', dotted: 'border-dotted', double: 'border-double', none: 'border-none', hidden: 'border-hidden' },
+  resize: { none: 'resize-none', both: 'resize', horizontal: 'resize-x', vertical: 'resize-y' },
+  appearance: { none: 'appearance-none', auto: 'appearance-auto' },
+  'align-self': { auto: 'self-auto', 'flex-start': 'self-start', 'flex-end': 'self-end', center: 'self-center', stretch: 'self-stretch', baseline: 'self-baseline' },
+  'align-content': { center: 'content-center', 'flex-start': 'content-start', 'flex-end': 'content-end', 'space-between': 'content-between', 'space-around': 'content-around', 'space-evenly': 'content-evenly', stretch: 'content-stretch' },
+  'place-items': { center: 'place-items-center', start: 'place-items-start', end: 'place-items-end', stretch: 'place-items-stretch' },
+  'flex-grow': { '0': 'grow-0', '1': 'grow' },
+  'flex-shrink': { '0': 'shrink-0', '1': 'shrink' },
 }
 
 // Size-based properties with arbitrary value support
@@ -67,7 +81,9 @@ function convertSizeProperty(prop: string, value: string): string | null {
 function convertSpacingProperty(prop: string, value: string): string | null {
   const prefix: Record<string, string> = {
     margin: 'm', 'margin-top': 'mt', 'margin-right': 'mr', 'margin-bottom': 'mb', 'margin-left': 'ml',
+    'margin-inline': 'mx', 'margin-block': 'my',
     padding: 'p', 'padding-top': 'pt', 'padding-right': 'pr', 'padding-bottom': 'pb', 'padding-left': 'pl',
+    'padding-inline': 'px', 'padding-block': 'py',
   }
   const p = prefix[prop]
   if (!p) return null

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "t4-app-monorepo",
@@ -33,7 +32,7 @@
     },
     "apps/cockpit": {
       "name": "cockpit",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@fontsource/fira-code": "^5.2.7",
         "@fontsource/jetbrains-mono": "^5.2.8",


### PR DESCRIPTION
## Summary

- **+27 tests** (211 → 238): settings store, history store, useToolState hook
- **CSS-to-Tailwind**: 14 new property mappings + margin-inline/padding-block shorthand

## Tests added
- `settings.store` — init(), update() optimistic + revert, theme cycling, persistence
- `history.store` — add(), loadForTool(), reload(), clearAll(), DB error handling
- `useToolState` — cache hit, cold-start SQLite load, debounce (2000ms), unmount save, cancelled load

## Note
`as any` in settings store tests is advisory (pre-commit warned, didn't block) — acceptable for vi mock casting in test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)