### PR TITLE
fix: correct auto-update manifest generation and release workflow

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -95,6 +95,16 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Generate release manifest
+        run: bun run scripts/generate-latest-json.ts
+
+      - name: Upload latest.json as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-json
+          path: apps/cockpit/latest.json
+          retention-days: 1
+
       - name: Build and release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -111,3 +121,22 @@ jobs:
           tauriScript: bunx tauri
           args: ${{ matrix.args }}
 
+  upload-manifest:
+    name: 'Upload manifest to release'
+    needs: [build, bump]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download latest.json artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: latest-json
+          path: .
+
+      - name: Upload to release
+        run: |
+          VERSION=$(jq -r '.version' latest.json)
+          gh release upload cockpit-v$VERSION latest.json --repo butteredstardust/devdrivr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/cockpit/latest.json
+++ b/apps/cockpit/latest.json
@@ -1,19 +1,23 @@
 {
   "version": "0.1.26",
   "notes": "Auto generated release manifest",
-  "pub_date": "2026-04-10T20:54:33.392Z",
+  "pub_date": "2026-04-10T21:06:22.452Z",
   "platforms": {
     "windows-x86_64": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_x64-setup.exe"
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_x64-setup.exe",
+      "signature": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_x64-setup.exe.sig"
     },
     "darwin-x86_64": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_x64.app.tar.gz"
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_x64.app.tar.gz",
+      "signature": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_x64.app.tar.gz.sig"
     },
     "darwin-aarch64": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_aarch64.app.tar.gz"
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_aarch64.app.tar.gz",
+      "signature": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_aarch64.app.tar.gz.sig"
     },
     "linux-x86_64": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_amd64.AppImage"
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_amd64.AppImage",
+      "signature": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_amd64.AppImage.sig"
     }
   }
 }

--- a/apps/cockpit/latest.json
+++ b/apps/cockpit/latest.json
@@ -1,16 +1,19 @@
 {
-  "version": "0.1.25",
+  "version": "0.1.26",
   "notes": "Auto generated release manifest",
-  "pub_date": "2026-04-10T19:38:21.835Z",
+  "pub_date": "2026-04-10T20:54:33.392Z",
   "platforms": {
-    "win32": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.exe"
+    "windows-x86_64": {
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_x64-setup.exe"
     },
-    "darwin": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.app.tar.gz"
+    "darwin-x86_64": {
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_x64.app.tar.gz"
     },
-    "linux": {
-      "url": "https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.AppImage"
+    "darwin-aarch64": {
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_aarch64.app.tar.gz"
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v0.1.26/devdrivr_0.1.26_amd64.AppImage"
     }
   }
 }

--- a/apps/cockpit/scripts/generate-latest-json.ts
+++ b/apps/cockpit/scripts/generate-latest-json.ts
@@ -16,15 +16,19 @@ async function main() {
     platforms: {
       'windows-x86_64': {
         url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_x64-setup.exe`,
+        signature: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_x64-setup.exe.sig`,
       },
       'darwin-x86_64': {
         url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_x64.app.tar.gz`,
+        signature: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_x64.app.tar.gz.sig`,
       },
       'darwin-aarch64': {
         url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_aarch64.app.tar.gz`,
+        signature: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_aarch64.app.tar.gz.sig`,
       },
       'linux-x86_64': {
         url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_amd64.AppImage`,
+        signature: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_amd64.AppImage.sig`,
       },
     },
   }

--- a/apps/cockpit/scripts/generate-latest-json.ts
+++ b/apps/cockpit/scripts/generate-latest-json.ts
@@ -1,27 +1,36 @@
 import * as fs from 'fs/promises'
-import { execSync } from 'child_process'
+
+const OWNER = 'butteredstardust'
+const REPO = 'devdrivr'
 
 async function main() {
   const pkg = JSON.parse(await fs.readFile('package.json', 'utf8'))
   const version = pkg.version
   const date = new Date().toISOString()
+  const tag = `cockpit-v${version}`
+
   const manifest = {
     version,
     notes: 'Auto generated release manifest',
     pub_date: date,
     platforms: {
-      win32: {
-        url: `https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.exe`,
+      'windows-x86_64': {
+        url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_x64-setup.exe`,
       },
-      darwin: {
-        url: `https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.app.tar.gz`,
+      'darwin-x86_64': {
+        url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_x64.app.tar.gz`,
       },
-      linux: {
-        url: `https://github.com/butteredstardust/devdrivr/releases/latest/download/devdrivre.AppImage`,
+      'darwin-aarch64': {
+        url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_aarch64.app.tar.gz`,
+      },
+      'linux-x86_64': {
+        url: `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/devdrivr_${version}_amd64.AppImage`,
       },
     },
   }
+
   await fs.writeFile('latest.json', JSON.stringify(manifest, null, 2))
   console.log('latest.json generated')
 }
+
 main().catch(console.error)

--- a/apps/cockpit/src-tauri/tauri.conf.json
+++ b/apps/cockpit/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",

--- a/apps/cockpit/src-tauri/tauri.conf.json
+++ b/apps/cockpit/src-tauri/tauri.conf.json
@@ -81,7 +81,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZDQzQ4NzIxNDkzOTNBMTcKUldRWE9qbEpJWWZFYkNQVHVubnFTeXpQR1dycDhLTW5zVlFZT25qbWROV2Aza1N4VXFNaTRCbkgK",
       "endpoints": [
-        "https://api.github.com/repos/butteredstardust/devdrivr/releases/latest/assets"
+        "https://github.com/butteredstardust/devdrivr/releases/download/cockpit-v{{version}}/latest.json"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Fix `generate-latest-json.ts` with correct file names and platform keys
- Use version tag in URLs instead of 'latest' for proper per-release manifests  
- Fix `tauri.conf.json` endpoint to use `{{version}}` placeholder
- Update CI workflow to generate and upload `latest.json` to each release
- Add dedicated job to upload manifest after builds complete

## Test plan
- [ ] Verify the `latest.json` generates with correct URLs
- [ ] Test the endpoint resolves correctly after merge
- [ ] Run a release build to confirm `latest.json` is uploaded to the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)