### PR TITLE
fix(ci): correct manifest generation and artifact upload

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -100,6 +100,7 @@ jobs:
         run: bun run scripts/generate-latest-json.ts
 
       - name: Upload latest.json as artifact
+        if: matrix.platform == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: latest-json


### PR DESCRIPTION
Fixes the CI build failures:
- Add working-directory to manifest generation step so script can be found
- Conditionally upload latest.json artifact only from ubuntu job to avoid 409 Conflict

After merge, the CI should pass and auto-update will work.