### PR TITLE
fix(cockpit): register history metadata migration (004)

### DIFF
--- a/apps/cockpit/src-tauri/src/lib.rs
+++ b/apps/cockpit/src-tauri/src/lib.rs
@@ -21,6 +21,12 @@ pub fn run() {
             sql: include_str!("../migrations/003_notes_tags.sql"),
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 4,
+            description: "add history metadata columns",
+            sql: include_str!("../migrations/004_history_metadata.sql"),
+            kind: MigrationKind::Up,
+        },
     ];
 
     tauri::Builder::default()


### PR DESCRIPTION
## Summary

Fixes the persistent database error: "table history has no column named duration_ms".

## Problem

The migration file `004_history_metadata.sql` existed in the codebase but was never registered in the Tauri app's migration list (`lib.rs`). This meant the columns `duration_ms`, `success`, `output_size`, and `starred` were never added to the local `history` table, causing insert failures whenever the app attempted to save history entries.

## Solution

Added migration version 4 to the migrations vector in [`apps/cockpit/src-tauri/src/lib.rs`](lib.rs#L24-30). The migration will now run automatically on app startup, adding the needed columns to existing databases.

## Changes

- [x] Register migration version 4 in `lib.rs`

## Test plan

- [x] Build and run the app: `bun run tauri dev`
- [x] Verify the migration runs automatically on startup (check console for any errors)
- [x] Perform actions that save history entries and confirm no errors appear
- [x] Check that history entries are being saved with metadata

## Manual verification (if needed)

If you already have an existing `cockpit.db` and see the error, you can manually apply the migration:

```bash
sqlite3 apps/cockpit/src-tauri/cockpit.db < apps/cockpit/src-tauri/migrations/004_history_metadata.sql
```

After restarting the app, errors should be gone.

🤖 Generated with Claude Code