### PR TITLE
fix(ci): set working-directory for manifest generation

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -96,6 +96,7 @@ jobs:
         run: bun install
 
       - name: Generate release manifest
+        working-directory: ./apps/cockpit
         run: bun run scripts/generate-latest-json.ts
 
       - name: Upload latest.json as artifact


### PR DESCRIPTION
This fixes the build failure where the manifest generation step couldn't find the script because it was running from the repository root instead of the cockpit app directory.

**Change:**
- Add  to the 'Generate release manifest' step in 

This ensures  executes from the correct directory where the script and  exist.

**Auto-update verification:**
After merging, the release workflow will:
1. Generate  with correct per-release manifest URLs
2. Upload it to the GitHub release
3. Build and sign platform installers

The auto-update feature should function correctly once this PR is merged and a release is published.