### PR TITLE
docs(cockpit): codify workflow, new patterns, and session learnings

### DIFF
--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -2,6 +2,21 @@
 
 Instructions for AI coding agents (OpenAI Codex, GitHub Copilot, etc.) working in `apps/cockpit`.
 
+## Development Workflow
+
+When given a feature or update request, execute this pipeline end-to-end without pausing for permission at each step:
+
+1. **Evaluate & refine** — read the relevant code before writing any; surface tradeoffs or ambiguities; propose adjustments if the request has edge cases worth flagging
+2. **Plan** — agree on approach before touching code; for anything non-trivial, write out the steps
+3. **Implement** — write the code; do not add features, abstractions, or cleanup beyond what was asked
+4. **Verify** — `npx tsc --noEmit` (zero errors) + `bunx vitest run` (all passing); fix anything broken before moving on
+5. **Code review** — self-review against the rules in this file; catch bugs, anti-patterns, and regressions
+6. **Fix** — address every issue found in review before committing
+7. **Commit & push** — conventional commit message on a feature branch
+8. **Open PR** — description targeted at a human reviewer; user-facing language, not a dev log
+
+Operate autonomously through all 8 steps. Make decisions informed by best practice and the non-negotiable rules below. Only pause if something is genuinely ambiguous about the intent of the request — not for routine implementation choices.
+
 ---
 
 ## What This Project Is

--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -331,6 +331,69 @@ y = Math.max(0, Math.min(y, origH - h))
 Also lower-bound any new `x`/`y` computed from a drag delta before using it to derive
 a new `w`/`h` (e.g., NW/SW handle drag: `nx = Math.max(0, startX + dx)`).
 
+### 21. Fuse.js search highlighting — use composite React keys
+
+When using `includeMatches: true`, define a local interface instead of importing Fuse types:
+
+```typescript
+interface FuseMatchEntry {
+  key?: string
+  indices: ReadonlyArray<[number, number]>
+}
+```
+
+Keep two memos: `fuseResults` (drives both filtered list AND match data) and `matchMap: Map<id, ReadonlyArray<FuseMatchEntry>>`.
+
+**Always use composite keys** on `<mark>` elements — `key={\`${start}-${end}\`}`, not `key={start}`. Fuse can return overlapping index ranges with the same `start` value, causing duplicate key warnings.
+
+### 22. CSS grid collapse animation
+
+```tsx
+<div
+  className={`grid transition-[grid-template-rows] duration-200 ${
+    collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+  }`}
+>
+  <div className="overflow-hidden">{children}</div>
+</div>
+```
+
+No pixel height needed. Outer div transitions row size; inner `overflow-hidden` clips content. Toggle button must have `aria-expanded={!collapsed}`.
+
+### 23. ARIA combobox — wiring and focus management
+
+```tsx
+<input
+  role="combobox"
+  aria-autocomplete="list"
+  aria-expanded={suggestions.length > 0}
+  aria-controls="suggestions-id"
+  aria-activedescendant={index >= 0 ? `suggestion-${suggestions[index]}` : undefined}
+/>
+<div role="listbox" id="suggestions-id">
+  {suggestions.map((s) => (
+    <button key={s} role="option" id={`suggestion-${s}`}
+      onMouseDown={(e) => { e.preventDefault(); void handleSelect(s) }}
+    />
+  ))}
+</div>
+```
+
+`e.preventDefault()` on `onMouseDown` keeps input focus when clicking a suggestion. Always prefix async `onMouseDown` handlers with `void` — omitting it leaves an unhandled promise rejection.
+
+### 24. `void` prefix for async fire-and-forget event handlers
+
+Calling an async function from a synchronous event handler without handling the returned Promise causes an unhandled rejection warning. Use `void`:
+
+```typescript
+// ✅
+onMouseDown={() => { void handleAsyncAction() }}
+onChange={() => { void saveToDb(value) }}
+
+// ❌ Returns a Promise that is silently dropped — triggers lint/runtime warning
+onMouseDown={() => handleAsyncAction()}
+```
+
 ---
 
 ## How to Add a New Tool
