### PR TITLE
fix(cockpit): add monaco-editor dependency for CI build

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -20,6 +20,7 @@
     "@fontsource/silkscreen": "^5.2.8",
     "@fontsource/source-code-pro": "^5.2.7",
     "@monaco-editor/react": "^4.7.0",
+    "monaco-editor": "^0.55.1",
     "@noble/hashes": "^2.0.1",
     "@phosphor-icons/react": "^2.1.10",
     "@prettier/plugin-xml": "^3.4.1",


### PR DESCRIPTION
Add monaco-editor as an explicit dependency in apps/cockpit/package.json so CI can resolve the Monaco peer dependency during Vite/Tauri build.