### PR TITLE
feat(cockpit): mermaid editor UX improvements — modes, templates, export, hints

### DIFF
--- a/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent, render } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import MermaidEditor from '../mermaid-editor/MermaidEditor'
 
@@ -9,21 +9,77 @@ describe('MermaidEditor', () => {
     expect(screen.getByTestId('monaco-editor')).toBeInTheDocument()
   })
 
-  it('renders template buttons', () => {
+  it('renders mode tabs: Edit, Split, Preview', () => {
     renderTool(MermaidEditor)
-    expect(screen.getByText('flowchart')).toBeInTheDocument()
-    expect(screen.getByText('sequence')).toBeInTheDocument()
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText('Split')).toBeInTheDocument()
+    expect(screen.getByText('Preview')).toBeInTheDocument()
   })
 
-  it('renders copy buttons', () => {
+  it('renders zoom badge showing 100%', () => {
     renderTool(MermaidEditor)
+    expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
+  it('always shows ↺ reset button in zoom badge', () => {
+    renderTool(MermaidEditor)
+    expect(screen.getByRole('button', { name: 'Reset view' })).toBeInTheDocument()
+  })
+
+  it('shows persistent interaction hint', () => {
+    renderTool(MermaidEditor)
+    expect(screen.getByText('Scroll · Drag · Double-click to reset')).toBeInTheDocument()
+  })
+})
+
+describe('MermaidEditor — Templates dropdown', () => {
+  it('renders Templates button', () => {
+    renderTool(MermaidEditor)
+    expect(screen.getByText('Templates')).toBeInTheDocument()
+  })
+
+  it('opens dropdown on click and shows all template names', () => {
+    renderTool(MermaidEditor)
+    fireEvent.click(screen.getByText('Templates'))
+    expect(screen.getByText('flowchart')).toBeInTheDocument()
+    expect(screen.getByText('sequence')).toBeInTheDocument()
+    expect(screen.getByText('er')).toBeInTheDocument()
+    expect(screen.getByText('gantt')).toBeInTheDocument()
+  })
+
+  it('closes dropdown on outside click', () => {
+    render(
+      <div>
+        <button data-testid="outside">outside</button>
+        <MermaidEditor />
+      </div>
+    )
+    fireEvent.click(screen.getByText('Templates'))
+    expect(screen.getByText('flowchart')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByText('flowchart')).toBeNull()
+  })
+})
+
+describe('MermaidEditor — Export dropdown', () => {
+  it('renders Export button', () => {
+    renderTool(MermaidEditor)
+    expect(screen.getByText('Export')).toBeInTheDocument()
+  })
+
+  it('opens dropdown on click and shows all export actions', () => {
+    renderTool(MermaidEditor)
+    fireEvent.click(screen.getByText('Export'))
     expect(screen.getByText('Copy SVG')).toBeInTheDocument()
-    expect(screen.getByText('Copy PNG')).toBeInTheDocument()
+    expect(screen.getByText('Download SVG')).toBeInTheDocument()
+    expect(screen.getByText('Copy PNG (2×)')).toBeInTheDocument()
+    expect(screen.getByText('Download PNG (2×)')).toBeInTheDocument()
     expect(screen.getByText('Copy Source')).toBeInTheDocument()
   })
 
-  it('renders export scale selector with all options', () => {
+  it('shows PNG resolution picker with all scales in the dropdown', () => {
     renderTool(MermaidEditor)
+    fireEvent.click(screen.getByText('Export'))
     expect(screen.getByTitle('Export PNG at 1× resolution')).toBeInTheDocument()
     expect(screen.getByTitle('Export PNG at 2× resolution')).toBeInTheDocument()
     expect(screen.getByTitle('Export PNG at 3× resolution')).toBeInTheDocument()
@@ -32,12 +88,30 @@ describe('MermaidEditor', () => {
 
   it('defaults to 2× export scale', () => {
     renderTool(MermaidEditor)
+    fireEvent.click(screen.getByText('Export'))
     const btn2x = screen.getByTitle('Export PNG at 2× resolution')
     expect(btn2x.className).toContain('text-[var(--color-accent)]')
   })
 
-  it('renders zoom badge showing 100%', () => {
+  it('all diagram-dependent actions are disabled when there is no diagram', () => {
     renderTool(MermaidEditor)
-    expect(screen.getByText('100%')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Export'))
+    expect(screen.getByText('Copy SVG')).toBeDisabled()
+    expect(screen.getByText('Download SVG')).toBeDisabled()
+    expect(screen.getByText('Copy PNG (2×)')).toBeDisabled()
+    expect(screen.getByText('Download PNG (2×)')).toBeDisabled()
+  })
+
+  it('closes dropdown on outside click', () => {
+    render(
+      <div>
+        <button data-testid="outside">outside</button>
+        <MermaidEditor />
+      </div>
+    )
+    fireEvent.click(screen.getByText('Export'))
+    expect(screen.getByText('Copy SVG')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByText('Copy SVG')).toBeNull()
   })
 })

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -2,17 +2,24 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
-import { CopyButton } from '@/components/shared/CopyButton'
+import { TabBar } from '@/components/shared/TabBar'
 import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
-import { Button } from '@/components/shared/Button'
+import { CaretDownIcon } from '@phosphor-icons/react'
 
 type MermaidEditorState = {
   content: string
-  exportScale?: number
+  exportScale: number
+  mode: 'edit' | 'split' | 'preview'
 }
 
 type Transform = { x: number; y: number; scale: number }
+
+const MODES = [
+  { id: 'edit', label: 'Edit' },
+  { id: 'split', label: 'Split' },
+  { id: 'preview', label: 'Preview' },
+]
 
 const TEMPLATES: Record<string, string> = {
   flowchart: `flowchart TD
@@ -83,13 +90,24 @@ export default function MermaidEditor() {
   const [state, updateState] = useToolState<MermaidEditorState>('mermaid-editor', {
     content: TEMPLATES['flowchart'] ?? '',
     exportScale: 2,
+    mode: 'split',
   })
 
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [svgHtml, setSvgHtml] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const previewRef = useRef<HTMLDivElement>(null)
+  const [isRendering, setIsRendering] = useState(false)
+  const [showTemplates, setShowTemplates] = useState(false)
+  const [showExport, setShowExport] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wheelCleanupRef = useRef<(() => void) | null>(null)
+  const templatesRef = useRef<HTMLDivElement>(null)
+  const exportRef = useRef<HTMLDivElement>(null)
+
+  const mode = state.mode ?? 'split'
+  const showEditor = mode === 'edit' || mode === 'split'
+  const showPreview = mode === 'preview' || mode === 'split'
+  const exportScale = state.exportScale ?? 2
 
   // ─── Pan & Zoom (local UI state, not persisted) ───────────────────
 
@@ -105,28 +123,36 @@ export default function MermaidEditor() {
 
   const isViewDefault = transform.scale === 1 && transform.x === 0 && transform.y === 0
 
-  // Non-passive wheel listener so we can call preventDefault (React 19 makes wheel passive by default)
-  useEffect(() => {
-    const el = previewRef.current
-    if (!el) return
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault()
-      const rect = el.getBoundingClientRect()
-      const cursorX = e.clientX - rect.left
-      const cursorY = e.clientY - rect.top
-      const { x, y, scale } = transformRef.current
-      const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
-      const newScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale * factor))
-      const ratio = newScale / scale
-      setTransform({
-        x: cursorX + (x - cursorX) * ratio,
-        y: cursorY + (y - cursorY) * ratio,
-        scale: newScale,
-      })
-    }
-    el.addEventListener('wheel', onWheel, { passive: false })
-    return () => el.removeEventListener('wheel', onWheel)
-  }, [setTransform])
+  // Callback ref — attaches/detaches the non-passive wheel listener whenever the
+  // preview pane mounts or unmounts (e.g. on mode switch). A plain useRef + useEffect
+  // fails here because the effect fires before the conditional branch is in the DOM.
+  const previewRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (wheelCleanupRef.current) {
+        wheelCleanupRef.current()
+        wheelCleanupRef.current = null
+      }
+      if (!el) return
+      const onWheel = (e: WheelEvent) => {
+        e.preventDefault()
+        const rect = el.getBoundingClientRect()
+        const cursorX = e.clientX - rect.left
+        const cursorY = e.clientY - rect.top
+        const { x, y, scale } = transformRef.current
+        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
+        const newScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale * factor))
+        const ratio = newScale / scale
+        setTransform({
+          x: cursorX + (x - cursorX) * ratio,
+          y: cursorY + (y - cursorY) * ratio,
+          scale: newScale,
+        })
+      }
+      el.addEventListener('wheel', onWheel, { passive: false })
+      wheelCleanupRef.current = () => el.removeEventListener('wheel', onWheel)
+    },
+    [setTransform]
+  )
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.button !== 0) return
@@ -160,16 +186,42 @@ export default function MermaidEditor() {
     setTransform(DEFAULT_TRANSFORM)
   }, [setTransform])
 
+  // ─── Outside-click dismiss for dropdowns ─────────────────────────
+
+  useEffect(() => {
+    if (!showTemplates) return
+    const handler = (e: MouseEvent) => {
+      if (templatesRef.current && !templatesRef.current.contains(e.target as Node)) {
+        setShowTemplates(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [showTemplates])
+
+  useEffect(() => {
+    if (!showExport) return
+    const handler = (e: MouseEvent) => {
+      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+        setShowExport(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [showExport])
+
   // ─── Mermaid rendering (debounced 500ms) ─────────────────────────
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!state.content.trim()) {
+      setSvgHtml('')
+      setError(null)
+      setIsRendering(false)
+      return
+    }
+    setIsRendering(true)
     debounceRef.current = setTimeout(async () => {
-      if (!state.content.trim()) {
-        setSvgHtml('')
-        setError(null)
-        return
-      }
       try {
         const mermaid = await getMermaid()
         const { svg } = await mermaid.render('mermaid-preview', state.content)
@@ -178,6 +230,8 @@ export default function MermaidEditor() {
       } catch (e) {
         setError((e as Error).message)
         setSvgHtml('')
+      } finally {
+        setIsRendering(false)
       }
     }, 500)
 
@@ -188,7 +242,7 @@ export default function MermaidEditor() {
 
   // ─── Export handlers ─────────────────────────────────────────────
 
-  const handleExportSvg = useCallback(async () => {
+  const handleCopySvg = useCallback(async () => {
     if (!svgHtml) return
     try {
       await navigator.clipboard.writeText(svgHtml)
@@ -196,81 +250,200 @@ export default function MermaidEditor() {
     } catch {
       setLastAction('Clipboard write failed', 'error')
     }
+    setShowExport(false)
   }, [svgHtml, setLastAction])
 
-  const handleExportPng = useCallback(async () => {
-    if (!svgHtml || !previewRef.current) return
-    const scale = state.exportScale ?? 2
-    const svgBlob = new Blob([svgHtml], { type: 'image/svg+xml' })
-    const url = URL.createObjectURL(svgBlob)
-    const img = new Image()
-    img.onerror = () => URL.revokeObjectURL(url)
-    img.onload = () => {
-      URL.revokeObjectURL(url)
-      const canvas = document.createElement('canvas')
-      canvas.width = img.width * scale
-      canvas.height = img.height * scale
-      const ctx = canvas.getContext('2d')
-      if (!ctx) return
-      ctx.scale(scale, scale)
-      ctx.drawImage(img, 0, 0)
-      canvas.toBlob(async (blob) => {
-        if (!blob) return
-        try {
-          await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
-          setLastAction(`PNG (${scale}×) copied to clipboard`, 'success')
-        } catch {
-          setLastAction('Clipboard write failed', 'error')
-        }
-      })
-    }
-    img.src = url
-  }, [svgHtml, setLastAction, state.exportScale])
+  const handleDownloadSvg = useCallback(() => {
+    if (!svgHtml) return
+    const blob = new Blob([svgHtml], { type: 'image/svg+xml' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'diagram.svg'
+    a.click()
+    URL.revokeObjectURL(url)
+    setLastAction('SVG downloaded', 'success')
+    setShowExport(false)
+  }, [svgHtml, setLastAction])
 
-  const exportScale = state.exportScale ?? 2
+  const renderPngBlob = useCallback(
+    (scale: number): Promise<Blob> =>
+      new Promise((resolve, reject) => {
+        if (!svgHtml) return reject(new Error('No SVG'))
+        const blob = new Blob([svgHtml], { type: 'image/svg+xml' })
+        const url = URL.createObjectURL(blob)
+        const img = new Image()
+        img.onerror = () => {
+          URL.revokeObjectURL(url)
+          reject(new Error('Image load failed'))
+        }
+        img.onload = () => {
+          URL.revokeObjectURL(url)
+          const canvas = document.createElement('canvas')
+          canvas.width = img.width * scale
+          canvas.height = img.height * scale
+          const ctx = canvas.getContext('2d')
+          if (!ctx) return reject(new Error('No canvas context'))
+          ctx.scale(scale, scale)
+          ctx.drawImage(img, 0, 0)
+          canvas.toBlob((b) => {
+            if (b) resolve(b)
+            else reject(new Error('toBlob failed'))
+          })
+        }
+        img.src = url
+      }),
+    [svgHtml]
+  )
+
+  const handleCopyPng = useCallback(async () => {
+    try {
+      const blob = await renderPngBlob(exportScale)
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+      setLastAction(`PNG (${exportScale}×) copied to clipboard`, 'success')
+    } catch {
+      setLastAction('Clipboard write failed', 'error')
+    }
+    setShowExport(false)
+  }, [renderPngBlob, exportScale, setLastAction])
+
+  const handleDownloadPng = useCallback(async () => {
+    try {
+      const blob = await renderPngBlob(exportScale)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `diagram-${exportScale}x.png`
+      a.click()
+      URL.revokeObjectURL(url)
+      setLastAction(`PNG (${exportScale}×) downloaded`, 'success')
+    } catch {
+      setLastAction('Export failed', 'error')
+    }
+    setShowExport(false)
+  }, [renderPngBlob, exportScale, setLastAction])
+
+  const handleCopySource = useCallback(() => {
+    navigator.clipboard
+      .writeText(state.content)
+      .then(() => setLastAction('Source copied to clipboard', 'success'))
+      .catch(() => setLastAction('Clipboard write failed', 'error'))
+    setShowExport(false)
+  }, [state.content, setLastAction])
 
   return (
     <div className="flex h-full flex-col">
-      {/* ─── Toolbar ────────────────────────────────────────────────── */}
-      <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
-        <span className="font-mono text-xs text-[var(--color-text-muted)]">Templates:</span>
-        {Object.keys(TEMPLATES).map((name) => (
-          <button
-            key={name}
-            onClick={() => updateState({ content: TEMPLATES[name] ?? '' })}
-            className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
-          >
-            {name}
-          </button>
-        ))}
-        <div className="mx-2 h-4 w-px bg-[var(--color-border)]" />
-        <Button variant="ghost" size="sm" onClick={handleExportSvg} disabled={!svgHtml}>
-          Copy SVG
-        </Button>
-        {/* PNG scale selector + copy button */}
-        <div className="flex items-center gap-1.5">
-          <div className="flex items-center rounded border border-[var(--color-border)]">
-            {EXPORT_SCALES.map((s) => (
-              <button
-                key={s}
-                onClick={() => updateState({ exportScale: s })}
-                title={`Export PNG at ${s}× resolution`}
-                className={`px-1.5 py-0.5 text-[10px] transition-colors first:rounded-l last:rounded-r ${
-                  exportScale === s
-                    ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
-                    : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
-                }`}
-              >
-                {s}×
-              </button>
-            ))}
+      {/* ─── Header ─────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-2">
+        <TabBar
+          tabs={MODES}
+          activeTab={mode}
+          onTabChange={(id) => updateState({ mode: id as MermaidEditorState['mode'] })}
+          noBorder
+        />
+
+        <div className="ml-auto flex items-center gap-3 py-2">
+          {/* Templates dropdown */}
+          <div ref={templatesRef} className="relative">
+            <button
+              onClick={() => setShowTemplates(!showTemplates)}
+              className="flex items-center gap-0.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            >
+              Templates
+              <CaretDownIcon size={10} />
+            </button>
+            {showTemplates && (
+              <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
+                {Object.keys(TEMPLATES).map((name) => (
+                  <button
+                    key={name}
+                    onClick={() => {
+                      updateState({ content: TEMPLATES[name] ?? '' })
+                      setShowTemplates(false)
+                    }}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-          <Button variant="ghost" size="sm" onClick={handleExportPng} disabled={!svgHtml}>
-            Copy PNG
-          </Button>
-        </div>
-        <div className="ml-auto">
-          <CopyButton text={state.content} label="Copy Source" />
+
+          {/* Export dropdown */}
+          <div ref={exportRef} className="relative">
+            <button
+              onClick={() => setShowExport(!showExport)}
+              className="flex items-center gap-0.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+            >
+              Export
+              <CaretDownIcon size={10} />
+            </button>
+            {showExport && (
+              <div className="absolute right-0 top-full z-10 mt-1 min-w-[180px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
+                <button
+                  onClick={handleCopySvg}
+                  disabled={!svgHtml}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  Copy SVG
+                </button>
+                <button
+                  onClick={handleDownloadSvg}
+                  disabled={!svgHtml}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  Download SVG
+                </button>
+
+                <div className="my-1 border-t border-[var(--color-border)]" />
+
+                {/* PNG resolution picker */}
+                <div className="flex items-center gap-2 px-3 py-1">
+                  <span className="text-[10px] text-[var(--color-text-muted)]">PNG res:</span>
+                  <div className="flex items-center rounded border border-[var(--color-border)]">
+                    {EXPORT_SCALES.map((s) => (
+                      <button
+                        key={s}
+                        onClick={() => updateState({ exportScale: s })}
+                        title={`Export PNG at ${s}× resolution`}
+                        className={`px-1.5 py-0.5 text-[10px] transition-colors first:rounded-l last:rounded-r ${
+                          exportScale === s
+                            ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
+                            : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
+                        }`}
+                      >
+                        {s}×
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <button
+                  onClick={handleCopyPng}
+                  disabled={!svgHtml}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  Copy PNG ({exportScale}×)
+                </button>
+                <button
+                  onClick={handleDownloadPng}
+                  disabled={!svgHtml}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                >
+                  Download PNG ({exportScale}×)
+                </button>
+
+                <div className="my-1 border-t border-[var(--color-border)]" />
+
+                <button
+                  onClick={handleCopySource}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                >
+                  Copy Source
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -287,74 +460,93 @@ export default function MermaidEditor() {
       {/* ─── Body ───────────────────────────────────────────────────── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Editor */}
-        <div className="w-1/2 border-r border-[var(--color-border)]">
-          <Editor
-            theme={monacoTheme}
-            value={state.content}
-            onChange={(v) => updateState({ content: v ?? '' })}
-            options={monacoOptions}
-          />
-        </div>
+        {showEditor && (
+          <div
+            className={`${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'} h-full`}
+          >
+            <Editor
+              theme={monacoTheme}
+              value={state.content}
+              onChange={(v) => updateState({ content: v ?? '' })}
+              options={monacoOptions}
+            />
+          </div>
+        )}
 
         {/* Preview — pan & zoom canvas */}
-        <div
-          ref={previewRef}
-          className="relative w-1/2 cursor-grab overflow-hidden bg-[var(--color-surface)] select-none active:cursor-grabbing"
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseLeave}
-          onDoubleClick={resetView}
-        >
-          {/* Transformed layer */}
+        {showPreview && (
           <div
-            style={{
-              transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
-              transformOrigin: '0 0',
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: '1rem',
-              pointerEvents: 'none',
-            }}
+            ref={previewRef}
+            className={`relative ${showEditor ? 'w-1/2' : 'w-full'} cursor-grab overflow-hidden bg-[var(--color-surface)] select-none active:cursor-grabbing`}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseLeave}
+            onDoubleClick={resetView}
           >
-            {svgHtml ? (
-              <div dangerouslySetInnerHTML={{ __html: svgHtml }} />
-            ) : (
-              <div className="select-none text-center text-sm text-[var(--color-text-muted)]">
-                <div>{error ? 'Fix syntax errors to see preview' : 'Enter mermaid syntax...'}</div>
-                {!error && (
-                  <div className="mt-1 text-[10px] opacity-40">
-                    Scroll to zoom · Drag to pan · Double-click to reset
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+            {/* Transformed layer */}
+            <div
+              style={{
+                transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+                transformOrigin: '0 0',
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '1rem',
+                pointerEvents: 'none',
+              }}
+            >
+              {svgHtml ? (
+                <div dangerouslySetInnerHTML={{ __html: svgHtml }} />
+              ) : (
+                <div className="select-none text-center text-sm text-[var(--color-text-muted)]">
+                  {isRendering ? (
+                    <div className="text-xs opacity-50">Rendering…</div>
+                  ) : (
+                    <div>
+                      {error ? 'Fix syntax errors to see preview' : 'Enter mermaid syntax…'}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
 
-          {/* Zoom badge (bottom-right) */}
-          <div className="pointer-events-none absolute bottom-2 right-2 flex items-center gap-1 rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-muted)]">
-            <span>{Math.round(transform.scale * 100)}%</span>
-            {!isViewDefault && (
+            {/* Persistent interaction hint — bottom-left, always visible */}
+            <div className="pointer-events-none absolute bottom-2 left-2 select-none text-[10px] text-[var(--color-text-muted)] opacity-30">
+              Scroll · Drag · Double-click to reset
+            </div>
+
+            {/* Zoom badge — bottom-right; ↺ always shown, dimmed at default */}
+            <div className="pointer-events-none absolute bottom-2 right-2 flex items-center gap-1 rounded bg-[var(--color-surface-hover)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-muted)]">
+              {isRendering && (
+                <span className="mr-0.5 opacity-60" aria-label="Rendering">
+                  ⟳
+                </span>
+              )}
+              <span>{Math.round(transform.scale * 100)}%</span>
               <button
-                className="pointer-events-auto ml-0.5 hover:text-[var(--color-text)]"
-                title="Reset view"
+                className={`pointer-events-auto ml-0.5 transition-colors ${
+                  isViewDefault ? 'cursor-default opacity-30' : 'hover:text-[var(--color-text)]'
+                }`}
+                title="Reset view (or double-click)"
                 onMouseDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
+                  if (isViewDefault) return
                   e.stopPropagation()
                   resetView()
                 }}
+                aria-label="Reset view"
               >
                 ↺
               </button>
-            )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Five UX improvements to the Mermaid editor, mirroring the pattern from the recent Markdown editor improvements.

### 1. Edit / Split / Preview mode tabs
The layout was hardcoded 50/50 with no escape. Added mode tabs (TabBar, `noBorder`) consistent with the Markdown editor. Mode is persisted in tool state.

### 2. Templates → dropdown
Seven inline template name buttons eating ~40% of the toolbar replaced with a `Templates ▾` dropdown + outside-click dismiss. Same pattern as Markdown editor and WorkspaceTabStrip context menu.

### 3. Export dropdown — adds Download SVG/PNG
Consolidated Copy SVG + scale picker + Copy PNG + Copy Source into a single `Export ▾` dropdown. Adds **Download SVG** and **Download PNG** (previously copy-to-clipboard only). PNG blob rendering extracted into a shared `renderPngBlob()` callback used by both Copy and Download paths. All diagram-dependent actions are disabled when no diagram is rendered.

### 4. Loading indicator
`isRendering` state set true when the debounce timer starts, cleared in `finally`. Shows "Rendering…" in the preview empty state and a `⟳` in the zoom badge while processing.

### 5. Reset view always accessible
The `↺` reset button is now always shown in the zoom badge (dimmed + non-interactive at the default view). A persistent `Scroll · Drag · Double-click to reset` hint sits at the bottom-left of the preview pane at `opacity-30` — present at all times, never blocking the diagram.

## Bug fixed (from code review)
**Wheel listener failed on mode switch.** The original `useRef + useEffect[showPreview]` pattern captured `null` from `previewRef.current` because the conditional preview `div` wasn't in the DOM yet when the effect fired. Fixed with the callback ref pattern documented in `CLAUDE.md` under "Callback Ref Pattern (Conditional Branches)".

## Files changed
- `MermaidEditor.tsx` — all 5 improvements + callback ref fix
- `mermaid-editor.test.tsx` — rewrote + added 12 new tests (408/408 passing)

## Test plan
- [ ] Mode tabs switch between editor-only, split, and preview-only
- [ ] Templates dropdown opens/closes; outside click dismisses it
- [ ] Export dropdown shows all 7 actions; Copy/Download SVG/PNG disabled with no diagram
- [ ] PNG resolution picker works inside the dropdown
- [ ] After switching from Edit → Split, scroll-to-zoom works in the preview pane
- [ ] "Rendering…" appears in preview while debounce is active
- [ ] ↺ button always visible in zoom badge; dimmed at 100% / no pan
- [ ] `bunx vitest run` → 408/408 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)