@@ -446,7 +509,7 @@ WAL mode is set at connection time in `getDb()` — not in migrations.
 Before opening a PR, verify every item:
 
 - [ ] `npx tsc --noEmit` — zero errors
-- [ ] `bunx vitest run` — 361/361 passing
+- [ ] `bunx vitest run` — all passing (zero failures)
 - [ ] No `Database.load()` outside `src/lib/db.ts`
 - [ ] No hardcoded colors (`#hex`, `rgb()`, Tailwind palette classes like `bg-zinc-900`)
 - [ ] No `React.StrictMode`

--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -19,6 +19,61 @@ Operate autonomously through all 8 steps. Make decisions informed by best practi
 
 ---
 
+## Git Workflow
+
+### Never commit directly to main
+
+All work goes on a feature branch. If commits accidentally land on `main` before a branch is created, rescue them before pushing:
+
+```bash
+git checkout -b feat/my-feature   # branch at current HEAD — captures the commits
+git checkout main
+git reset --hard origin/main      # strip the commits off main
+git push -u origin feat/my-feature
+```
+
+### Branch naming
+
+```
+feat/short-description       # new feature or enhancement
+fix/short-description        # bug fix
+docs/short-description       # documentation only
+chore/short-description      # tooling, deps, config
+refactor/short-description   # no behaviour change
+```
+
+### Commit messages — conventional commits
+
+Format: `type(scope): short description` — imperative mood, no period, under 72 chars. Scope is almost always `cockpit`.
+
+```
+feat(cockpit): add cron expression parser
+fix(cockpit): resolve tag filter losing focus on blur
+docs(cockpit): update AGENTS.md with git workflow
+```
+
+### Commits need HUSKY_PATH
+
+The pre-commit hook calls `bunx`. Bun lives in `/opt/homebrew/bin`, which is not on the minimal shell PATH. Every commit must be prefixed:
+
+```bash
+HUSKY_PATH=/opt/homebrew/bin PATH="/opt/homebrew/bin:$PATH" git commit -m "..."
+```
+
+Omitting this causes `command not found: bunx` and the commit fails.
+
+### PRs
+
+- Title: matches the commit message format, under 70 chars
+- Body: **Summary** bullets in user-facing language + **Test plan** checklist
+- Target: always `main`
+- Push new branches with `-u`: `git push -u origin feat/my-feature`
+- Never force-push to `main`
+
+When asked to "open a PR" or "commit and push", the full sequence is implied — branch (if not already on one) → commit → push → `gh pr create`. Do not ask for confirmation between steps.
+
+---
+
 ## What This Project Is
 
 **devdrivr cockpit** is a local-first, keyboard-driven developer utility desktop app.

--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -128,6 +128,8 @@ PATH="/opt/homebrew/bin:$PATH" bun run clean
 
 ## File Map — Know Before You Touch
 
