### PR TITLE
chore: add .grepai/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ pnpm-lock.yaml
 *.swp
 *.swo
 
+.grepai/


### PR DESCRIPTION
## Summary
- Adds `.grepai/` to `.gitignore` to exclude grepai semantic search index files from version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)