### PR TITLE
feat(cockpit): Image Tool — resize, crop, compress & export

### DIFF
--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -12,7 +12,7 @@ Instructions for AI coding agents (OpenAI Codex, GitHub Copilot, etc.) working i
 - **UI**: React 19 + TypeScript 5.9 + Tailwind CSS 4
 - **State**: Zustand 5 stores → SQLite (WAL mode) via `@tauri-apps/plugin-sql`
 - **Build**: Vite 7 + Bun (package manager)
-- **27 tools** across 7 groups (Code, Data, Web, Convert, Test, Network, Write)
+- **29 tools** across 7 groups (Code, Data, Web, Convert, Test, Network, Write)
 - **No cloud, no accounts** — everything runs locally
 
 ---
@@ -202,6 +202,135 @@ import { ArrowRight, Clipboard } from '@phosphor-icons/react'
 <span>→</span>
 ```
 
+### 13. Never use the Preview MCP tool
+
+This is a Tauri desktop app. The browser-based preview cannot render it.
+Do not call `preview_start` or any preview tool unless the user explicitly asks.
+
+### 14. Use `TextEncoder`/`TextDecoder` for UTF-8, not `unescape`/`escape`
+
+```typescript
+// ✅ Encode text → base64 (handles full Unicode)
+const bytes = new TextEncoder().encode(text)
+let binary = ''
+for (const byte of bytes) binary += String.fromCharCode(byte)
+const encoded = btoa(binary)
+
+// ✅ Decode base64 → text
+const decoded = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+const text = new TextDecoder().decode(decoded)
+
+// ❌ Deprecated — breaks on multi-byte characters
+btoa(unescape(encodeURIComponent(text)))
+decodeURIComponent(escape(atob(b64)))
+```
+
+### 15. React 19 — Wheel events are passive by default
+
+`onWheel` in JSX cannot call `e.preventDefault()` (browser ignores it). Attach the
+listener imperatively for any zoom / scroll-hijack:
+
+```typescript
+useEffect(() => {
+  const el = ref.current
+  if (!el) return
+  const onWheel = (e: WheelEvent) => {
+    e.preventDefault() /* zoom */
+  }
+  el.addEventListener('wheel', onWheel, { passive: false })
+  return () => el.removeEventListener('wheel', onWheel)
+}, [])
+```
+
+### 16. Refs on conditional JSX branches — use callback refs, not `useRef` + `useEffect`
+
+If a `ref` is attached to an element inside a conditional branch, a plain `useRef`
+will be `null` when the `useEffect` runs on mount (the branch may not be active).
+Use a `useCallback` callback ref so the listener attaches/detaches as the node
+mounts and unmounts:
+
+```typescript
+const wheelCleanupRef = useRef<(() => void) | null>(null)
+
+const callbackRef = useCallback((el: HTMLDivElement | null) => {
+  wheelCleanupRef.current?.()
+  wheelCleanupRef.current = null
+  if (!el) return
+  const onWheel = (e: WheelEvent) => {
+    e.preventDefault() /* ... */
+  }
+  el.addEventListener('wheel', onWheel, { passive: false })
+  wheelCleanupRef.current = () => el.removeEventListener('wheel', onWheel)
+}, []) // deps: only stable values
+
+// <div ref={callbackRef}>
+```
+
+### 17. ResizeObserver: guard for jsdom
+
+`ResizeObserver` is `undefined` in the Vitest/jsdom environment. Always guard:
+
+```typescript
+if (typeof ResizeObserver === 'undefined') return
+const observer = new ResizeObserver(update)
+observer.observe(el)
+return () => observer.disconnect()
+```
+
+### 18. Cross-tool navigation — inject state via `useToolStateCache`
+
+To pre-populate a destination tool before navigating, write to `useToolStateCache`.
+The destination reads from it synchronously on mount — no IPC or pub/sub needed:
+
+```typescript
+const cacheSet = useToolStateCache((s) => s.set)
+const cacheGet = useToolStateCache((s) => s.get)
+const openTab = useUiStore((s) => s.openTab)
+
+cacheSet('target-tool', {
+  ...cacheGet('target-tool'),
+  draft: {
+    /* ... */
+  },
+})
+openTab('target-tool')
+```
+
+### 19. Canvas 2D is sufficient for image processing
+
+No npm image library is needed for resize, crop, format conversion, or quality control.
+Canvas handles all of it:
+
+```typescript
+canvas.width = outW
+canvas.height = outH
+ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, outW, outH)
+canvas.toBlob(
+  (blob) => {
+    /* download */
+  },
+  'image/jpeg',
+  quality / 100
+)
+```
+
+For large images, debounce any input that triggers `toDataURL`/`toBlob` on every keystroke.
+
+### 20. Crop / geometry math — clamp dimensions before position
+
+When clamping a crop/selection rectangle to image bounds, always clamp `w`/`h` first
+so the subsequent `x`/`y` clamp expressions (`origW - w`, `origH - h`) use valid values:
+
+```typescript
+w = Math.max(1, Math.min(w, origW))
+h = Math.max(1, Math.min(h, origH))
+x = Math.max(0, Math.min(x, origW - w))
+y = Math.max(0, Math.min(y, origH - h))
+```
+
+Also lower-bound any new `x`/`y` computed from a drag delta before using it to derive
+a new `w`/`h` (e.g., NW/SW handle drag: `nx = Math.max(0, startX + dx)`).
+
 ---
 
 ## How to Add a New Tool
@@ -317,7 +446,7 @@ WAL mode is set at connection time in `getDb()` — not in migrations.
 Before opening a PR, verify every item:
 
 - [ ] `npx tsc --noEmit` — zero errors
-- [ ] `bunx vitest run` — 326/326 passing
+- [ ] `bunx vitest run` — 361/361 passing
 - [ ] No `Database.load()` outside `src/lib/db.ts`
 - [ ] No hardcoded colors (`#hex`, `rgb()`, Tailwind palette classes like `bg-zinc-900`)
 - [ ] No `React.StrictMode`

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -22,7 +22,7 @@ Full canonical docs live in [`documentation/`](./documentation/):
 - **Package manager:** Bun only. Never use npm or yarn.
 - **Run commands from:** `apps/cockpit/` unless noted.
 - **Type-check:** `npx tsc --noEmit` — must stay clean.