+The `@/` path alias maps to `src/`. Use it for all imports — never write relative paths like `../../lib/db`.
+
 ```
 src/app/tool-registry.ts          ← SINGLE SOURCE OF TRUTH for all tools
 src/app/tool-groups.tsx           ← sidebar group metadata (Phosphor icons)
@@ -476,6 +478,47 @@ No pixel height needed. Outer div transitions row size; inner `overflow-hidden` 
 
 ### 24. `void` prefix for async fire-and-forget event handlers
 
+### 25. DB migrations — always backfill existing rows
+
+`ALTER TABLE` gives existing rows `NULL` for the new column. Always include an explicit `UPDATE` in the same migration — never rely on `DEFAULT` alone for existing data:
+
+```sql
+-- ✅ Column added AND existing rows backfilled in same migration
+ALTER TABLE snippets ADD COLUMN folder TEXT NOT NULL DEFAULT '';
+UPDATE snippets SET folder = '' WHERE folder IS NULL;
+
+-- ❌ Existing rows are NULL even with DEFAULT — causes runtime errors on existing installs
+ALTER TABLE snippets ADD COLUMN folder TEXT NOT NULL DEFAULT '';
+```
+
+### 26. Tailwind v4 — no config file
+
+This project uses Tailwind CSS 4 (CSS-first). There is **no `tailwind.config.js`** — do not create one. All configuration lives in `src/index.css`. Do not use `@apply` with v3 plugin syntax. Standard arbitrary value syntax still applies: `bg-[var(--color-surface)]`, `grid-rows-[0fr]`.
+
+### 27. Prefer platform APIs over npm packages
+
+Reach for browser/web platform APIs before adding a dependency:
+
+| Task                       | Use this                    | Not this                 |
+| -------------------------- | --------------------------- | ------------------------ |
+| Image resize/crop/compress | Canvas 2D API               | `sharp`, `jimp`          |
+| Hashing                    | `crypto.subtle`             | `crypto-js`              |
+| UTF-8 encode/decode        | `TextEncoder`/`TextDecoder` | `buffer` polyfill        |
+| HTML/XML parsing           | `DOMParser`                 | `cheerio`, `htmlparser2` |
+
+If a browser API handles the task, use it. Adding a package requires a clear reason why the platform API is insufficient.
+
+### 28. Test file location
+
+Tool tests live in `src/tools/__tests__/<tool-id>.test.tsx` — not co-located with the component. Creating `src/tools/my-tool/MyTool.test.tsx` works but breaks the established pattern.
+
+```
+src/tools/__tests__/
+  snippets.test.tsx
+  api-client.test.tsx
+  markdown-editor.test.tsx
+```
+
 Calling an async function from a synchronous event handler without handling the returned Promise causes an unhandled rejection warning. Use `void`:
 
 ```typescript
@@ -586,7 +629,7 @@ if (typeof data === 'object' && data !== null) { ... }
 settings         (key TEXT PRIMARY KEY, value TEXT)            -- JSON values
 tool_state       (tool_id TEXT PRIMARY KEY, state TEXT, updated_at INTEGER)
 notes            (id, title, content, color, pinned, popped_out, window_*, created_at, updated_at, tags)
-snippets         (id, title, content, language, tags TEXT, created_at, updated_at)  -- tags = JSON array
+snippets         (id, title, content, language, tags TEXT, folder TEXT, created_at, updated_at)  -- tags = JSON array; folder added migration 005
 history          (id, tool, sub_tab, input, output, timestamp)
 api_environments (id, name, base_url, headers, created_at, updated_at)  -- API Client — migration 002
 api_collections  (id, name, description, created_at, updated_at)        -- API Client — migration 002
@@ -603,6 +646,7 @@ Before opening a PR, verify every item:
 
 - [ ] `npx tsc --noEmit` — zero errors
 - [ ] `bunx vitest run` — all passing (zero failures)
+- [ ] `bun run lint` — zero errors (warnings tolerated up to threshold)
 - [ ] No `Database.load()` outside `src/lib/db.ts`
 - [ ] No hardcoded colors (`#hex`, `rgb()`, Tailwind palette classes like `bg-zinc-900`)
 - [ ] No `React.StrictMode`

--- a/apps/cockpit/AGENTS.md
+++ b/apps/cockpit/AGENTS.md
@@ -87,19 +87,42 @@ When asked to "open a PR" or "commit and push", the full sequence is implied —
 
 ---
 
-## Commands (always run from `apps/cockpit/`)
+## Commands
+
+**All commands must be run from `apps/cockpit/`** with the PATH prefix shown. Running from the monorepo root will use the wrong config or fail to find binaries entirely.
 
 ```bash
-bun install              # install/restore dependencies
-bun run tauri dev        # start dev server (Vite + Tauri hot-reload)
-bun run clean            # delete node_modules, dist, src-tauri/target
-npx tsc --noEmit         # type-check — MUST pass before submitting
-bunx vitest run          # run Vitest tests — MUST all pass (use bunx, not bun run test)
-bun run tauri build      # production build
+# Typecheck — zero errors required before every commit
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+
+# Tests — bunx ONLY; bun run test cannot resolve the vitest binary
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run        # run once
+PATH="/opt/homebrew/bin:$PATH" bunx vitest            # watch mode
+
+# Lint
+PATH="/opt/homebrew/bin:$PATH" bun run lint
+
+# Dev server (Vite + Tauri hot-reload)
+PATH="/opt/homebrew/bin:$PATH" bun run tauri dev
+
+# Production build
+PATH="/opt/homebrew/bin:$PATH" bun run tauri build
+
+# Install / restore dependencies
+PATH="/opt/homebrew/bin:$PATH" bun install
+
+# Clean build artifacts and node_modules
+PATH="/opt/homebrew/bin:$PATH" bun run clean
 ```
 
