### PR TITLE
feat(cockpit): improve modal accessibility

### DIFF
--- a/apps/cockpit/src/components/shared/Dialog.tsx
+++ b/apps/cockpit/src/components/shared/Dialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useId, useRef, type KeyboardEvent, type ReactNode, type RefObject } from 'react'
+import { XIcon } from '@phosphor-icons/react'
+
+type DialogProps = {
+  title: ReactNode
+  children: ReactNode
+  onClose: () => void
+  footer?: ReactNode
+  className?: string
+  bodyClassName?: string
+  titleClassName?: string
+  closeLabel?: string
+  initialFocusRef?: RefObject<HTMLElement | null>
+  onOpenAutoFocus?: (target: HTMLElement) => void
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
+    return el.tabIndex >= 0 && el.getAttribute('aria-hidden') !== 'true'
+  })
+}
+
+export function Dialog({
+  title,
+  children,
+  onClose,
+  footer,
+  className = '',
+  bodyClassName = 'p-4',
+  titleClassName = '',
+  closeLabel = 'Close dialog',
+  initialFocusRef,
+  onOpenAutoFocus,
+}: DialogProps) {
+  const titleId = useId()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const panel = panelRef.current
+    if (!panel) return
+
+    const previousFocus =
+      document.activeElement instanceof window.HTMLElement ? document.activeElement : null
+    const focusTarget = initialFocusRef?.current ?? getFocusableElements(panel)[0] ?? panel
+
+    focusTarget.focus()
+    onOpenAutoFocus?.(focusTarget)
+
+    return () => {
+      if (previousFocus && document.contains(previousFocus)) {
+        previousFocus.focus()
+      }
+    }
+  }, [initialFocusRef, onOpenAutoFocus])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+      return
+    }
+
+    if (e.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const focusable = getFocusableElements(panel)
+    if (focusable.length === 0) {
+      e.preventDefault()
+      panel.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const active = document.activeElement
+
+    if (e.shiftKey && (!active || active === first || !panel.contains(active))) {
+      e.preventDefault()
+      last?.focus()
+      return
+    }
+
+    if (!e.shiftKey && active === last) {
+      e.preventDefault()
+      first?.focus()
+    }
+  }
+
+  return (
+    <>
+      <div
+        role="presentation"
+        className="fixed inset-0 z-50"
+        style={{ backgroundColor: 'color-mix(in srgb, var(--color-shadow) 50%, transparent)' }}
+        onClick={onClose}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className={`animate-fade-in fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg outline-none ${className}`}
+      >
+        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
+          <h2
+            id={titleId}
+            className={`font-mono text-sm text-[var(--color-text)] ${titleClassName}`}
+          >
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={closeLabel}
+            className="inline-flex min-h-8 min-w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+          >
+            <XIcon size={16} aria-hidden="true" />
+          </button>
+        </div>
+        <div className={`min-h-0 flex-1 overflow-y-auto ${bodyClassName}`}>{children}</div>
+        {footer && (
+          <div className="flex justify-end gap-2 border-t border-[var(--color-border)] px-4 py-3">
+            {footer}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/apps/cockpit/src/components/shared/__tests__/Dialog.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Dialog.test.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Dialog } from '@/components/shared/Dialog'
+
+afterEach(cleanup)
+
+function DialogHarness() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open dialog
+      </button>
+      {open && (
+        <Dialog title="Example dialog" onClose={() => setOpen(false)}>
+          <button type="button">First action</button>
+          <button type="button">Second action</button>
+        </Dialog>
+      )}
+    </>
+  )
+}
+
+describe('Dialog', () => {
+  it('renders an accessible modal dialog and restores focus on close', () => {
+    render(<DialogHarness />)
+
+    const trigger = screen.getByRole('button', { name: 'Open dialog' })
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    const dialog = screen.getByRole('dialog', { name: 'Example dialog' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByRole('button', { name: 'Close dialog' })).toHaveFocus()
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog', { name: 'Example dialog' })).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('traps keyboard focus inside the dialog', () => {
+    render(<DialogHarness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Example dialog' })
+    const closeButton = screen.getByRole('button', { name: 'Close dialog' })
+    const secondAction = screen.getByRole('button', { name: 'Second action' })
+
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true })
+    expect(secondAction).toHaveFocus()
+
+    fireEvent.keyDown(dialog, { key: 'Tab' })
+    expect(closeButton).toHaveFocus()
+  })
+
+  it('supports backdrop close', () => {
+    const onClose = vi.fn()
+
+    render(
+      <Dialog title="Backdrop dialog" onClose={onClose}>
+        Content
+      </Dialog>
+    )
+
+    fireEvent.click(screen.getByRole('presentation'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import type Fuse from 'fuse.js'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useNotesStore } from '@/stores/notes.store'
@@ -51,15 +51,16 @@ const NOTE_COLORS: NoteColor[] = [
   'gray',
 ]
 
-const COLOR_MAP: Record<NoteColor, string> = {
-  yellow: 'bg-yellow-500/10 border-yellow-500/20',
-  green: 'bg-green-500/10 border-green-500/20',
-  blue: 'bg-blue-500/10 border-blue-500/20',
-  pink: 'bg-pink-500/10 border-pink-500/20',
-  purple: 'bg-purple-500/10 border-purple-500/20',
-  orange: 'bg-orange-500/10 border-orange-500/20',
-  red: 'bg-red-500/10 border-red-500/20',
-  gray: 'bg-gray-500/10 border-gray-500/20',
+function noteColorVar(color: NoteColor): string {
+  return `var(--note-${color})`
+}
+
+function noteCardStyle(color: NoteColor): CSSProperties {
+  const token = noteColorVar(color)
+  return {
+    backgroundColor: `color-mix(in srgb, ${token} 10%, var(--color-surface))`,
+    borderColor: `color-mix(in srgb, ${token} 28%, var(--color-border))`,
+  }
 }
 
 function MarkdownRenderer({ content }: { content: string }) {
@@ -83,26 +84,35 @@ function NoteEditor({
   onDone,
 }: {
   note: NoteType
-  onUpdate: (id: string, patch: Partial<NoteType>) => void
+  onUpdate: (id: string, patch: Partial<NoteType>) => void | Promise<void>
   onDone: () => void
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [tagInput, setTagInput] = useState('')
 
+  const applyUpdate = useCallback(
+    (patch: Partial<NoteType>) => {
+      void Promise.resolve(onUpdate(note.id, patch)).catch(() => {
+        // The persisted notes store already raises the user-facing toast.
+      })
+    },
+    [note.id, onUpdate]
+  )
+
   const handleAddTag = useCallback(() => {
     const tag = tagInput.trim().toLowerCase()
     if (tag && !note.tags.includes(tag)) {
-      onUpdate(note.id, { tags: [...note.tags, tag] })
+      applyUpdate({ tags: [...note.tags, tag] })
     }
     setTagInput('')
-  }, [tagInput, note.id, note.tags, onUpdate])
+  }, [applyUpdate, tagInput, note.tags])
 
   const handleRemoveTag = useCallback(
     (tag: string) => {
-      onUpdate(note.id, { tags: note.tags.filter((t) => t !== tag) })
+      applyUpdate({ tags: note.tags.filter((t) => t !== tag) })
     },
-    [note.id, note.tags, onUpdate]
+    [applyUpdate, note.tags]
   )
 
   const autoGrow = useCallback(() => {
@@ -130,7 +140,7 @@ function NoteEditor({
     <div ref={containerRef} className="flex min-w-0 flex-col gap-1 overflow-hidden">
       <input
         value={note.title}
-        onChange={(e) => onUpdate(note.id, { title: e.target.value })}
+        onChange={(e) => applyUpdate({ title: e.target.value })}
         placeholder="Title"
         className="w-full bg-transparent text-xs font-bold text-[var(--color-text)] outline-none"
         autoFocus
@@ -139,7 +149,7 @@ function NoteEditor({
         ref={textareaRef}
         value={note.content}
         onChange={(e) => {
-          onUpdate(note.id, { content: e.target.value })
+          applyUpdate({ content: e.target.value })
           autoGrow()
         }}
         onInput={autoGrow}
@@ -156,8 +166,13 @@ function NoteEditor({
             className="flex items-center gap-1 rounded bg-[var(--color-accent-dim)] px-1.5 py-0.5 text-[10px] text-[var(--color-accent)]"
           >
             {tag}
-            <button onClick={() => handleRemoveTag(tag)} className="hover:text-[var(--color-text)]">
-              <XIcon size={10} />
+            <button
+              type="button"
+              onClick={() => handleRemoveTag(tag)}
+              aria-label={`Remove ${tag} tag`}
+              className="inline-flex min-h-5 min-w-5 items-center justify-center rounded transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+            >
+              <XIcon size={10} aria-hidden="true" />
             </button>
           </span>
         ))}
@@ -177,14 +192,22 @@ function NoteEditor({
           {NOTE_COLORS.map((c) => (
             <button
               key={c}
-              onClick={() => onUpdate(note.id, { color: c })}
-              className={`h-3 w-3 rounded-full border ${note.color === c ? 'ring-2 ring-[var(--color-accent)]' : 'border-[var(--color-border)]'}`}
-              style={{ backgroundColor: `var(--note-${c}, ${c === 'gray' ? '#666' : c})` }}
+              type="button"
+              onClick={() => applyUpdate({ color: c })}
+              aria-label={`Set note color to ${c}`}
+              aria-pressed={note.color === c}
+              className={`min-h-6 min-w-6 rounded-full border transition-transform duration-150 hover:scale-110 ${
+                note.color === c
+                  ? 'border-[var(--color-accent)] ring-2 ring-[var(--color-accent)]'
+                  : 'border-[var(--color-border)]'
+              }`}
+              style={{ backgroundColor: noteColorVar(c) }}
               title={c}
             />
           ))}
         </div>
         <button
+          type="button"
           onClick={onDone}
           className="rounded px-2 py-0.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-accent)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)]"
         >
@@ -277,15 +300,23 @@ export function NotesDrawer() {
   }, [historyEntries, historyFilter])
 
   const handleAddNote = useCallback(async () => {
-    const note = await addNote('New note', '', 'yellow')
-    setEditingId(note.id)
-    setLastAction('Note created', 'success')
+    try {
+      const note = await addNote('New note', '', 'yellow')
+      setEditingId(note.id)
+      setLastAction('Note created', 'success')
+    } catch {
+      setLastAction('Failed to create note', 'error')
+    }
   }, [addNote, setLastAction])
 
   const handleDelete = useCallback(
     async (id: string) => {
-      await removeNote(id)
-      setLastAction('Note deleted', 'info')
+      try {
+        await removeNote(id)
+        setLastAction('Note deleted', 'info')
+      } catch {
+        setLastAction('Failed to delete note', 'error')
+      }
     },
     [removeNote, setLastAction]
   )
@@ -308,6 +339,9 @@ export function NotesDrawer() {
       {/* Drag handle — sits on the left edge */}
       <div
         onMouseDown={handleDragStart}
+        role="separator"
+        aria-label="Resize notes drawer"
+        aria-orientation="vertical"
         className="absolute left-0 top-0 z-10 h-full w-1 cursor-col-resize hover:bg-[var(--color-accent)]/40 active:bg-[var(--color-accent)]/60 transition-colors"
         title="Drag to resize"
       />
@@ -325,7 +359,10 @@ export function NotesDrawer() {
               className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
             />
             <button
-              onClick={handleAddNote}
+              type="button"
+              onClick={() => {
+                void handleAddNote()
+              }}
               aria-label="New note"
               className="rounded border border-[var(--color-accent)] px-2 py-1 font-mono text-xs text-[var(--color-accent)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)]"
             >
@@ -343,7 +380,8 @@ export function NotesDrawer() {
             {filteredNotes.map((note) => (
               <div
                 key={note.id}
-                className={`mb-3 rounded-lg border shadow-sm transition-colors duration-150 ${COLOR_MAP[note.color] ?? 'bg-[var(--color-surface)] border-[var(--color-border)]'} ${editingId === note.id ? 'ring-1 ring-[var(--color-accent)]' : ''}`}
+                className={`mb-3 rounded-lg border shadow-sm transition-colors duration-150 ${editingId === note.id ? 'ring-1 ring-[var(--color-accent)]' : ''}`}
+                style={noteCardStyle(note.color)}
               >
                 <div className="p-3">
                   {editingId === note.id ? (
@@ -358,48 +396,65 @@ export function NotesDrawer() {
                         <span className="truncate text-xs font-bold text-[var(--color-text)]">
                           {note.title || 'Untitled'}
                         </span>
-                        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                           <button
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation()
-                              navigator.clipboard.writeText(note.content)
-                              setLastAction('Copied to clipboard', 'info')
+                              navigator.clipboard
+                                .writeText(note.content)
+                                .then(() => setLastAction('Copied to clipboard', 'info'))
+                                .catch(() => setLastAction('Failed to copy note', 'error'))
                             }}
-                            className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
+                            aria-label={`Copy ${note.title || 'untitled note'} content`}
+                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
                             title="Copy content"
                           >
-                            <CopyIcon size={12} />
+                            <CopyIcon size={12} aria-hidden="true" />
                           </button>
                           <button
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation()
                               setPendingSendTo(note.content)
                               setLastAction('Ready to send to tool', 'info')
                             }}
-                            className="rounded p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
+                            aria-label={`Use ${note.title || 'untitled note'} as input`}
+                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
                             title="Use as input"
                           >
-                            <PaperPlaneTiltIcon size={12} />
+                            <PaperPlaneTiltIcon size={12} aria-hidden="true" />
                           </button>
                           <button
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation()
-                              updateNote(note.id, { pinned: !note.pinned })
+                              void updateNote(note.id, { pinned: !note.pinned }).catch(() =>
+                                setLastAction('Failed to update note', 'error')
+                              )
                             }}
-                            className={`rounded p-1 transition-colors duration-150 ${note.pinned ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}`}
+                            aria-label={`${note.pinned ? 'Unpin' : 'Pin'} ${note.title || 'untitled note'}`}
+                            aria-pressed={note.pinned}
+                            className={`inline-flex min-h-7 min-w-7 items-center justify-center rounded transition-colors duration-150 ${note.pinned ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'}`}
                             title={note.pinned ? 'Unpin' : 'Pin'}
                           >
-                            <PushPinIcon size={12} weight={note.pinned ? 'fill' : 'regular'} />
+                            <PushPinIcon
+                              size={12}
+                              weight={note.pinned ? 'fill' : 'regular'}
+                              aria-hidden="true"
+                            />
                           </button>
                           <button
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation()
-                              handleDelete(note.id)
+                              void handleDelete(note.id)
                             }}
-                            className="rounded p-1 text-[var(--color-text-muted)] transition-colors duration-150 hover:text-[var(--color-error)]"
+                            aria-label={`Delete ${note.title || 'untitled note'}`}
+                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-error)]"
                             title="Delete note"
                           >
-                            <TrashIcon size={12} />
+                            <TrashIcon size={12} aria-hidden="true" />
                           </button>
                         </div>
                       </div>
@@ -417,7 +472,7 @@ export function NotesDrawer() {
                               key={tag}
                               className="flex items-center gap-0.5 rounded-full bg-[var(--color-text-muted)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]"
                             >
-                              <TagIcon size={8} />
+                              <TagIcon size={8} aria-hidden="true" />
                               {tag}
                             </span>
                           ))}

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -9,7 +9,6 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { DEFAULT_SETTINGS, type AppSettings, type Theme } from '@/types/models'
 import { TOOLS } from '@/app/tool-registry'
 import {
-  XIcon,
   GearSixIcon,
   CodeIcon,
   DatabaseIcon,
@@ -24,6 +23,7 @@ import {
   ArrowCircleUpIcon,
   SpinnerIcon,
 } from '@phosphor-icons/react'
+import { Dialog } from '@/components/shared/Dialog'
 import { Toggle } from '@/components/shared/Toggle'
 import { ALL_THEMES, THEME_META } from '@/lib/theme'
 import { getVersion } from '@tauri-apps/api/app'
@@ -142,14 +142,20 @@ function DangerButton({
   confirmLabel,
   onConfirm,
   icon,
+  successMessage,
+  errorMessage,
 }: {
   label: string
   confirmLabel: string
   onConfirm: () => Promise<void>
   icon: React.ReactNode
+  successMessage: string
+  errorMessage: string
 }) {
   const [confirming, setConfirming] = useState(false)
   const [done, setDone] = useState(false)
+  const [pending, setPending] = useState(false)
+  const addToast = useUiStore((s) => s.addToast)
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
@@ -163,13 +169,17 @@ function DangerButton({
       return
     }
     clearTimeout(timerRef.current)
+    setPending(true)
     try {
       await onConfirm()
       setDone(true)
+      addToast(successMessage, 'success')
       timerRef.current = setTimeout(() => setDone(false), 2000)
-    } catch {
-      // silently reset — the store action is responsible for user feedback
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      addToast(`${errorMessage}: ${msg}`, 'error')
     } finally {
+      setPending(false)
       setConfirming(false)
     }
   }
@@ -188,15 +198,23 @@ function DangerButton({
 
   return (
     <button
+      type="button"
       onClick={handleClick}
+      disabled={pending}
       className={`flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors ${
         confirming
           ? 'border-[var(--color-error)] bg-[var(--color-error)]/10 text-[var(--color-error)]'
           : 'border-[var(--color-border)] text-[var(--color-text-muted)] hover:border-[var(--color-error)] hover:text-[var(--color-error)]'
-      }`}
+      } disabled:pointer-events-none disabled:opacity-60`}
     >
-      {confirming ? <WarningIcon size={12} /> : icon}
-      {confirming ? confirmLabel : label}
+      {pending ? (
+        <SpinnerIcon size={12} className="animate-spin" aria-hidden="true" />
+      ) : confirming ? (
+        <WarningIcon size={12} aria-hidden="true" />
+      ) : (
+        icon
+      )}
+      {pending ? 'Working…' : confirming ? confirmLabel : label}
     </button>
   )
 }
@@ -211,6 +229,7 @@ function GeneralTab() {
   const checkForUpdatesAutomatically = useSettingsStore((s) => s.checkForUpdatesAutomatically)
   const downloadUpdatesAutomatically = useSettingsStore((s) => s.downloadUpdatesAutomatically)
   const notifyWhenUpdateAvailable = useSettingsStore((s) => s.notifyWhenUpdateAvailable)
+  const addToast = useUiStore((s) => s.addToast)
 
   const isChecking = useUpdaterStore((s) => s.isChecking)
   const lastCheckedAt = useUpdaterStore((s) => s.lastCheckedAt)
@@ -228,10 +247,10 @@ function GeneralTab() {
     (checked: boolean) => {
       getCurrentWindow()
         .setAlwaysOnTop(checked)
-        .catch(() => {})
-      update('alwaysOnTop', checked).catch(() => {})
+        .then(() => update('alwaysOnTop', checked))
+        .catch(() => addToast('Failed to update window pin state', 'error'))
     },
-    [update]
+    [addToast, update]
   )
 
   const lastCheckedLabel = lastCheckedAt
@@ -294,7 +313,10 @@ function GeneralTab() {
             <span className="text-[10px] text-[var(--color-text-muted)]">v{appVersion}</span>
           )}
           <button
-            onClick={() => checkForUpdate(true).catch(() => {})}
+            type="button"
+            onClick={() => {
+              void checkForUpdate(true)
+            }}
             disabled={isChecking}
             className="flex items-center gap-1.5 rounded border border-[var(--color-border)] px-2.5 py-1.5 text-xs text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] disabled:opacity-50"
           >
@@ -449,8 +471,7 @@ function DataTab() {
     ])
     const validToolIds = new Set(TOOLS.map((tool) => tool.id))
     const isToolGroup = (id: unknown): id is AppSettings['collapsedSidebarGroups'][number] =>
-      typeof id === 'string' &&
-      validGroups.has(id as AppSettings['collapsedSidebarGroups'][number])
+      typeof id === 'string' && validGroups.has(id as AppSettings['collapsedSidebarGroups'][number])
 
     try {
       const text = await navigator.clipboard.readText()
@@ -514,10 +535,7 @@ function DataTab() {
       if (typeof obj['defaultTimezone'] === 'string')
         await su('defaultTimezone', obj['defaultTimezone'])
       if (Array.isArray(obj['collapsedSidebarGroups'])) {
-        await su(
-          'collapsedSidebarGroups',
-          obj['collapsedSidebarGroups'].filter(isToolGroup)
-        )
+        await su('collapsedSidebarGroups', obj['collapsedSidebarGroups'].filter(isToolGroup))
       }
       if (Array.isArray(obj['pinnedToolIds'])) {
         await su(
@@ -529,9 +547,7 @@ function DataTab() {
       }
       // Apply alwaysOnTop to the live Tauri window
       const finalOnTop = useSettingsStore.getState().alwaysOnTop
-      getCurrentWindow()
-        .setAlwaysOnTop(finalOnTop)
-        .catch(() => {})
+      await getCurrentWindow().setAlwaysOnTop(finalOnTop)
       addToast('Settings imported', 'success')
     } catch {
       addToast('Failed to import settings', 'error')
@@ -544,11 +560,8 @@ function DataTab() {
     for (const key of keys) {
       await settingsUpdate(key, DEFAULT_SETTINGS[key])
     }
-    getCurrentWindow()
-      .setAlwaysOnTop(false)
-      .catch(() => {})
-    addToast('Settings reset to defaults', 'success')
-  }, [addToast])
+    await getCurrentWindow().setAlwaysOnTop(false)
+  }, [])
 
   // Build timezone options: user's local TZ first, then popular list (deduped)
   const tzOptions = useMemo(() => {
@@ -612,18 +625,24 @@ function DataTab() {
             confirmLabel="Confirm clear?"
             onConfirm={clearNotes}
             icon={<TrashIcon size={12} />}
+            successMessage="Notes cleared"
+            errorMessage="Failed to clear notes"
           />
           <DangerButton
             label={`Clear Snippets (${snippetCount})`}
             confirmLabel="Confirm clear?"
             onConfirm={clearSnippets}
             icon={<TrashIcon size={12} />}
+            successMessage="Snippets cleared"
+            errorMessage="Failed to clear snippets"
           />
           <DangerButton
             label={`Clear History (${historyCount})`}
             confirmLabel="Confirm clear?"
             onConfirm={clearHistory}
             icon={<TrashIcon size={12} />}
+            successMessage="History cleared"
+            errorMessage="Failed to clear history"
           />
         </div>
       </div>
@@ -636,6 +655,7 @@ function DataTab() {
         </h4>
         <div className="flex flex-wrap gap-2">
           <button
+            type="button"
             onClick={handleExportSettings}
             className="flex items-center gap-1.5 rounded border border-[var(--color-border)] px-2.5 py-1.5 text-xs text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
           >
@@ -643,6 +663,7 @@ function DataTab() {
             Export to Clipboard
           </button>
           <button
+            type="button"
             onClick={handleImportSettings}
             className="flex items-center gap-1.5 rounded border border-[var(--color-border)] px-2.5 py-1.5 text-xs text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
           >
@@ -654,6 +675,8 @@ function DataTab() {
             confirmLabel="Confirm reset?"
             onConfirm={handleResetDefaults}
             icon={<ArrowCounterClockwiseIcon size={12} />}
+            successMessage="Settings reset to defaults"
+            errorMessage="Failed to reset settings"
           />
         </div>
       </div>
@@ -676,70 +699,19 @@ export function SettingsPanel() {
   const open = useUiStore((s) => s.settingsPanelOpen)
   const setOpen = useUiStore((s) => s.setSettingsPanelOpen)
   const [activeTab, setActiveTab] = useState<TabId>('general')
-  const panelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    function handleEscape(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [open, setOpen])
 
   if (!open) return null
 
   return (
-    <div
-      role="presentation"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) setOpen(false)
-      }}
-    >
-      <div
-        ref={panelRef}
-        className="animate-fade-in w-full max-w-lg rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-xl"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
-          <h2 className="font-mono text-sm text-[var(--color-accent)]">Settings</h2>
-          <button
-            onClick={() => setOpen(false)}
-            aria-label="Close settings"
-            className="rounded p-1 text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-          >
-            <XIcon size={16} />
-          </button>
-        </div>
-
-        {/* Tab bar */}
-        <div className="flex border-b border-[var(--color-border)]">
-          {TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`-mb-px flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium transition-colors ${
-                activeTab === tab.id
-                  ? 'border-b-2 border-[var(--color-accent)] text-[var(--color-accent)]'
-                  : 'border-b-2 border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
-              }`}
-            >
-              {tab.icon}
-              {tab.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Tab content */}
-        <div className="max-h-[60vh] overflow-y-auto px-4 py-3">
-          {activeTab === 'general' && <GeneralTab />}
-          {activeTab === 'editor' && <EditorTab />}
-          {activeTab === 'data' && <DataTab />}
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between border-t border-[var(--color-border)] px-4 py-2.5">
+    <Dialog
+      title="Settings"
+      onClose={() => setOpen(false)}
+      closeLabel="Close settings"
+      className="w-full max-w-lg"
+      bodyClassName="p-0"
+      titleClassName="text-[var(--color-accent)]"
+      footer={
+        <div className="flex w-full items-center justify-between">
           <span className="text-[10px] text-[var(--color-text-muted)]">
             {TOOLS.length} tools loaded
           </span>
@@ -747,7 +719,33 @@ export function SettingsPanel() {
             Changes saved automatically
           </span>
         </div>
+      }
+    >
+      {/* Tab bar */}
+      <div className="flex border-b border-[var(--color-border)]">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={`-mb-px flex items-center gap-1.5 px-4 py-2.5 text-xs font-medium transition-colors ${
+              activeTab === tab.id
+                ? 'border-b-2 border-[var(--color-accent)] text-[var(--color-accent)]'
+                : 'border-b-2 border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            {tab.icon}
+            {tab.label}
+          </button>
+        ))}
       </div>
-    </div>
+
+      {/* Tab content */}
+      <div className="max-h-[60vh] overflow-y-auto px-4 py-3">
+        {activeTab === 'general' && <GeneralTab />}
+        {activeTab === 'editor' && <EditorTab />}
+        {activeTab === 'data' && <DataTab />}
+      </div>
+    </Dialog>
   )
 }

--- a/apps/cockpit/src/components/shell/ShortcutsModal.tsx
+++ b/apps/cockpit/src/components/shell/ShortcutsModal.tsx
@@ -1,7 +1,6 @@
-import { useEffect } from 'react'
+import { Dialog } from '@/components/shared/Dialog'
 import { useUiStore } from '@/stores/ui.store'
 import { usePlatform } from '@/hooks/usePlatform'
-import { XIcon } from '@phosphor-icons/react'
 
 type ShortcutEntry = {
   keys: string[]
@@ -63,59 +62,38 @@ export function ShortcutsModal() {
   const setOpen = useUiStore((s) => s.setShortcutsModalOpen)
   const { modSymbol } = usePlatform()
 
-  useEffect(() => {
-    if (!open) return
-    function handleEscape(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('keydown', handleEscape)
-    return () => document.removeEventListener('keydown', handleEscape)
-  }, [open, setOpen])
-
   if (!open) return null
 
   const categories = getCategories(modSymbol)
 
   return (
-    <>
-      <div
-        role="presentation"
-        className="fixed inset-0 z-50 bg-black/50"
-        onClick={() => setOpen(false)}
-      />
-      <div className="animate-fade-in fixed left-1/2 top-1/2 z-50 w-full max-w-[560px] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg">
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
-          <h2 className="font-mono text-sm text-[var(--color-accent)]">Keyboard Shortcuts</h2>
-          <button
-            onClick={() => setOpen(false)}
-            aria-label="Close shortcuts"
-            className="rounded p-1 text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-          >
-            <XIcon size={16} />
-          </button>
-        </div>
-        <div className="max-h-[70vh] overflow-y-auto px-4 py-3">
-          {categories.map((cat) => (
-            <div key={cat.label} className="mb-4 last:mb-0">
-              <h3 className="mb-2 font-mono text-xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                {cat.label}
-              </h3>
-              <div className="flex flex-col gap-1">
-                {cat.shortcuts.map((s) => (
-                  <div key={s.action} className="flex items-center justify-between py-1.5">
-                    <span className="text-xs text-[var(--color-text)]">{s.action}</span>
-                    <div className="flex items-center gap-1">
-                      {s.keys.map((k, i) => (
-                        <Kbd key={i}>{k}</Kbd>
-                      ))}
-                    </div>
-                  </div>
-                ))}
+    <Dialog
+      title="Keyboard Shortcuts"
+      onClose={() => setOpen(false)}
+      closeLabel="Close shortcuts"
+      className="w-full max-w-[560px]"
+      bodyClassName="max-h-[70vh] px-4 py-3"
+      titleClassName="text-[var(--color-accent)]"
+    >
+      {categories.map((cat) => (
+        <div key={cat.label} className="mb-4 last:mb-0">
+          <h3 className="mb-2 font-mono text-xs uppercase tracking-widest text-[var(--color-text-muted)]">
+            {cat.label}
+          </h3>
+          <div className="flex flex-col gap-1">
+            {cat.shortcuts.map((s) => (
+              <div key={s.action} className="flex items-center justify-between py-1.5">
+                <span className="text-xs text-[var(--color-text)]">{s.action}</span>
+                <div className="flex items-center gap-1">
+                  {s.keys.map((k, i) => (
+                    <Kbd key={i}>{k}</Kbd>
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
-    </>
+      ))}
+    </Dialog>
   )
 }

--- a/apps/cockpit/src/components/shell/UpdateNotification.tsx
+++ b/apps/cockpit/src/components/shell/UpdateNotification.tsx
@@ -13,11 +13,15 @@ export function UpdateNotification() {
   if (!updateInfo || dismissed || !notifyWhenUpdateAvailable) return null
 
   const handleDownload = () => {
-    downloadUpdate().catch(() => {})
+    void downloadUpdate()
   }
 
   return (
-    <div className="flex items-center gap-3 border-b border-[var(--color-accent)]/30 bg-[var(--color-accent)]/10 px-4 py-2">
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-3 border-b border-[var(--color-accent)]/30 bg-[var(--color-accent)]/10 px-4 py-2"
+    >
       <ArrowCircleUpIcon size={14} className="shrink-0 text-[var(--color-accent)]" />
       <span className="flex-1 text-xs text-[var(--color-text)]">
         <span className="font-medium text-[var(--color-accent)]">
@@ -34,20 +38,23 @@ export function UpdateNotification() {
         </div>
       ) : (
         <button
+          type="button"
           onClick={handleDownload}
-          className="flex items-center gap-1.5 rounded border border-[var(--color-accent)] px-2.5 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)] hover:text-[var(--color-bg)]"
+          disabled={isDownloading}
+          className="flex min-h-8 items-center gap-1.5 rounded border border-[var(--color-accent)] px-2.5 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)] hover:text-[var(--color-bg)] disabled:pointer-events-none disabled:opacity-60"
         >
-          <DownloadSimpleIcon size={12} />
+          <DownloadSimpleIcon size={12} aria-hidden="true" />
           Download
         </button>
       )}
 
       <button
+        type="button"
         onClick={dismiss}
         aria-label="Dismiss update notification"
-        className="rounded p-0.5 text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text)]"
+        className="inline-flex min-h-8 min-w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
       >
-        <XIcon size={12} />
+        <XIcon size={12} aria-hidden="true" />
       </button>
     </div>
   )

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NotesDrawer } from '@/components/shell/NotesDrawer'
+import { useHistoryStore } from '@/stores/history.store'
+import { useNotesStore } from '@/stores/notes.store'
+import { useSettingsStore } from '@/stores/settings.store'
+import { useUiStore } from '@/stores/ui.store'
+import { DEFAULT_SETTINGS, type Note } from '@/types/models'
+
+const testNote: Note = {
+  id: 'note-1',
+  title: 'Test note',
+  content: 'Use this as input',
+  color: 'yellow',
+  pinned: false,
+  poppedOut: false,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: ['api'],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSettingsStore.setState({ ...DEFAULT_SETTINGS, notesDrawerOpen: true, notesDrawerWidth: 320 })
+  useNotesStore.setState({
+    notes: [testNote],
+    initialized: true,
+    update: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+  })
+  useHistoryStore.setState({ entries: [] })
+  useUiStore.setState({ lastAction: null, pendingSendTo: null })
+})
+
+afterEach(cleanup)
+
+describe('NotesDrawer', () => {
+  it('labels compact note actions for assistive technology', () => {
+    render(<NotesDrawer />)
+
+    expect(screen.getByRole('button', { name: 'Copy Test note content' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use Test note as input' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Pin Test note' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete Test note' })).toBeInTheDocument()
+    expect(screen.getByRole('separator', { name: 'Resize notes drawer' })).toHaveAttribute(
+      'aria-orientation',
+      'vertical'
+    )
+  })
+
+  it('uses labelled, larger color swatches while editing', () => {
+    render(<NotesDrawer />)
+
+    fireEvent.click(screen.getByText('Test note'))
+
+    const yellow = screen.getByRole('button', { name: 'Set note color to yellow' })
+    const blue = screen.getByRole('button', { name: 'Set note color to blue' })
+
+    expect(yellow).toHaveAttribute('aria-pressed', 'true')
+    expect(blue).toHaveAttribute('aria-pressed', 'false')
+    expect(yellow.className).toContain('min-h-6')
+    expect(yellow.className).toContain('min-w-6')
+  })
+})

--- a/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SettingsPanel } from '@/components/shell/SettingsPanel'
+import { useHistoryStore } from '@/stores/history.store'
+import { useNotesStore } from '@/stores/notes.store'
+import { useSettingsStore } from '@/stores/settings.store'
+import { useSnippetsStore } from '@/stores/snippets.store'
+import { useUiStore } from '@/stores/ui.store'
+import { DEFAULT_SETTINGS } from '@/types/models'
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('0.1.0'),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    setAlwaysOnTop: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: true })
+  useNotesStore.setState({
+    notes: [
+      {
+        id: 'note-1',
+        title: 'Test note',
+        content: '',
+        color: 'yellow',
+        pinned: false,
+        poppedOut: false,
+        createdAt: 1,
+        updatedAt: 1,
+        tags: [],
+      },
+    ],
+    clearAll: vi.fn().mockResolvedValue(undefined),
+  })
+  useSnippetsStore.setState({ snippets: [], clearAll: vi.fn().mockResolvedValue(undefined) })
+  useHistoryStore.setState({ entries: [], clearAll: vi.fn().mockResolvedValue(undefined) })
+  useUiStore.setState({
+    settingsPanelOpen: true,
+    addToast: vi.fn(),
+  })
+})
+
+afterEach(cleanup)
+
+describe('SettingsPanel', () => {
+  it('uses dialog semantics and reports destructive action success', async () => {
+    const clearNotes = useNotesStore.getState().clearAll
+    const addToast = useUiStore.getState().addToast
+
+    render(<SettingsPanel />)
+
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Data' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Notes (1)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm clear?' }))
+
+    await waitFor(() => expect(clearNotes).toHaveBeenCalledTimes(1))
+    expect(addToast).toHaveBeenCalledWith('Notes cleared', 'success')
+  })
+})

--- a/apps/cockpit/src/components/shell/__tests__/UpdateNotification.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/UpdateNotification.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UpdateNotification } from '@/components/shell/UpdateNotification'
+import { useSettingsStore } from '@/stores/settings.store'
+import { useUpdaterStore } from '@/stores/updater.store'
+import { DEFAULT_SETTINGS } from '@/types/models'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useSettingsStore.setState({ ...DEFAULT_SETTINGS, notifyWhenUpdateAvailable: true })
+  useUpdaterStore.setState({
+    updateInfo: {
+      version: '0.2.0',
+      notes: 'Polish pass',
+      pub_date: '2026-04-15',
+      url: 'https://example.com/devdrivr.dmg',
+      platformKey: 'darwin-aarch64',
+    },
+    dismissed: false,
+    isDownloading: false,
+    downloadUpdate: vi.fn().mockResolvedValue(undefined),
+    dismiss: vi.fn(),
+  })
+})
+
+afterEach(cleanup)
+
+describe('UpdateNotification', () => {
+  it('announces update state and exposes labelled actions', () => {
+    const downloadUpdate = useUpdaterStore.getState().downloadUpdate
+    const dismiss = useUpdaterStore.getState().dismiss
+
+    render(<UpdateNotification />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('devdrivr v0.2.0')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+    expect(downloadUpdate).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss update notification' }))
+    expect(dismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { useApiStore } from '@/stores/api.store'
 import { Button } from '@/components/shared/Button'
+import { Dialog } from '@/components/shared/Dialog'
 import { Input } from '@/components/shared/Input'
+import { XIcon } from '@phosphor-icons/react'
 
 type Props = {
   onClose: () => void
@@ -64,120 +66,117 @@ export function EnvironmentModal({ onClose }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="flex h-[80vh] w-[800px] max-w-[90vw] flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl">
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
-          <h2 className="font-mono text-lg text-[var(--color-text)]">Manage Environments</h2>
-          <button
-            onClick={onClose}
-            className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-          >
-            ✕
-          </button>
-        </div>
-
-        <div className="flex flex-1 overflow-hidden">
-          {/* Left Sidebar: Env List */}
-          <div className="w-1/3 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] flex overflow-hidden">
-            <div className="p-2">
-              <Button variant="secondary" size="sm" onClick={handleAdd} className="w-full mb-2">
-                + Create Environment
-              </Button>
-            </div>
-            <div className="flex-1 overflow-y-auto w-full">
-              {environments.map((env) => (
-                <button
-                  key={env.id}
-                  onClick={() => setSelectedId(env.id)}
-                  className={`block w-full px-3 py-2 text-left text-sm ${
-                    env.id === selectedId
-                      ? 'bg-[var(--color-accent-dim)] font-bold text-[var(--color-accent)]'
-                      : 'text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]'
-                  }`}
-                >
-                  {env.name}
-                </button>
-              ))}
-              {environments.length === 0 && (
-                <div className="p-4 text-center text-xs text-[var(--color-text-muted)]">
-                  No environments yet.
-                </div>
-              )}
-            </div>
+    <Dialog
+      title="Manage Environments"
+      onClose={onClose}
+      closeLabel="Close environment manager"
+      className="h-[80vh] w-[800px] max-w-[90vw]"
+      bodyClassName="flex overflow-hidden p-0"
+      titleClassName="text-lg"
+    >
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left Sidebar: Env List */}
+        <div className="w-1/3 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] flex overflow-hidden">
+          <div className="p-2">
+            <Button variant="secondary" size="sm" onClick={handleAdd} className="w-full mb-2">
+              + Create Environment
+            </Button>
           </div>
-
-          {/* Right Panel: Editor */}
-          <div className="flex-1 flex flex-col w-full overflow-hidden bg-[var(--color-bg)]">
-            {activeEnv ? (
-              <>
-                <div className="flex items-center gap-3 border-b border-[var(--color-border)] p-4">
-                  <input
-                    value={activeEnv.name}
-                    onChange={(e) => handleRename(e.target.value)}
-                    className="flex-1 border-b border-transparent bg-transparent px-1 py-0.5 text-lg font-bold text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
-                    placeholder="Environment Name"
-                  />
-                  <button
-                    onClick={handleDeleteEnv}
-                    className="rounded text-xs text-[var(--color-error)] hover:underline"
-                  >
-                    Delete Environment
-                  </button>
-                </div>
-
-                <div className="flex-1 overflow-y-auto p-4">
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="font-bold text-sm text-[var(--color-text)]">Variables</span>
-                    <button
-                      onClick={handleAddVar}
-                      className="text-xs text-[var(--color-accent)] hover:underline"
-                    >
-                      + Add Variable
-                    </button>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    {Object.entries(activeEnv.variables).map(([key, value]) => (
-                      <div key={key} className="flex items-center gap-2">
-                        <Input
-                          value={key}
-                          onChange={(e) => handleUpdateVar(key, e.target.value, value)}
-                          placeholder="Variable name"
-                          size="md"
-                          className="w-1/3 font-mono"
-                        />
-                        <span className="text-[var(--color-text-muted)]">=</span>
-                        <Input
-                          value={value}
-                          onChange={(e) => handleUpdateVar(key, key, e.target.value)}
-                          placeholder="Value"
-                          size="md"
-                          className="flex-1 font-mono"
-                        />
-                        <button
-                          onClick={() => handleDeleteVar(key)}
-                          className="text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
-                        >
-                          ✕
-                        </button>
-                      </div>
-                    ))}
-                    {Object.keys(activeEnv.variables).length === 0 && (
-                      <div className="text-center text-xs text-[var(--color-text-muted)] py-4">
-                        No variables defined. Add one (e.g., baseUrl, token).
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)]">
-                Select or create an environment
+          <div className="flex-1 overflow-y-auto w-full">
+            {environments.map((env) => (
+              <button
+                key={env.id}
+                onClick={() => setSelectedId(env.id)}
+                className={`block w-full px-3 py-2 text-left text-sm ${
+                  env.id === selectedId
+                    ? 'bg-[var(--color-accent-dim)] font-bold text-[var(--color-accent)]'
+                    : 'text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]'
+                }`}
+              >
+                {env.name}
+              </button>
+            ))}
+            {environments.length === 0 && (
+              <div className="p-4 text-center text-xs text-[var(--color-text-muted)]">
+                No environments yet.
               </div>
             )}
           </div>
         </div>
+
+        {/* Right Panel: Editor */}
+        <div className="flex-1 flex flex-col w-full overflow-hidden bg-[var(--color-bg)]">
+          {activeEnv ? (
+            <>
+              <div className="flex items-center gap-3 border-b border-[var(--color-border)] p-4">
+                <input
+                  value={activeEnv.name}
+                  onChange={(e) => handleRename(e.target.value)}
+                  className="flex-1 border-b border-transparent bg-transparent px-1 py-0.5 text-lg font-bold text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
+                  placeholder="Environment Name"
+                />
+                <button
+                  onClick={handleDeleteEnv}
+                  className="rounded text-xs text-[var(--color-error)] hover:underline"
+                >
+                  Delete Environment
+                </button>
+              </div>
+
+              <div className="flex-1 overflow-y-auto p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="font-bold text-sm text-[var(--color-text)]">Variables</span>
+                  <button
+                    onClick={handleAddVar}
+                    className="text-xs text-[var(--color-accent)] hover:underline"
+                  >
+                    + Add Variable
+                  </button>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  {Object.entries(activeEnv.variables).map(([key, value]) => (
+                    <div key={key} className="flex items-center gap-2">
+                      <Input
+                        value={key}
+                        onChange={(e) => handleUpdateVar(key, e.target.value, value)}
+                        placeholder="Variable name"
+                        size="md"
+                        className="w-1/3 font-mono"
+                      />
+                      <span className="text-[var(--color-text-muted)]">=</span>
+                      <Input
+                        value={value}
+                        onChange={(e) => handleUpdateVar(key, key, e.target.value)}
+                        placeholder="Value"
+                        size="md"
+                        className="flex-1 font-mono"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteVar(key)}
+                        aria-label={`Delete ${key} variable`}
+                        className="inline-flex min-h-8 min-w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-error)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+                      >
+                        <XIcon size={16} aria-hidden="true" />
+                      </button>
+                    </div>
+                  ))}
+                  {Object.keys(activeEnv.variables).length === 0 && (
+                    <div className="text-center text-xs text-[var(--color-text-muted)] py-4">
+                      No variables defined. Add one (e.g., baseUrl, token).
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)]">
+              Select or create an environment
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </Dialog>
   )
 }

--- a/apps/cockpit/src/tools/api-client/components/SaveRequestModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/SaveRequestModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
+import { Dialog } from '@/components/shared/Dialog'
 import { Input } from '@/components/shared/Input'
 import type { ApiCollection } from '@/types/models'
 
@@ -27,9 +28,10 @@ export function SaveRequestModal({
   const [newColName, setNewColName] = useState('')
   const nameRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    nameRef.current?.focus()
-    nameRef.current?.select()
+  const handleOpenAutoFocus = useCallback((target: HTMLElement) => {
+    if (target === nameRef.current) {
+      nameRef.current.select()
+    }
   }, [])
 
   const isNewCol = collectionId === NEW_COLLECTION_SENTINEL
@@ -50,72 +52,19 @@ export function SaveRequestModal({
       e.preventDefault()
       handleSubmit()
     }
-    if (e.key === 'Escape') onClose()
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onKeyDown={handleKeyDown}
-    >
-      <div className="flex w-[420px] flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
-          <h2 className="font-mono text-sm text-[var(--color-text)]">
-            {mode === 'save-as' ? 'Save Request As' : 'Save Request'}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-          >
-            ✕
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="flex flex-col gap-4 p-4">
-          <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">
-              Request Name
-            </label>
-            <Input ref={nameRef} value={name} onChange={(e) => setName(e.target.value)} size="md" />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">Collection</label>
-            <select
-              value={collectionId}
-              onChange={(e) => setCollectionId(e.target.value)}
-              className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
-            >
-              <option value="">(Unassigned)</option>
-              {collections.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-              <option value={NEW_COLLECTION_SENTINEL}>+ New Collection…</option>
-            </select>
-          </div>
-
-          {isNewCol && (
-            <div className="flex flex-col gap-1">
-              <label className="font-mono text-xs text-[var(--color-text-muted)]">
-                New Collection Name
-              </label>
-              <Input
-                autoFocus
-                value={newColName}
-                onChange={(e) => setNewColName(e.target.value)}
-                placeholder="My Collection"
-                size="md"
-              />
-            </div>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="flex justify-end gap-2 border-t border-[var(--color-border)] px-4 py-3">
+    <Dialog
+      title={mode === 'save-as' ? 'Save Request As' : 'Save Request'}
+      onClose={onClose}
+      closeLabel="Close save request dialog"
+      initialFocusRef={nameRef}
+      onOpenAutoFocus={handleOpenAutoFocus}
+      className="w-[420px] max-w-[calc(100vw-2rem)]"
+      bodyClassName="p-0"
+      footer={
+        <>
           <Button variant="secondary" size="sm" onClick={onClose}>
             Cancel
           </Button>
@@ -127,8 +76,47 @@ export function SaveRequestModal({
           >
             {mode === 'save-as' ? 'Save As' : 'Save'}
           </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4 p-4" onKeyDown={handleKeyDown}>
+        <div className="flex flex-col gap-1">
+          <label className="font-mono text-xs text-[var(--color-text-muted)]">Request Name</label>
+          <Input ref={nameRef} value={name} onChange={(e) => setName(e.target.value)} size="md" />
         </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="font-mono text-xs text-[var(--color-text-muted)]">Collection</label>
+          <select
+            value={collectionId}
+            onChange={(e) => setCollectionId(e.target.value)}
+            className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+          >
+            <option value="">(Unassigned)</option>
+            {collections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+            <option value={NEW_COLLECTION_SENTINEL}>+ New Collection…</option>
+          </select>
+        </div>
+
+        {isNewCol && (
+          <div className="flex flex-col gap-1">
+            <label className="font-mono text-xs text-[var(--color-text-muted)]">
+              New Collection Name
+            </label>
+            <Input
+              autoFocus
+              value={newColName}
+              onChange={(e) => setNewColName(e.target.value)}
+              placeholder="My Collection"
+              size="md"
+            />
+          </div>
+        )}
       </div>
-    </div>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Summary
- Added a shared accessible dialog shell for cockpit modal surfaces.
- Migrated the API environment manager, save request modal, and keyboard shortcuts modal to shared dialog semantics.
- Added focus trapping, Escape/backdrop close behavior, focus restoration, labelled dialog titles, and larger labelled close/delete controls.

## Test plan
- [x] `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit`
- [x] `PATH="/opt/homebrew/bin:$PATH" bun run lint`
- [x] `PATH="/opt/homebrew/bin:$PATH" bun run clean-js`
- [x] `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`
- [x] Before-commit staged diff checks and local secret/architecture scans