-- **Tests:** `bunx vitest run` (Vitest, 326 tests / 48 files). Use `bunx`, not `bun run test`.
+- **Tests:** `bunx vitest run` (Vitest, 361 tests / 49 files). Use `bunx`, not `bun run test`.
 - **Dev server:** `bun run tauri dev` (starts Vite + Rust binary).
 
 ## Architecture
@@ -107,6 +107,135 @@ Migration {
 - Don't use physical pixel APIs (`outerPosition`, `outerSize`) without converting via `scaleFactor()` + `toLogical()`
 - Don't add `React.StrictMode` — it was removed to prevent double-mount flash in the Tauri WebView
 - Don't skip the idempotent promise guard when writing a new store `init()` method
+- Don't use the Preview MCP tool — this is a desktop app running in Tauri; the browser preview cannot render it and wastes tokens
+- Don't use deprecated `unescape`/`escape` for UTF-8 — use `TextEncoder`/`TextDecoder` instead
+
+## Patterns Established in This Codebase
+
+### React 19 — Non-Passive Wheel Events
+
+React 19 registers `wheel` and `touch` listeners as passive by default, so calling
+`e.preventDefault()` in a React `onWheel` handler has no effect (browser ignores it).
+For zoom-to-cursor and any scroll-hijacking, attach the listener imperatively:
+
+```typescript
+useEffect(
+  () => {
+    const el = ref.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      // zoom logic
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  },
+  [
+    /* stable deps only */
+  ]
+)
+```
+
+### Callback Ref Pattern (Conditional Branches)
+
+A single `useRef` + `useEffect` wheel-listener fails when the ref target is inside a
+conditional JSX branch — the effect runs once on mount when the element doesn't exist yet.
+Use a `useCallback` callback ref instead so the listener attaches/detaches as the node
+mounts and unmounts:
+
+```typescript
+const wheelCleanupRef = useRef<(() => void) | null>(null)
+
+const callbackRef = useCallback(
+  (el: HTMLDivElement | null) => {
+    if (wheelCleanupRef.current) {
+      wheelCleanupRef.current()
+      wheelCleanupRef.current = null
+    }
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault() /* ... */
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    wheelCleanupRef.current = () => el.removeEventListener('wheel', onWheel)
+  },
+  [
+    /* stable deps */
+  ]
+)
+
+// Use as: <div ref={callbackRef}>
+```
+
+### transformRef Mirror Pattern (Zoom State)
+
+For zoom/pan state that is read inside a non-React event handler (wheel) and also
+needs to trigger re-renders for a zoom badge, keep a `useRef` and `useState` in sync
+via a single setter. The `useRef` prevents stale closures; the `useState` drives renders:
+
+```typescript
+const [transform, _setTransform] = useState<Transform>(DEFAULT)
+const transformRef = useRef<Transform>(DEFAULT)
+const setTransform = useCallback((t: Transform) => {
+  transformRef.current = t // read by wheel handler — always fresh
+  _setTransform(t) // triggers zoom badge re-render
+}, [])
+```
+
+### Cross-Tool State Injection via `useToolStateCache`
+
+To pre-populate a destination tool before navigating to it, write directly to
+`useToolStateCache` (Zustand, accessible outside components). The target tool reads
+from the cache synchronously on mount via `useToolState` — no pub/sub or IPC needed:
+
+```typescript
+const cacheSet = useToolStateCache((s) => s.set)
+const cacheGet = useToolStateCache((s) => s.get)
+const openTab = useUiStore((s) => s.openTab)
+
+const handleSend = useCallback(() => {
+  const existing = cacheGet('target-tool')
+  cacheSet('target-tool', {
+    ...existing,
+    draft: {
+      /* ... */
+    },
+  })
+  openTab('target-tool')
+}, [cacheGet, cacheSet, openTab])
+```
+
+### Canvas 2D for Image Processing
+
+No npm image library is needed. The Canvas 2D API handles resize + crop + format
+conversion + quality encoding entirely in the browser:
+
+```typescript
+canvas.width = outW
+canvas.height = outH
+ctx.drawImage(img, srcX, srcY, srcW, srcH, 0, 0, outW, outH)
+canvas.toBlob(
+  (blob) => {
+    /* download or clipboard */
+  },
+  'image/jpeg',
+  quality / 100
+)
+```
+
+For export, `canvas.toDataURL` is synchronous. For large images, debounce any
+quality-slider or resize-input that triggers a re-render with a canvas redraw.
+
+### ResizeObserver Guard for jsdom
+
+`ResizeObserver` is undefined in jsdom (Vitest). Guard before using it:
+
+```typescript
+if (typeof ResizeObserver === 'undefined') return
+const observer = new ResizeObserver(update)
+observer.observe(el)
+return () => observer.disconnect()
+```
 
 ## Running the Test Suite
 

--- a/apps/cockpit/src/app/tool-registry.ts
+++ b/apps/cockpit/src/app/tool-registry.ts
@@ -29,6 +29,7 @@ const ApiClient = lazy(() => import('@/tools/api-client/ApiClient'))
 const DocsBrowser = lazy(() => import('@/tools/docs-browser/DocsBrowser'))
 const SnippetsManager = lazy(() => import('@/tools/snippets/SnippetsManager'))
 const CsvTools = lazy(() => import('@/tools/csv-tools/CsvTools'))
+const ImageTool = lazy(() => import('@/tools/image-tool/ImageTool'))
 
 export const TOOLS: ToolDefinition[] = [
   // --- Code ---
@@ -103,8 +104,7 @@ export const TOOLS: ToolDefinition[] = [
     name: 'CSV Tools',
     group: 'data',
     icon: 'CSV',
-    description:
-      'View, edit, convert with JSON, analyze stats, and generate schemas for CSV data',
+    description: 'View, edit, convert with JSON, analyze stats, and generate schemas for CSV data',
     component: CsvTools,
   },
   // --- Web ---
@@ -207,6 +207,14 @@ export const TOOLS: ToolDefinition[] = [
     icon: '##',
     description: 'Generate hashes and HMAC with comparison and export',
     component: HashGenerator,
+  },
+  {
+    id: 'image-tool',
+    name: 'Image Tool',
+    group: 'convert',
+    icon: '🖼',
+    description: 'Resize, crop, compress and convert images (JPEG, PNG, WebP)',
+    component: ImageTool,
   },
   // --- Test ---
   {

--- a/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderTool } from './test-utils'
+import ImageTool from '../image-tool/ImageTool'
+
+describe('ImageTool', () => {
+  // ── Empty state ──────────────────────────────────────────────────
+
+  it('renders the drop zone when no image is loaded', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText(/drop an image here/i)).toBeInTheDocument()
+  })
+
+  it('shows accepted formats in the drop zone hint', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText(/jpeg.*png.*webp/i)).toBeInTheDocument()
+  })
+
+  it('renders an "Open Image" button', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText('Open Image')).toBeInTheDocument()
+  })
+
+  it('renders a "Browse files" button in the drop zone', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText('Browse files')).toBeInTheDocument()
+  })
+
+  it('shows placeholder text when no image is loaded', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText(/open an image or drop it anywhere/i)).toBeInTheDocument()
+  })
+
+  // ── Tab structure ────────────────────────────────────────────────
+
+  it('renders all three tabs', () => {
+    renderTool(ImageTool)
+    expect(screen.getByText('Resize')).toBeInTheDocument()
+    expect(screen.getByText('Crop')).toBeInTheDocument()
+    expect(screen.getByText('Export')).toBeInTheDocument()
+  })
+
+  // ── Resize tab controls ──────────────────────────────────────────
+
+  it('shows resize controls when clicking Resize tab', () => {
+    renderTool(ImageTool)
+    fireEvent.click(screen.getByText('Resize'))
+    expect(screen.getByText(/open an image to get started/i)).toBeInTheDocument()
+  })
+
+  // ── Crop tab ─────────────────────────────────────────────────────
+
+  it('switches to crop tab and shows enable crop toggle', () => {
+    renderTool(ImageTool)
+    fireEvent.click(screen.getByText('Crop'))
+    expect(screen.getByText(/open an image to get started/i)).toBeInTheDocument()
+  })
+
+  // ── Export tab ───────────────────────────────────────────────────
+
+  it('switches to export tab', () => {
+    renderTool(ImageTool)
+    fireEvent.click(screen.getByText('Export'))
+    expect(screen.getByText(/open an image to get started/i)).toBeInTheDocument()
+  })
+
+  // ── Drag over state ──────────────────────────────────────────────
+
+  it('shows drag-over overlay when dragging a file over the preview area', () => {
+    renderTool(ImageTool)
+    // The preview container is the outer flex div; fire drag events on it
+    const dropZone = screen.getByText(/drop an image here/i).closest('div')!.parentElement!
+    fireEvent.dragOver(dropZone)
+    expect(screen.getByText(/drop to open image/i)).toBeInTheDocument()
+  })
+
+  it('hides drag-over overlay when drag leaves', () => {
+    renderTool(ImageTool)
+    const dropZone = screen.getByText(/drop an image here/i).closest('div')!.parentElement!
+    fireEvent.dragOver(dropZone)
+    fireEvent.dragLeave(dropZone)
+    expect(screen.queryByText(/drop to open image/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -1,0 +1,1136 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useToolState } from '@/hooks/useToolState'
+import { useUiStore } from '@/stores/ui.store'
+import { Button } from '@/components/shared/Button'
+import { TabBar } from '@/components/shared/TabBar'
+import {
+  ImageIcon,
+  UploadSimpleIcon,
+  LockSimpleIcon,
+  LockSimpleOpenIcon,
+  ArrowCounterClockwiseIcon,
+  DownloadSimpleIcon,
+  CopyIcon,
+} from '@phosphor-icons/react'
+
+// ── Types ──────────────────────────────────────────────────────────
+
+type ImageToolState = {
+  activeTab: string
+  // Resize
+  resizeW: number | null
+  resizeH: number | null
+  lockAspect: boolean
+  // Crop
+  cropEnabled: boolean
+  cropX: number
+  cropY: number
+  cropW: number | null
+  cropH: number | null
+  // Export
+  format: 'png' | 'jpeg' | 'webp'
+  quality: number
+}
+
+type DisplayMetrics = {
+  displayScale: number
+  displayW: number
+  displayH: number
+  offsetX: number
+  offsetY: number
+}
+
+type CropHandle = 'nw' | 'ne' | 'sw' | 'se' | 'body'
+
+type CropDragState = {
+  handle: CropHandle
+  startMouseX: number
+  startMouseY: number
+  startCrop: { x: number; y: number; w: number; h: number }
+  displayScale: number
+  origW: number
+  origH: number
+}
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const TABS = [
+  { id: 'resize', label: 'Resize' },
+  { id: 'crop', label: 'Crop' },
+  { id: 'export', label: 'Export' },
+]
+
+const FORMAT_TABS = [
+  { id: 'png', label: 'PNG' },
+  { id: 'jpeg', label: 'JPEG' },
+  { id: 'webp', label: 'WebP' },
+]
+
+const PRESET_SIZES = [
+  { label: '1:1', w: 1, h: 1 },
+  { label: '16:9', w: 16, h: 9 },
+  { label: '4:3', w: 4, h: 3 },
+  { label: '3:2', w: 3, h: 2 },
+]
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+// Estimate compressed file size from data URL length
+function estimateSizeFromDataUrl(dataUrl: string): number {
+  // data URL is base64 encoded; each 4 chars ≈ 3 bytes
+  const base64 = dataUrl.split(',')[1] ?? ''
+  return Math.round((base64.length * 3) / 4)
+}
+
+// ── Component ──────────────────────────────────────────────────────
+
+export default function ImageTool() {
+  const [state, updateState] = useToolState<ImageToolState>('image-tool', {
+    activeTab: 'resize',
+    resizeW: null,
+    resizeH: null,
+    lockAspect: true,
+    cropEnabled: false,
+    cropX: 0,
+    cropY: 0,
+    cropW: null,
+    cropH: null,
+    format: 'png',
+    quality: 85,
+  })
+
+  const setLastAction = useUiStore((s) => s.setLastAction)
+
+  // ── Local state ────────────────────────────────────────────────
+
+  const [originalImg, setOriginalImg] = useState<HTMLImageElement | null>(null)
+  const [originalFileSize, setOriginalFileSize] = useState<number>(0)
+  const [fileName, setFileName] = useState<string>('image')
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [displayMetrics, setDisplayMetrics] = useState<DisplayMetrics | null>(null)
+  const [outputDataUrl, setOutputDataUrl] = useState<string | null>(null)
+  const [outputSize, setOutputSize] = useState<{ w: number; h: number } | null>(null)
+
+  // ── Refs ────────────────────────────────────────────────────────
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const previewContainerRef = useRef<HTMLDivElement>(null)
+  const outputCanvasRef = useRef<HTMLCanvasElement>(null)
+  const cropDragRef = useRef<CropDragState | null>(null)
+
+  // ── Image loading ──────────────────────────────────────────────
+
+  const loadImageFile = useCallback(
+    (file: File) => {
+      if (!file.type.startsWith('image/')) {
+        setLastAction('File is not an image', 'error')
+        return
+      }
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const src = e.target?.result as string
+        const img = new Image()
+        img.onload = () => {
+          // Reset display metrics before setting the new image so one stale render
+          // of the crop overlay with the previous image's metrics doesn't occur.
+          setDisplayMetrics(null)
+          setOriginalImg(img)
+          setFileName(file.name)
+          setOriginalFileSize(file.size)
+          updateState({
+            resizeW: img.naturalWidth,
+            resizeH: img.naturalHeight,
+            cropX: 0,
+            cropY: 0,
+            cropW: img.naturalWidth,
+            cropH: img.naturalHeight,
+            cropEnabled: false,
+          })
+          setLastAction(`Opened "${file.name}"`, 'success')
+        }
+        img.onerror = () => setLastAction('Failed to load image', 'error')
+        img.src = src
+      }
+      reader.readAsDataURL(file)
+    },
+    [updateState, setLastAction]
+  )
+
+  // ── Drag & drop ────────────────────────────────────────────────
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => setIsDragOver(false), [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragOver(false)
+      const file = e.dataTransfer.files[0]
+      if (file) loadImageFile(file)
+    },
+    [loadImageFile]
+  )
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (file) loadImageFile(file)
+      e.target.value = ''
+    },
+    [loadImageFile]
+  )
+
+  // ── Display metrics (for crop overlay positioning) ─────────────
+  // Updated via ResizeObserver so crop handles stay accurate on resize.
+
+  useEffect(() => {
+    const container = previewContainerRef.current
+    if (!container || !originalImg) return
+
+    const update = () => {
+      const { width, height } = container.getBoundingClientRect()
+      if (!width || !height) return
+      const origW = originalImg.naturalWidth
+      const origH = originalImg.naturalHeight
+      const scale = Math.min(width / origW, height / origH)
+      const displayW = origW * scale
+      const displayH = origH * scale
+      setDisplayMetrics({
+        displayScale: scale,
+        displayW,
+        displayH,
+        offsetX: (width - displayW) / 2,
+        offsetY: (height - displayH) / 2,
+      })
+    }
+
+    update()
+
+    // Guard for jsdom / environments without ResizeObserver
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(update)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [originalImg])
+
+  // ── Canvas rendering ───────────────────────────────────────────
+  // Always draws to the hidden/visible output canvas so export works
+  // regardless of which tab is active.
+
+  useEffect(() => {
+    const canvas = outputCanvasRef.current
+    if (!canvas || !originalImg) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const srcX = state.cropEnabled ? state.cropX : 0
+    const srcY = state.cropEnabled ? state.cropY : 0
+    const srcW = state.cropEnabled
+      ? (state.cropW ?? originalImg.naturalWidth)
+      : originalImg.naturalWidth
+    const srcH = state.cropEnabled
+      ? (state.cropH ?? originalImg.naturalHeight)
+      : originalImg.naturalHeight
+
+    const outW = Math.max(1, state.resizeW ?? srcW)
+    const outH = Math.max(1, state.resizeH ?? srcH)
+
+    canvas.width = outW
+    canvas.height = outH
+    ctx.clearRect(0, 0, outW, outH)
+    ctx.drawImage(originalImg, srcX, srcY, srcW, srcH, 0, 0, outW, outH)
+
+    setOutputSize({ w: outW, h: outH })
+
+    const mimeType =
+      state.format === 'jpeg' ? 'image/jpeg' : state.format === 'webp' ? 'image/webp' : 'image/png'
+    setOutputDataUrl(canvas.toDataURL(mimeType, state.quality / 100))
+  }, [originalImg, state])
+
+  // ── Resize helpers ─────────────────────────────────────────────
+
+  const sourceW = state.cropEnabled
+    ? (state.cropW ?? originalImg?.naturalWidth ?? 0)
+    : (originalImg?.naturalWidth ?? 0)
+  const sourceH = state.cropEnabled
+    ? (state.cropH ?? originalImg?.naturalHeight ?? 0)
+    : (originalImg?.naturalHeight ?? 0)
+  const aspect = sourceW > 0 && sourceH > 0 ? sourceW / sourceH : 1
+
+  const handleResizeW = useCallback(
+    (w: number) => {
+      if (!w || w < 1) return
+      if (state.lockAspect) {
+        updateState({ resizeW: w, resizeH: Math.max(1, Math.round(w / aspect)) })
+      } else {
+        updateState({ resizeW: w })
+      }
+    },
+    [state.lockAspect, aspect, updateState]
+  )
+
+  const handleResizeH = useCallback(
+    (h: number) => {
+      if (!h || h < 1) return
+      if (state.lockAspect) {
+        updateState({ resizeH: h, resizeW: Math.max(1, Math.round(h * aspect)) })
+      } else {
+        updateState({ resizeH: h })
+      }
+    },
+    [state.lockAspect, aspect, updateState]
+  )
+
+  const handleResetResize = useCallback(() => {
+    if (!originalImg) return
+    updateState({ resizeW: originalImg.naturalWidth, resizeH: originalImg.naturalHeight })
+  }, [originalImg, updateState])
+
+  const handleApplyPreset = useCallback(
+    (pw: number, ph: number) => {
+      if (!originalImg) return
+      const baseW = originalImg.naturalWidth
+      // Fit the preset ratio within the original dimensions
+      const targetAspect = pw / ph
+      let w = baseW
+      let h = Math.round(baseW / targetAspect)
+      if (h > originalImg.naturalHeight) {
+        h = originalImg.naturalHeight
+        w = Math.round(h * targetAspect)
+      }
+      updateState({ resizeW: w, resizeH: h })
+    },
+    [originalImg, updateState]
+  )
+
+  // ── Crop interaction ────────────────────────────────────────────
+
+  const handleCropHandleMouseDown = useCallback(
+    (e: React.MouseEvent, handle: CropHandle) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!displayMetrics || !originalImg) return
+      cropDragRef.current = {
+        handle,
+        startMouseX: e.clientX,
+        startMouseY: e.clientY,
+        startCrop: {
+          x: state.cropX,
+          y: state.cropY,
+          w: state.cropW ?? originalImg.naturalWidth,
+          h: state.cropH ?? originalImg.naturalHeight,
+        },
+        displayScale: displayMetrics.displayScale,
+        origW: originalImg.naturalWidth,
+        origH: originalImg.naturalHeight,
+      }
+    },
+    [displayMetrics, originalImg, state.cropX, state.cropY, state.cropW, state.cropH]
+  )
+
+  const handleCropMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const drag = cropDragRef.current
+      if (!drag) return
+      const { displayScale, origW, origH } = drag
+      const dx = (e.clientX - drag.startMouseX) / displayScale
+      const dy = (e.clientY - drag.startMouseY) / displayScale
+
+      let { x, y, w, h } = drag.startCrop
+      switch (drag.handle) {
+        case 'nw': {
+          // Lower-bound nx/ny so dragging past the image edge doesn't invert the rect
+          const nx = Math.max(
+            0,
+            Math.min(drag.startCrop.x + dx, drag.startCrop.x + drag.startCrop.w - 1)
+          )
+          const ny = Math.max(
+            0,
+            Math.min(drag.startCrop.y + dy, drag.startCrop.y + drag.startCrop.h - 1)
+          )
+          w = drag.startCrop.w - (nx - drag.startCrop.x)
+          h = drag.startCrop.h - (ny - drag.startCrop.y)
+          x = nx
+          y = ny
+          break
+        }
+        case 'ne': {
+          const ny = Math.max(
+            0,
+            Math.min(drag.startCrop.y + dy, drag.startCrop.y + drag.startCrop.h - 1)
+          )
+          h = drag.startCrop.h - (ny - drag.startCrop.y)
+          w = Math.max(1, drag.startCrop.w + dx)
+          y = ny
+          break
+        }
+        case 'sw': {
+          // Lower-bound nx so dragging past x=0 doesn't produce a negative width
+          const nx = Math.max(
+            0,
+            Math.min(drag.startCrop.x + dx, drag.startCrop.x + drag.startCrop.w - 1)
+          )
+          w = drag.startCrop.w - (nx - drag.startCrop.x)
+          h = Math.max(1, drag.startCrop.h + dy)
+          x = nx
+          break
+        }
+        case 'se':
+          w = Math.max(1, drag.startCrop.w + dx)
+          h = Math.max(1, drag.startCrop.h + dy)
+          break
+        case 'body':
+          x = drag.startCrop.x + dx
+          y = drag.startCrop.y + dy
+          break
+      }
+
+      // Clamp dimensions first, then positions — ordering matters because
+      // the position clamp uses the (now correct) clamped w/h values.
+      w = Math.max(1, Math.min(w, origW))
+      h = Math.max(1, Math.min(h, origH))
+      x = Math.max(0, Math.min(x, origW - w))
+      y = Math.max(0, Math.min(y, origH - h))
+
+      updateState({
+        cropX: Math.round(x),
+        cropY: Math.round(y),
+        cropW: Math.round(w),
+        cropH: Math.round(h),
+      })
+    },
+    [updateState]
+  )
+
+  const handleCropMouseUp = useCallback(() => {
+    cropDragRef.current = null
+  }, [])
+
+  const handleResetCrop = useCallback(() => {
+    if (!originalImg) return
+    updateState({
+      cropX: 0,
+      cropY: 0,
+      cropW: originalImg.naturalWidth,
+      cropH: originalImg.naturalHeight,
+    })
+  }, [originalImg, updateState])
+
+  // ── Export ─────────────────────────────────────────────────────
+
+  const handleDownload = useCallback(() => {
+    const canvas = outputCanvasRef.current
+    if (!canvas) return
+    const mimeType =
+      state.format === 'jpeg' ? 'image/jpeg' : state.format === 'webp' ? 'image/webp' : 'image/png'
+    const ext = state.format
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) return
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${fileName.replace(/\.[^.]+$/, '')}.${ext}`
+        a.click()
+        URL.revokeObjectURL(url)
+        setLastAction(`Saved as ${ext.toUpperCase()} (${formatBytes(blob.size)})`, 'success')
+      },
+      mimeType,
+      state.quality / 100
+    )
+  }, [state.format, state.quality, fileName, setLastAction])
+
+  const handleCopyImage = useCallback(async () => {
+    const canvas = outputCanvasRef.current
+    if (!canvas) return
+    try {
+      await new Promise<void>((resolve, reject) => {
+        canvas.toBlob(async (blob) => {
+          if (!blob) {
+            reject(new Error('No blob'))
+            return
+          }
+          try {
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+            resolve()
+          } catch (err) {
+            reject(err)
+          }
+        }, 'image/png')
+      })
+      setLastAction('Copied image to clipboard', 'success')
+    } catch {
+      setLastAction('Clipboard write failed', 'error')
+    }
+  }, [setLastAction])
+
+  const handleResetAll = useCallback(() => {
+    if (!originalImg) return
+    updateState({
+      resizeW: originalImg.naturalWidth,
+      resizeH: originalImg.naturalHeight,
+      lockAspect: true,
+      cropEnabled: false,
+      cropX: 0,
+      cropY: 0,
+      cropW: originalImg.naturalWidth,
+      cropH: originalImg.naturalHeight,
+      format: 'png',
+      quality: 85,
+    })
+    setLastAction('Reset all settings', 'info')
+  }, [originalImg, updateState, setLastAction])
+
+  // ── Crop box display rect (image coords → screen coords) ────────
+
+  const cropDisplayRect =
+    displayMetrics && originalImg
+      ? {
+          left: displayMetrics.offsetX + state.cropX * displayMetrics.displayScale,
+          top: displayMetrics.offsetY + state.cropY * displayMetrics.displayScale,
+          width: (state.cropW ?? originalImg.naturalWidth) * displayMetrics.displayScale,
+          height: (state.cropH ?? originalImg.naturalHeight) * displayMetrics.displayScale,
+        }
+      : null
+
+  const estimatedBytes = outputDataUrl ? estimateSizeFromDataUrl(outputDataUrl) : 0
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* ── Toolbar ─────────────────────────────────────────────── */}
+      <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
+        <Button variant="primary" size="sm" onClick={() => fileInputRef.current?.click()}>
+          <UploadSimpleIcon size={13} />
+          Open Image
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileInputChange}
+        />
+
+        {originalImg ? (
+          <>
+            <span
+              className="max-w-48 truncate font-mono text-xs text-[var(--color-text-muted)]"
+              title={fileName}
+            >
+              {fileName}
+            </span>
+            <span className="shrink-0 text-[10px] text-[var(--color-text-muted)]">
+              {originalImg.naturalWidth} × {originalImg.naturalHeight}px
+            </span>
+            {originalFileSize > 0 && (
+              <span className="shrink-0 text-[10px] text-[var(--color-text-muted)]">
+                {formatBytes(originalFileSize)}
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="text-xs text-[var(--color-text-muted)]">
+            Open an image or drop it anywhere
+          </span>
+        )}
+
+        {originalImg && (
+          <button
+            onClick={handleResetAll}
+            title="Reset all settings"
+            className="ml-auto flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            <ArrowCounterClockwiseIcon size={13} />
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* ── Tab bar ──────────────────────────────────────────────── */}
+      <div className="border-b border-[var(--color-border)]">
+        <TabBar
+          tabs={TABS}
+          activeTab={state.activeTab}
+          onTabChange={(id) => updateState({ activeTab: id })}
+        />
+      </div>
+
+      {/* ── Main body ────────────────────────────────────────────── */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Preview panel */}
+        <div
+          ref={previewContainerRef}
+          className="relative flex flex-1 select-none items-center justify-center overflow-hidden bg-[var(--color-surface)]"
+          style={{
+            backgroundImage:
+              'repeating-conic-gradient(var(--color-border) 0% 25%, transparent 0% 50%)',
+            backgroundSize: '16px 16px',
+          }}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          onMouseMove={state.activeTab === 'crop' ? handleCropMouseMove : undefined}
+          // onMouseLeave is intentionally NOT wired to handleCropMouseUp: letting
+          // the drag continue if the cursor briefly exits the container and
+          // re-enters is more forgiving UX than silently aborting mid-drag.
+          onMouseUp={state.activeTab === 'crop' ? handleCropMouseUp : undefined}
+        >
+          {originalImg ? (
+            <>
+              {/* Original image — shown in crop tab for the crop overlay UI */}
+              {state.activeTab === 'crop' && (
+                <img
+                  src={originalImg.src}
+                  alt="Original"
+                  className="max-h-full max-w-full object-contain"
+                  draggable={false}
+                />
+              )}
+
+              {/* Output canvas — always rendered; visible only outside crop tab */}
+              <canvas
+                ref={outputCanvasRef}
+                className={`max-h-full max-w-full object-contain ${state.activeTab === 'crop' ? 'hidden' : ''}`}
+              />
+
+              {/* Crop selection overlay */}
+              {state.activeTab === 'crop' && state.cropEnabled && cropDisplayRect && (
+                <>
+                  {/* Dimming strips around the crop area */}
+                  <div
+                    className="pointer-events-none absolute"
+                    style={{
+                      top: displayMetrics?.offsetY ?? 0,
+                      left: displayMetrics?.offsetX ?? 0,
+                      width: displayMetrics?.displayW ?? 0,
+                      height: cropDisplayRect.top - (displayMetrics?.offsetY ?? 0),
+                      background: 'rgba(0,0,0,0.55)',
+                    }}
+                  />
+                  <div
+                    className="pointer-events-none absolute"
+                    style={{
+                      top: cropDisplayRect.top + cropDisplayRect.height,
+                      left: displayMetrics?.offsetX ?? 0,
+                      width: displayMetrics?.displayW ?? 0,
+                      bottom: 0,
+                      height:
+                        (displayMetrics?.offsetY ?? 0) +
+                        (displayMetrics?.displayH ?? 0) -
+                        (cropDisplayRect.top + cropDisplayRect.height),
+                      background: 'rgba(0,0,0,0.55)',
+                    }}
+                  />
+                  <div
+                    className="pointer-events-none absolute"
+                    style={{
+                      top: cropDisplayRect.top,
+                      left: displayMetrics?.offsetX ?? 0,
+                      width: cropDisplayRect.left - (displayMetrics?.offsetX ?? 0),
+                      height: cropDisplayRect.height,
+                      background: 'rgba(0,0,0,0.55)',
+                    }}
+                  />
+                  <div
+                    className="pointer-events-none absolute"
+                    style={{
+                      top: cropDisplayRect.top,
+                      left: cropDisplayRect.left + cropDisplayRect.width,
+                      width:
+                        (displayMetrics?.offsetX ?? 0) +
+                        (displayMetrics?.displayW ?? 0) -
+                        (cropDisplayRect.left + cropDisplayRect.width),
+                      height: cropDisplayRect.height,
+                      background: 'rgba(0,0,0,0.55)',
+                    }}
+                  />
+
+                  {/* Crop box + handles */}
+                  <div
+                    className="absolute"
+                    style={{
+                      left: cropDisplayRect.left,
+                      top: cropDisplayRect.top,
+                      width: cropDisplayRect.width,
+                      height: cropDisplayRect.height,
+                      border: '1.5px solid white',
+                      boxSizing: 'border-box',
+                      cursor: 'move',
+                    }}
+                    onMouseDown={(e) => handleCropHandleMouseDown(e, 'body')}
+                  >
+                    {/* Rule-of-thirds grid lines */}
+                    <div
+                      className="pointer-events-none absolute inset-0"
+                      style={{
+                        backgroundImage:
+                          'linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px)',
+                        backgroundSize: '33.33% 33.33%',
+                      }}
+                    />
+
+                    {/* Corner handles */}
+                    {(['nw', 'ne', 'sw', 'se'] as const).map((handle) => (
+                      <div
+                        key={handle}
+                        onMouseDown={(e) => handleCropHandleMouseDown(e, handle)}
+                        style={{
+                          position: 'absolute',
+                          width: 12,
+                          height: 12,
+                          background: 'white',
+                          border: '1.5px solid rgba(0,0,0,0.4)',
+                          boxSizing: 'border-box',
+                          ...(handle === 'nw' && {
+                            top: -6,
+                            left: -6,
+                            cursor: 'nw-resize',
+                          }),
+                          ...(handle === 'ne' && {
+                            top: -6,
+                            right: -6,
+                            cursor: 'ne-resize',
+                          }),
+                          ...(handle === 'sw' && {
+                            bottom: -6,
+                            left: -6,
+                            cursor: 'sw-resize',
+                          }),
+                          ...(handle === 'se' && {
+                            bottom: -6,
+                            right: -6,
+                            cursor: 'se-resize',
+                          }),
+                        }}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          ) : (
+            /* Drop zone placeholder */
+            <div className="flex flex-col items-center gap-3 text-[var(--color-text-muted)]">
+              <ImageIcon size={52} className="opacity-20" />
+              <div className="text-center">
+                <div className="text-sm font-medium">Drop an image here</div>
+                <div className="mt-0.5 text-[10px] opacity-60">
+                  JPEG · PNG · WebP · GIF · BMP · SVG
+                </div>
+              </div>
+              <Button variant="secondary" size="sm" onClick={() => fileInputRef.current?.click()}>
+                Browse files
+              </Button>
+            </div>
+          )}
+
+          {/* Drag-over overlay */}
+          {isDragOver && (
+            <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-[var(--color-surface)]/90 backdrop-blur-sm">
+              <UploadSimpleIcon size={32} className="text-[var(--color-accent)]" />
+              <span className="text-sm font-medium text-[var(--color-accent)]">
+                Drop to open image
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* ── Controls panel ──────────────────────────────────────── */}
+        <div className="w-64 shrink-0 overflow-y-auto border-l border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+          {!originalImg ? (
+            <p className="text-xs text-[var(--color-text-muted)]">Open an image to get started.</p>
+          ) : state.activeTab === 'resize' ? (
+            <ResizePanel
+              resizeW={state.resizeW}
+              resizeH={state.resizeH}
+              lockAspect={state.lockAspect}
+              originalW={originalImg.naturalWidth}
+              originalH={originalImg.naturalHeight}
+              onResizeW={handleResizeW}
+              onResizeH={handleResizeH}
+              onLockToggle={() => updateState({ lockAspect: !state.lockAspect })}
+              onReset={handleResetResize}
+              onPreset={handleApplyPreset}
+            />
+          ) : state.activeTab === 'crop' ? (
+            <CropPanel
+              enabled={state.cropEnabled}
+              x={state.cropX}
+              y={state.cropY}
+              w={state.cropW ?? originalImg.naturalWidth}
+              h={state.cropH ?? originalImg.naturalHeight}
+              maxW={originalImg.naturalWidth}
+              maxH={originalImg.naturalHeight}
+              onToggle={() => updateState({ cropEnabled: !state.cropEnabled })}
+              onChange={(x, y, w, h) => updateState({ cropX: x, cropY: y, cropW: w, cropH: h })}
+              onReset={handleResetCrop}
+            />
+          ) : (
+            <ExportPanel
+              format={state.format}
+              quality={state.quality}
+              outputW={outputSize?.w ?? 0}
+              outputH={outputSize?.h ?? 0}
+              originalBytes={originalFileSize}
+              estimatedBytes={estimatedBytes}
+              onFormatChange={(f) => updateState({ format: f as ImageToolState['format'] })}
+              onQualityChange={(q) => updateState({ quality: q })}
+              onDownload={handleDownload}
+              onCopy={handleCopyImage}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── ResizePanel ────────────────────────────────────────────────────
+
+function ResizePanel({
+  resizeW,
+  resizeH,
+  lockAspect,
+  originalW,
+  originalH,
+  onResizeW,
+  onResizeH,
+  onLockToggle,
+  onReset,
+  onPreset,
+}: {
+  resizeW: number | null
+  resizeH: number | null
+  lockAspect: boolean
+  originalW: number
+  originalH: number
+  onResizeW: (w: number) => void
+  onResizeH: (h: number) => void
+  onLockToggle: () => void
+  onReset: () => void
+  onPreset: (w: number, h: number) => void
+}) {
+  const inputClass =
+    'w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 font-mono text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]'
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Dimensions
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex flex-1 flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">Width (px)</label>
+            <input
+              type="number"
+              min={1}
+              value={resizeW ?? ''}
+              onChange={(e) => onResizeW(Number(e.target.value))}
+              placeholder="Width"
+              className={inputClass}
+            />
+          </div>
+
+          <button
+            onClick={onLockToggle}
+            title={lockAspect ? 'Unlock aspect ratio' : 'Lock aspect ratio'}
+            className="mt-4 shrink-0 rounded p-1 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-accent)]"
+          >
+            {lockAspect ? <LockSimpleIcon size={14} /> : <LockSimpleOpenIcon size={14} />}
+          </button>
+
+          <div className="flex flex-1 flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">Height (px)</label>
+            <input
+              type="number"
+              min={1}
+              value={resizeH ?? ''}
+              onChange={(e) => onResizeH(Number(e.target.value))}
+              placeholder="Height"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <button
+          onClick={onReset}
+          className="mt-2 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
+        >
+          Reset to original ({originalW} × {originalH})
+        </button>
+      </div>
+
+      <div>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Aspect Ratio Presets
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {PRESET_SIZES.map(({ label, w, h }) => (
+            <button
+              key={label}
+              onClick={() => onPreset(w, h)}
+              className="rounded border border-[var(--color-border)] px-2 py-0.5 text-[10px] text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {resizeW && resizeH && (resizeW !== originalW || resizeH !== originalH) && (
+        <div className="rounded bg-[var(--color-accent)]/10 px-3 py-2 text-[10px] text-[var(--color-accent)]">
+          Output: {resizeW} × {resizeH}px (
+          {((resizeW * resizeH) / (originalW * originalH)).toFixed(2)}× pixels)
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── CropPanel ──────────────────────────────────────────────────────
+
+function CropPanel({
+  enabled,
+  x,
+  y,
+  w,
+  h,
+  maxW,
+  maxH,
+  onToggle,
+  onChange,
+  onReset,
+}: {
+  enabled: boolean
+  x: number
+  y: number
+  w: number
+  h: number
+  maxW: number
+  maxH: number
+  onToggle: () => void
+  onChange: (x: number, y: number, w: number, h: number) => void
+  onReset: () => void
+}) {
+  const inputClass =
+    'w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 font-mono text-xs text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] disabled:opacity-40'
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Enable toggle */}
+      <label className="flex cursor-pointer items-center gap-2">
+        <div
+          onClick={onToggle}
+          className={`relative h-5 w-9 rounded-full transition-colors ${enabled ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-border)]'}`}
+        >
+          <div
+            className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-4' : 'translate-x-0.5'}`}
+          />
+        </div>
+        <span className="text-xs text-[var(--color-text)]">Enable crop</span>
+      </label>
+
+      {/* Crop coordinates */}
+      <div className={enabled ? '' : 'pointer-events-none opacity-40'}>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Offset
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">X (px)</label>
+            <input
+              type="number"
+              min={0}
+              max={maxW - 1}
+              value={x}
+              disabled={!enabled}
+              onChange={(e) => onChange(Number(e.target.value), y, w, h)}
+              className={inputClass}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">Y (px)</label>
+            <input
+              type="number"
+              min={0}
+              max={maxH - 1}
+              value={y}
+              disabled={!enabled}
+              onChange={(e) => onChange(x, Number(e.target.value), w, h)}
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div className="mb-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Size
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">Width (px)</label>
+            <input
+              type="number"
+              min={1}
+              max={maxW}
+              value={w}
+              disabled={!enabled}
+              onChange={(e) => onChange(x, y, Number(e.target.value), h)}
+              className={inputClass}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[10px] text-[var(--color-text-muted)]">Height (px)</label>
+            <input
+              type="number"
+              min={1}
+              max={maxH}
+              value={h}
+              disabled={!enabled}
+              onChange={(e) => onChange(x, y, w, Number(e.target.value))}
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <button
+          onClick={onReset}
+          disabled={!enabled}
+          className="mt-3 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-accent)] disabled:pointer-events-none"
+        >
+          Reset to full image
+        </button>
+      </div>
+
+      {enabled && (
+        <div className="rounded bg-[var(--color-accent)]/10 px-3 py-2 text-[10px] text-[var(--color-accent)]">
+          Crop: {w} × {h}px at ({x}, {y})
+        </div>
+      )}
+
+      <p className="text-[10px] text-[var(--color-text-muted)]">
+        Drag the crop box or its corners in the preview to adjust visually.
+      </p>
+    </div>
+  )
+}
+
+// ── ExportPanel ────────────────────────────────────────────────────
+
+function ExportPanel({
+  format,
+  quality,
+  outputW,
+  outputH,
+  originalBytes,
+  estimatedBytes,
+  onFormatChange,
+  onQualityChange,
+  onDownload,
+  onCopy,
+}: {
+  format: string
+  quality: number
+  outputW: number
+  outputH: number
+  originalBytes: number
+  estimatedBytes: number
+  onFormatChange: (f: string) => void
+  onQualityChange: (q: number) => void
+  onDownload: () => void
+  onCopy: () => void
+}) {
+  const isLossy = format === 'jpeg' || format === 'webp'
+  const compressionRatio =
+    originalBytes > 0 && estimatedBytes > 0
+      ? ((1 - estimatedBytes / originalBytes) * 100).toFixed(0)
+      : null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Format
+        </div>
+        <TabBar tabs={FORMAT_TABS} activeTab={format} onTabChange={onFormatChange} />
+        <div className="mt-1.5 text-[10px] text-[var(--color-text-muted)]">
+          {format === 'png' && 'Lossless · Supports transparency'}
+          {format === 'jpeg' && 'Lossy · Best for photos · No transparency'}
+          {format === 'webp' && 'Lossy/lossless · Modern · Smallest size'}
+        </div>
+      </div>
+
+      {isLossy && (
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+              Quality
+            </div>
+            <span className="font-mono text-xs text-[var(--color-text)]">{quality}%</span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={100}
+            value={quality}
+            onChange={(e) => onQualityChange(Number(e.target.value))}
+            className="w-full accent-[var(--color-accent)]"
+          />
+          <div className="mt-1 flex justify-between text-[9px] text-[var(--color-text-muted)]">
+            <span>Smaller</span>
+            <span>Higher quality</span>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          Output Info
+        </div>
+        <div className="space-y-1 text-xs text-[var(--color-text-muted)]">
+          <div>
+            Dimensions:{' '}
+            <span className="font-mono text-[var(--color-text)]">
+              {outputW} × {outputH}px
+            </span>
+          </div>
+          <div>
+            Est. size:{' '}
+            <span className="font-mono text-[var(--color-text)]">
+              {formatBytes(estimatedBytes)}
+            </span>
+          </div>
+          {originalBytes > 0 && compressionRatio !== null && Number(compressionRatio) > 0 && (
+            <div>
+              Savings:{' '}
+              <span className="font-mono text-[var(--color-success)]">{compressionRatio}%</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Button variant="primary" size="sm" onClick={onDownload}>
+          <DownloadSimpleIcon size={13} />
+          Download {format.toUpperCase()}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={onCopy}>
+          <CopyIcon size={13} />
+          Copy as PNG
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a new **Image Tool** to the Convert group
- Pure Web APIs only (Canvas 2D) — zero new npm dependencies
- 11 tests across 49 files; all passing; tsc clean

## Features

| Tab | What it does |
|-----|-------------|
| **Resize** | Width/height inputs with aspect-ratio lock, 4 ratio presets (1:1, 16:9, 4:3, 3:2), reset to original |
| **Crop** | Interactive crop box with 4 corner drag handles + rule-of-thirds grid overlay + numeric inputs for precision |
| **Export** | Format (PNG / JPEG / WebP), quality slider for lossy formats, estimated file size & savings, Download + Copy as PNG |

Additional UX details:
- Drag-and-drop or file picker to open (JPEG, PNG, WebP, GIF, BMP, SVG)
- Checkerboard background reveals transparency
- Crop and resize are non-destructive — applied to the original on every change
- File name, original dimensions, and file size shown in toolbar

## Implementation notes

- Canvas always renders to a hidden output element so export works on any tab
- ResizeObserver tracks preview container for accurate crop-handle positioning (jsdom guard included)
- `displayMetrics` cleared on new image load to prevent one stale crop-overlay render
- Clamp ordering fixed: `w`/`h` clamped before `x`/`y` (so position clamp uses bounded dimensions)
- NW/SW handles lower-bounded at 0 to prevent negative widths when dragging past image edge
- `onMouseLeave` not wired to crop-drag cancel — drags resume if cursor briefly exits container

## Test plan

- [ ] Open JPEG/PNG/WebP by file picker and drag-drop
- [ ] Resize with aspect lock on/off; verify ratio presets apply correctly
- [ ] Crop: drag body, drag all 4 corner handles, verify clamp at image edges
- [ ] Crop + Resize together: confirm pipeline is crop-then-resize
- [ ] Export: Download PNG/JPEG/WebP; verify quality slider affects JPEG/WebP file size
- [ ] Copy as PNG: paste into any app, should render correctly
- [ ] Reset All: returns to original dimensions and disables crop

🤖 Generated with [Claude Code](https://claude.com/claude-code)