-> **Note**: Always run these from `apps/cockpit/`. `bun run test` may fail if the shell
-> cannot resolve the `vitest` binary — use `bunx vitest run` instead.
+### Common mistakes
+
+| Wrong                      | Right                                | Why                                                     |
+| -------------------------- | ------------------------------------ | ------------------------------------------------------- |
+| Run from monorepo root     | Run from `apps/cockpit/`             | Wrong tsconfig, wrong vitest config, wrong node_modules |
+| `bun run test`             | `bunx vitest run`                    | bun can't resolve the vitest binary directly            |
+| `npm run ...` / `yarn ...` | `bun run ...`                        | npm/yarn are not the package manager                    |
+| No PATH prefix             | `PATH="/opt/homebrew/bin:$PATH" ...` | Homebrew tools not on default shell PATH                |
 
 ---
 

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -172,6 +172,34 @@ Capabilities live in `src-tauri/capabilities/default.json` scoped to `"windows":
 - `useRef` for values that shouldn't trigger re-renders.
 - Phosphor icons (`@phosphor-icons/react`) for all iconography — tree-shakeable, 6 weights.
 
+### Path alias
+
+`@/` maps to `src/`. Use it for all imports — never use relative paths like `../../lib/db`:
+
+```typescript
+// ✅
+import { getDb } from '@/lib/db'
+import { useSnippetsStore } from '@/stores/snippets.store'
+
+// ❌ Works but breaks the codebase pattern
+import { getDb } from '../../lib/db'
+```
+
+### Tailwind v4 — no config file
+
+This project uses Tailwind CSS 4, which is CSS-first. There is no `tailwind.config.js` — configuration lives in `src/index.css`. Do not create a config file. Do not use `@apply` with v3 plugin syntax. Arbitrary values use the standard bracket syntax: `bg-[var(--color-surface)]`, `grid-rows-[0fr]`.
+
+### Prefer platform APIs over npm packages
+
+Reach for browser/web platform APIs before adding a dependency. This codebase already uses:
+
+- **Canvas 2D** for image resize, crop, compress, export — no `sharp` or `jimp`
+- **Web Crypto** (`crypto.subtle`) for hashing — no `crypto-js`
+- **`TextEncoder`/`TextDecoder`** for UTF-8 — no `buffer` polyfill
+- **`DOMParser`** for HTML/XML parsing — no `cheerio`
+
+If a browser API exists that handles the task, use it.
+
 ## Key Files
 
 | File                                  | Purpose                                                          |
@@ -194,6 +222,17 @@ Adding a migration requires **two changes** — both must be in the same commit:
 2. Register it in `src-tauri/src/lib.rs` — add a `Migration { version: N, ... }` entry to the `migrations` vec.
 
 The SQL file alone does nothing. `tauri-plugin-sql` only runs migrations that are registered in `lib.rs`. Shipping without step 2 will leave existing installs with missing columns and runtime errors.
+
+### Migration backfill rule
+
+When adding a column via `ALTER TABLE`, existing rows get `NULL` for that column. Always include an explicit `UPDATE` in the same migration to backfill a sensible default — otherwise existing installs silently have corrupt/missing data:
+
+```sql
+ALTER TABLE snippets ADD COLUMN folder TEXT NOT NULL DEFAULT '';
+UPDATE snippets SET folder = '' WHERE folder IS NULL;
+```
+
+Never rely on `DEFAULT` alone for existing rows — always backfill explicitly.
 
 ```rust
 Migration {
@@ -405,7 +444,19 @@ bunx vitest run       # run once (bun run test fails — shell can't resolve vit
 bunx vitest           # watch mode
 ```
 
-Tests live in `src/**/*.test.ts` and cover: platform detection, theming, keybinding logic.
+Tests live in `src/**/__tests__/*.test.tsx` for tool tests and `src/**/*.test.ts` for unit tests.
+
+### Test file location
+
+Tool tests go in `src/tools/__tests__/<tool-id>.test.tsx` — **not** co-located with the component. Putting a test file next to the component (`src/tools/my-tool/MyTool.test.tsx`) works but breaks the established pattern.
+
+```
+src/tools/__tests__/
+  snippets.test.tsx
+  markdown-editor.test.tsx
+  api-client.test.tsx
+  ...
+```
 
 ### Testing Patterns — Common Traps
 

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -22,7 +22,7 @@ Full canonical docs live in [`documentation/`](./documentation/):
 - **Package manager:** Bun only. Never use npm or yarn.
 - **Run commands from:** `apps/cockpit/` unless noted.
 - **Type-check:** `npx tsc --noEmit` — must stay clean.
-- **Tests:** `bunx vitest run` (Vitest, 361 tests / 49 files). Use `bunx`, not `bun run test`.
+- **Tests:** `bunx vitest run` (Vitest, 380+ tests / 50+ files). Use `bunx`, not `bun run test`.
 - **Dev server:** `bun run tauri dev` (starts Vite + Rust binary).
 
 ## Architecture
@@ -226,6 +226,62 @@ canvas.toBlob(
 For export, `canvas.toDataURL` is synchronous. For large images, debounce any
 quality-slider or resize-input that triggers a re-render with a canvas redraw.
 
+### Fuse.js Search Highlighting
+
+Use `includeMatches: true` in Fuse config. Define a local interface to avoid importing Fuse types directly:
+
+```typescript
+interface FuseMatchEntry {
+  key?: string
+  indices: ReadonlyArray<[number, number]>
+}
+```
+
+Keep two memos: `fuseResults` (drives both the filtered list AND match data) and `matchMap: Map<id, ReadonlyArray<FuseMatchEntry>>`. The `highlightMatches(text, matches, key)` helper wraps matched char ranges in `<mark>`.
+
+**Use a composite React key** `key={\`${start}-${end}\`}`— Fuse can return overlapping ranges where two entries share the same`start`value, which causes duplicate key warnings with`key={start}` alone.
+
+### CSS Grid Collapse Animation
+
+```tsx
+<div
+  className={`grid transition-[grid-template-rows] duration-200 ${
+    collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'
+  }`}
+>
+  <div className="overflow-hidden">{children}</div>
+</div>
+```
+
+The outer div transitions between row sizes; the inner `overflow-hidden` div clips the content. No need to know the pixel height. Set `aria-expanded={!collapsed}` on the toggle button.
+
+### ARIA Combobox for Autocomplete Inputs
+
+```tsx
+<input
+  role="combobox"
+  aria-autocomplete="list"
+  aria-expanded={suggestions.length > 0}
+  aria-controls="suggestions-listbox"
+  aria-activedescendant={index >= 0 ? `suggestion-${suggestions[index]}` : undefined}
+/>
+<div role="listbox" id="suggestions-listbox" data-testid="suggestions">
+  {suggestions.map((s, i) => (
+    <button
+      key={s}
+      role="option"
+      id={`suggestion-${s}`}
+      onMouseDown={(e) => {
+        e.preventDefault() // keep input focus
+        void handleSelect(s) // void prefix — async handler in onMouseDown
+      }}
+    />
+  ))}
+</div>
+```
+
+`onMouseDown` + `e.preventDefault()` prevents the input from losing focus when clicking a suggestion. Always prefix async `onMouseDown` handlers with `void` to avoid unhandled promise rejections.
+
 ### ResizeObserver Guard for jsdom
 
 `ResizeObserver` is undefined in jsdom (Vitest). Guard before using it:
@@ -245,3 +301,19 @@ bunx vitest           # watch mode
 ```
 
 Tests live in `src/**/*.test.ts` and cover: platform detection, theming, keybinding logic.
+
+### Testing Patterns — Common Traps
+
+**Text split by `<mark>` elements** — `highlightMatches` renders `<mark>` nodes that split the text across multiple DOM nodes. `getByText(/regex/)` and `getByText('full text')` will fail because testing-library matches single text nodes. Query the parent element and check `.textContent` instead:
+
+```typescript
+const titleEl = document.querySelector('.my-title-class')
+expect(titleEl?.textContent).toBe('fetchUserData')
+```
+
+**Ambiguous `getByText` when same text appears in multiple places** — e.g. a global tag chip and an autocomplete suggestion dropdown both showing "api" causes "Found multiple elements". Scope to the container via `data-testid` and use `toHaveTextContent()`:
+
+```typescript
+const suggestions = screen.getByTestId('tag-suggestions')
+expect(suggestions).toHaveTextContent('api')
+```

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -90,10 +90,45 @@ Full canonical docs live in [`documentation/`](./documentation/):
 ## Essentials
 
 - **Package manager:** Bun only. Never use npm or yarn.
-- **Run commands from:** `apps/cockpit/` unless noted.
-- **Type-check:** `npx tsc --noEmit` — must stay clean.
-- **Tests:** `bunx vitest run` (Vitest, 380+ tests / 50+ files). Use `bunx`, not `bun run test`.
-- **Dev server:** `bun run tauri dev` (starts Vite + Rust binary).
+- **Run commands from:** `apps/cockpit/` — never the monorepo root.
+- **PATH prefix required:** Bun and other Homebrew tools are in `/opt/homebrew/bin`, which is not on the default shell PATH. Every command below needs the prefix.
+
+## Commands
+
+All commands must be run from `apps/cockpit/` with the PATH prefix. Running from the monorepo root will silently use the wrong config or fail to find binaries.
+
+```bash
+# Typecheck — must be zero errors before committing
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+
+# Tests — use bunx, NOT bun run test (bun can't resolve the vitest binary directly)
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run        # run once
+PATH="/opt/homebrew/bin:$PATH" bunx vitest            # watch mode
+
+# Lint — ESLint across src/
+PATH="/opt/homebrew/bin:$PATH" bun run lint
+
+# Dev server — starts Vite + Tauri hot-reload
+PATH="/opt/homebrew/bin:$PATH" bun run tauri dev
+
+# Production build
+PATH="/opt/homebrew/bin:$PATH" bun run tauri build
+
+# Install / restore dependencies
+PATH="/opt/homebrew/bin:$PATH" bun install
+
+# Clean build artifacts and node_modules
+PATH="/opt/homebrew/bin:$PATH" bun run clean
+```
+
+### Common mistakes
+
+| Wrong                      | Right                                | Why                                                             |
+| -------------------------- | ------------------------------------ | --------------------------------------------------------------- |
+| Run from monorepo root     | Run from `apps/cockpit/`             | Wrong tsconfig, wrong vitest config, wrong node_modules         |
+| `bun run test`             | `bunx vitest run`                    | bun resolves scripts but can't find the `vitest` binary in PATH |
+| `npm run ...` / `yarn ...` | `bun run ...`                        | npm/yarn are not the package manager here                       |
+| No PATH prefix             | `PATH="/opt/homebrew/bin:$PATH" ...` | Homebrew tools not on default shell PATH                        |
 
 ## Architecture
 

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Guidance for Claude Code working in `apps/cockpit`.
 
+## Development Workflow
+
+When given a feature or update request, follow this pipeline end-to-end without pausing for permission at each step:
+
+1. **Evaluate & refine** — read the relevant code, surface any tradeoffs or ambiguities, propose adjustments if the request has edge cases worth flagging
+2. **Plan** — agree on approach before touching code; for anything non-trivial, write out the steps
+3. **Implement** — write the code; don't add features, abstractions, or cleanup beyond what was asked
+4. **Verify** — `npx tsc --noEmit` (zero errors) + `bunx vitest run` (all passing); fix anything broken before moving on
+5. **Code review** — self-review or spawn a reviewer agent; catch bugs, anti-patterns, and anything that violates the rules in this file
+6. **Fix** — address every issue found in review before committing
+7. **Commit & push** — conventional commit message on a feature branch
+8. **Open PR** — description targeted at a human reviewer, not a dev log
+
+Operate autonomously through all 8 steps. Make decisions informed by best practice and the patterns in this file. Only pause to ask if something is genuinely ambiguous about the intent of the request — not for routine implementation choices.
+
+---
+
 ## Documentation
 
 Full canonical docs live in [`documentation/`](./documentation/):

--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -2,6 +2,59 @@
 
 Guidance for Claude Code working in `apps/cockpit`.
 
+## Git Workflow
+
+### Never commit directly to main
+
+All work goes on a feature branch. If commits accidentally land on `main` before a branch is created, rescue them:
+
+```bash
+git checkout -b feat/my-feature   # create branch at current HEAD (captures the commits)
+git checkout main
+git reset --hard origin/main      # strip the commits off main
+git push -u origin feat/my-feature
+```
+
+### Branch naming
+
+```
+feat/short-description       # new feature or enhancement
+fix/short-description        # bug fix
+docs/short-description       # documentation only
+chore/short-description      # tooling, deps, config
+refactor/short-description   # no behaviour change
+```
+
+### Commit messages — conventional commits
+
+```
+feat(cockpit): add cron expression parser
+fix(cockpit): resolve tag filter losing focus on blur
+docs(cockpit): update CLAUDE.md with Fuse.js pattern
+chore(release): bump version to 0.1.37 [skip ci]
+```
+
+Format: `type(scope): short description` — imperative mood, no period, under 72 chars. Scope is almost always `cockpit`.
+
+### Commits need HUSKY_PATH
+
+The pre-commit hook calls `bunx`. Bun lives in `/opt/homebrew/bin`, which isn't on the minimal shell PATH. Always prefix:
+
+```bash
+HUSKY_PATH=/opt/homebrew/bin PATH="/opt/homebrew/bin:$PATH" git commit -m "..."
+```
+
+### PRs
+
+- Title: matches the commit message format, under 70 chars
+- Body: **Summary** bullets (user-facing language) + **Test plan** checklist
+- Target branch: always `main`
+- Never force-push to `main`
+
+When asked to "open a PR" or "commit and push", the full sequence is implied: branch (if not already on one) → commit → `git push -u origin <branch>` → `gh pr create`.
+
+---
+
 ## Development Workflow
 
 When given a feature or update request, follow this pipeline end-to-end without pausing for permission at each step:


### PR DESCRIPTION
## Summary

- Adds a **Development Workflow** section to both files — the 8-step pipeline (evaluate → plan → implement → verify → code review → fix → commit/push → open PR) with explicit instruction to operate autonomously
- Adds a **Git Workflow** section to both files covering:
  - Never commit directly to `main`; rescue pattern when commits accidentally land there
  - Branch naming conventions (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
  - Conventional commit format with scope
  - `HUSKY_PATH` requirement for commits (pre-commit hook calls `bunx`)
  - PR structure and the implicit "full sequence" when asked to open a PR
- Updates test count from 361/49 to 380+/50+; checklist entry changed to `all passing` so it never goes stale
- Documents three new patterns from the SnippetsManager UX work: Fuse.js highlighting (composite `${start}-${end}` React key), CSS grid collapse animation, ARIA combobox wiring
- Adds Rule 24: `void` prefix for async fire-and-forget event handlers
- Adds a Testing Patterns section: `.textContent` check for `<mark>`-split text; `data-testid` scoping for ambiguous `getByText`

## Test plan

- [ ] Docs only — no code changes
- [ ] Confirm both files render correctly on GitHub