### PR TITLE
fix(cockpit): remove double border below markdown editor tabs

### DIFF
--- a/apps/cockpit/src/components/shared/TabBar.tsx
+++ b/apps/cockpit/src/components/shared/TabBar.tsx
@@ -7,14 +7,16 @@ type TabBarProps = {
   tabs: Tab[]
   activeTab: string
   onTabChange: (tabId: string) => void
+  /** Pass true when the parent container already provides the bottom border. */
+  noBorder?: boolean
 }
 
-export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps) {
+export function TabBar({ tabs, activeTab, onTabChange, noBorder }: TabBarProps) {
   // Tab switching via Cmd+1/2/3 is handled globally in useGlobalShortcuts
   // via the 'switch-tab' tool action — no duplicate registration here.
 
   return (
-    <div className="flex border-b border-[var(--color-border)]">
+    <div className={`flex ${noBorder ? '' : 'border-b border-[var(--color-border)]'}`}>
       {tabs.map((tab) => (
         <button
           key={tab.id}

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -234,8 +234,22 @@ const FORMATTING_ACTIONS = [
     placeholder: '',
     line: true,
   },
-  { label: '🔗', title: 'Link', prefix: '[', suffix: '](url)', placeholder: 'link text', modal: 'link' as const },
-  { label: '📷', title: 'Image', prefix: '![', suffix: '](url)', placeholder: 'alt text', modal: 'image' as const },
+  {
+    label: '🔗',
+    title: 'Link',
+    prefix: '[',
+    suffix: '](url)',
+    placeholder: 'link text',
+    modal: 'link' as const,
+  },
+  {
+    label: '📷',
+    title: 'Image',
+    prefix: '![',
+    suffix: '](url)',
+    placeholder: 'alt text',
+    modal: 'image' as const,
+  },
   { label: '•', title: 'Bullet List', prefix: '- ', suffix: '', placeholder: 'item', line: true },
   {
     label: '1.',
@@ -366,7 +380,10 @@ export default function MarkdownEditor() {
         const result = await processor.process(state.content)
         setHtml(String(result))
       } catch (e) {
-        const msg = (e as Error).message.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        const msg = (e as Error).message
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
         setHtml(`<p style="color: var(--color-error)">Render error: ${msg}</p>`)
       }
     }, 300)
@@ -568,6 +585,7 @@ img{max-width:100%}</style>
           tabs={MODES}
           activeTab={state.mode}
           onTabChange={(id) => updateState({ mode: id })}
+          noBorder
         />
         <div className="ml-auto flex items-center gap-3 py-2">
           {stats && (


### PR DESCRIPTION
## Problem

The Edit / Split / Preview tab bar in the Markdown editor had a visible gap/double-line below it. `TabBar` renders its own `border-b`, and the markdown editor's header wrapper `<div>` also had `border-b` — two 1 px borders stacked, with the tab bar's border sitting slightly above the container's border due to `items-center` alignment.

YAML tools don't have this issue because they mount `<TabBar>` directly as a top-level child with no wrapper.

## Fix

Added an optional `noBorder` prop to `TabBar` (defaults to `false` — no breaking change). When `noBorder` is passed, `TabBar` omits its own `border-b` and defers to the parent container.

`MarkdownEditor` passes `noBorder` to `TabBar` so the outer header `<div>` (which also holds the stats/sync controls) remains the sole source of the full-width separator.

All other `TabBar` consumers (YAML, JSON tools, etc.) are unaffected.

## Test plan

- [ ] Markdown editor: Edit / Split / Preview tabs show a single clean border, no gap
- [ ] YAML tools tabs unchanged (single border, no regression)
- [ ] `bunx vitest run` → 400/400 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)