### PR TITLE
fix(cockpit): stabilize Monaco cursor behavior

### DIFF
--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -65,8 +65,6 @@ const THEME_OPTIONS: { value: Theme; label: string }[] = [
 
 const KEYBINDING_OPTIONS: { value: AppSettings['editorKeybindingMode']; label: string }[] = [
   { value: 'standard', label: 'Standard' },
-  { value: 'vim', label: 'Vim' },
-  { value: 'emacs', label: 'Emacs' },
 ]
 
 const EDITOR_THEME_OPTIONS: { value: AppSettings['editorTheme']; label: string }[] = [
@@ -394,7 +392,7 @@ function EditorTab() {
           options={EDITOR_THEME_OPTIONS}
         />
       </SettingRow>
-      <SettingRow label="Keybinding Mode" hint="Keyboard shortcuts style">
+      <SettingRow label="Keybinding Mode" hint="Monaco standard shortcuts">
         <SelectInput
           value={editorKeybindingMode}
           onChange={(v) =>
@@ -469,11 +467,7 @@ function DataTab() {
       'cyber-luxe',
       'soft-focus',
     ])
-    const validKeybindings = new Set<AppSettings['editorKeybindingMode']>([
-      'standard',
-      'vim',
-      'emacs',
-    ])
+    const validKeybindings = new Set<AppSettings['editorKeybindingMode']>(['standard'])
     const validGroups = new Set<AppSettings['collapsedSidebarGroups'][number]>([
       'code',
       'data',

--- a/apps/cockpit/src/components/shell/Workspace.tsx
+++ b/apps/cockpit/src/components/shell/Workspace.tsx
@@ -7,9 +7,30 @@ import { dispatchToolAction } from '@/lib/tool-actions'
 import { ToolboxIcon } from '@phosphor-icons/react'
 import { WorkspaceTabStrip } from '@/components/shell/WorkspaceTabStrip'
 
+const MONACO_TOOL_IDS = new Set([
+  'api-client',
+  'code-formatter',
+  'css-to-tailwind',
+  'css-validator',
+  'csv-tools',
+  'curl-to-fetch',
+  'diff-viewer',
+  'html-validator',
+  'json-schema-validator',
+  'json-tools',
+  'markdown-editor',
+  'mermaid-editor',
+  'refactoring-toolkit',
+  'snippets',
+  'ts-playground',
+  'xml-tools',
+  'yaml-tools',
+])
+
 export function Workspace() {
   const activeTool = useUiStore((s) => s.activeTool)
   const tool = getToolById(activeTool)
+  const usesMonaco = MONACO_TOOL_IDS.has(activeTool)
   const addToast = useUiStore((s) => s.addToast)
   const errorBoundaryRef = useRef<ErrorBoundary>(null)
 
@@ -46,7 +67,11 @@ export function Workspace() {
           </div>
         </div>
       ) : (
-        <div className="min-h-0 flex-1 overflow-hidden bg-[var(--color-bg)]">
+        <div
+          className={`min-h-0 flex-1 bg-[var(--color-bg)] ${
+            usesMonaco ? 'overflow-hidden' : 'overflow-auto'
+          }`}
+        >
           <ErrorBoundary ref={errorBoundaryRef}>
             <Suspense
               fallback={

--- a/apps/cockpit/src/components/shell/Workspace.tsx
+++ b/apps/cockpit/src/components/shell/Workspace.tsx
@@ -46,7 +46,7 @@ export function Workspace() {
           </div>
         </div>
       ) : (
-        <div className="flex-1 overflow-auto bg-[var(--color-bg)]">
+        <div className="min-h-0 flex-1 overflow-hidden bg-[var(--color-bg)]">
           <ErrorBoundary ref={errorBoundaryRef}>
             <Suspense
               fallback={

--- a/apps/cockpit/src/components/shell/__tests__/Workspace.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/Workspace.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Workspace } from '@/components/shell/Workspace'
+import { useUiStore } from '@/stores/ui.store'
+
+vi.mock('@/lib/db', () => ({
+  setSetting: vi.fn().mockResolvedValue(undefined),
+  getSetting: vi.fn(),
+}))
+
+vi.mock('@/hooks/useFileDropZone', () => ({
+  useFileDropZone: () => ({ isDragging: false }),
+}))
+
+vi.mock('@/components/shell/WorkspaceTabStrip', () => ({
+  WorkspaceTabStrip: () => <div data-testid="workspace-tabs" />,
+}))
+
+vi.mock('@/app/tool-registry', () => ({
+  getToolById: (id: string) => {
+    if (!id) return undefined
+    function MockTool() {
+      return <div data-testid={`tool-${id}`} />
+    }
+    return {
+      id,
+      name: id,
+      icon: '•',
+      description: '',
+      component: MockTool,
+    }
+  },
+}))
+
+beforeEach(() => {
+  cleanup()
+  useUiStore.setState({ tabs: [], activeTabId: null, activeTool: '' })
+  vi.clearAllMocks()
+})
+
+describe('Workspace overflow behavior', () => {
+  it('bounds Monaco tools so editor hit testing does not depend on workspace scrolling', () => {
+    useUiStore.setState({ activeTool: 'json-tools' })
+
+    render(<Workspace />)
+
+    const host = screen.getByTestId('tool-json-tools').parentElement
+    expect(host?.className).toContain('overflow-hidden')
+    expect(host?.className).not.toContain('overflow-auto')
+  })
+
+  it('keeps a scroll fallback for tools that do not embed Monaco', () => {
+    useUiStore.setState({ activeTool: 'hash-generator' })
+
+    render(<Workspace />)
+
+    const host = screen.getByTestId('tool-hash-generator').parentElement
+    expect(host?.className).toContain('overflow-auto')
+    expect(host?.className).not.toContain('overflow-hidden')
+  })
+})

--- a/apps/cockpit/src/hooks/useMonaco.ts
+++ b/apps/cockpit/src/hooks/useMonaco.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme } from '@/lib/theme'
 import { loader } from '@monaco-editor/react'
@@ -65,6 +65,7 @@ const LIGHT_THEME: MonacoThemeData = {
 }
 
 let themesRegistered = false
+const EMPTY_OVERRIDES: Record<string, unknown> = {}
 
 /** Convert an rgb()/rgba() string returned by getComputedStyle to a Monaco-compatible hex */
 function rgbToMonacoHex(rgb: string): string {
@@ -134,7 +135,9 @@ export function useMonacoSettings() {
   const resolvedTheme = resolveMonacoTheme(effective, editorTheme)
 
   useEffect(() => {
-    loader.init().then((monaco) => {
+    let cancelled = false
+
+    loader.init().then(async (monaco) => {
       if (!themesRegistered) {
         monaco.editor.defineTheme('cockpit-dark', DARK_THEME)
         monaco.editor.defineTheme('cockpit-light', LIGHT_THEME)
@@ -152,8 +155,22 @@ export function useMonacoSettings() {
       }
 
       monaco.editor.setTheme(resolvedTheme)
+
+      try {
+        await document.fonts?.ready
+      } catch {
+        // Font readiness can reject in constrained webview environments. Monaco still
+        // falls back to its current measurements in that case.
+      }
+
+      if (!cancelled && typeof monaco.editor.remeasureFonts === 'function') {
+        monaco.editor.remeasureFonts()
+      }
     })
-  }, [resolvedTheme, effective])
+    return () => {
+      cancelled = true
+    }
+  }, [resolvedTheme, effective, editorFont])
 
   return {
     theme: resolvedTheme,
@@ -169,24 +186,27 @@ export function useMonacoTheme(): string {
   return theme
 }
 
-export function useMonacoOptions(overrides: Record<string, unknown> = {}) {
+export function useMonacoOptions(overrides: Record<string, unknown> = EMPTY_OVERRIDES) {
   const settings = useMonacoSettings()
 
-  return {
-    ...EDITOR_OPTIONS,
-    fontSize: settings.fontSize,
-    fontFamily: settings.fontFamily,
-    tabSize: settings.tabSize,
-    formatOnPaste: settings.formatOnPaste,
-    ...overrides,
-  }
+  return useMemo(
+    () => ({
+      ...EDITOR_OPTIONS,
+      fontSize: settings.fontSize,
+      fontFamily: settings.fontFamily,
+      lineHeight: Math.max(20, Math.ceil(settings.fontSize * 1.5)),
+      tabSize: settings.tabSize,
+      formatOnPaste: settings.formatOnPaste,
+      ...overrides,
+    }),
+    [settings.fontSize, settings.fontFamily, settings.tabSize, settings.formatOnPaste, overrides]
+  )
 }
 
 /**
  * Base Monaco editor options shared across all tools.
  */
 export const EDITOR_OPTIONS = {
-  lineHeight: 20,
   minimap: { enabled: false },
   scrollBeyondLastLine: false,
   automaticLayout: true,

--- a/apps/cockpit/src/stores/settings.store.ts
+++ b/apps/cockpit/src/stores/settings.store.ts
@@ -24,6 +24,7 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => ({
       initPromise = (async () => {
         const saved = await getSetting<Partial<AppSettings>>('appSettings', {})
         const merged = { ...DEFAULT_SETTINGS, ...saved }
+        if (merged.editorKeybindingMode !== 'standard') merged.editorKeybindingMode = 'standard'
         set({ ...merged, initialized: true })
         applyTheme(merged.theme)
       })()

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -880,7 +880,7 @@ export default function ApiClient() {
                       options={{ ...monacoOptions, readOnly: true }}
                     />
                   ) : (
-                    <div className="p-3">
+                    <div className="h-full overflow-auto p-3">
                       {Object.entries(response.headers).map(([key, value]) => (
                         <div key={key} className="mb-1 flex items-start gap-1 text-xs">
                           <span className="shrink-0 font-bold text-[var(--color-accent)]">

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -688,9 +688,9 @@ export default function ApiClient() {
           </Button>
         </div>
 
-        <div className="flex flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* ── Request panel ─────────────────────────────────── */}
-          <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+          <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
             <TabBar tabs={REQUEST_TABS} activeTab={requestTab} onTabChange={setRequestTab} />
 
             {/* Params tab */}
@@ -800,7 +800,7 @@ export default function ApiClient() {
 
             {/* Body tab */}
             {requestTab === 'body' && (
-              <div className="flex flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-1">
                   {BODY_MODES.map((mode) => (
                     <button
@@ -822,7 +822,7 @@ export default function ApiClient() {
                   )}
                 </div>
                 {showBody ? (
-                  <div className="flex-1">
+                  <div className="min-h-0 flex-1 overflow-hidden">
                     <Editor
                       theme={monacoTheme}
                       language={bodyEditorLang}
@@ -843,7 +843,7 @@ export default function ApiClient() {
           </div>
 
           {/* ── Response panel ────────────────────────────────── */}
-          <div className="flex w-1/2 flex-col">
+          <div className="flex min-h-0 w-1/2 flex-col overflow-hidden">
             {error && (
               <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-xs text-[var(--color-error)]">
                 {error}
@@ -870,7 +870,7 @@ export default function ApiClient() {
                   </div>
                 </div>
                 <TabBar tabs={RESPONSE_TABS} activeTab={responseTab} onTabChange={setResponseTab} />
-                <div className="flex-1 overflow-auto">
+                <div className="min-h-0 flex-1 overflow-hidden">
                   {responseTab === 'body' ? (
                     <Editor
                       theme={monacoTheme}

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -155,7 +155,7 @@ export default function CodeFormatter() {
           {error}
         </Alert>
       )}
-      <div className="flex-1">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={monacoTheme}
           language={state.language}

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -330,11 +330,11 @@ export default function CssToTailwind() {
   return (
     <div className="flex h-full flex-col">
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+        <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
             CSS Input
           </div>
-          <div className="flex-1">
+          <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
               theme={monacoTheme}
               language="css"

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -422,7 +422,10 @@ function formatCssString(css: string) {
     .replace(/\s*,\s*/g, ', ')
     .trim()
 
-  const lines = compact.split(/\n/).map((line) => line.trim()).filter(Boolean)
+  const lines = compact
+    .split(/\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
   let indent = 0
   let output = ''
 
@@ -533,10 +536,7 @@ function analyzeCss(css: string, disabledRules: string[]) {
           })
         }
 
-        if (
-          isRuleEnabled('deprecated', disabledRules) &&
-          DEPRECATED_PROPERTIES.has(normalized)
-        ) {
+        if (isRuleEnabled('deprecated', disabledRules) && DEPRECATED_PROPERTIES.has(normalized)) {
           issues.push({
             message: `Deprecated CSS property "${property}".`,
             line: declLoc.line,
@@ -560,10 +560,7 @@ function analyzeCss(css: string, disabledRules: string[]) {
           })
         }
 
-        if (
-          isRuleEnabled('zero-units', disabledRules) &&
-          LENGTH_PROPERTIES.has(normalized)
-        ) {
+        if (isRuleEnabled('zero-units', disabledRules) && LENGTH_PROPERTIES.has(normalized)) {
           cssTree.walk(declaration.value, {
             visit: 'Number',
             enter(node) {
@@ -757,8 +754,7 @@ export default function CssValidator() {
           isWholeLine: true,
           linesDecorationsClassName:
             issue.type === 'error' ? 'css-error-line-gutter' : 'css-warning-line-gutter',
-          inlineClassName:
-            issue.type === 'error' ? 'css-error-inline' : 'css-warning-inline',
+          inlineClassName: issue.type === 'error' ? 'css-error-inline' : 'css-warning-inline',
           hoverMessage: { value: issue.message },
         },
       }
@@ -766,7 +762,7 @@ export default function CssValidator() {
 
     decorationIdsRef.current = editorRef.current.deltaDecorations(
       decorationIdsRef.current,
-      decorations,
+      decorations
     )
   }, [issues])
 
@@ -848,9 +844,15 @@ export default function CssValidator() {
 
       {stats && (
         <div className="flex flex-wrap items-center gap-4 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-1 text-xs text-[var(--color-text-muted)]">
-          <span>{stats.rules} rule{stats.rules !== 1 ? 's' : ''}</span>
-          <span>{stats.selectors} selector{stats.selectors !== 1 ? 's' : ''}</span>
-          <span>{stats.declarations} declaration{stats.declarations !== 1 ? 's' : ''}</span>
+          <span>
+            {stats.rules} rule{stats.rules !== 1 ? 's' : ''}
+          </span>
+          <span>
+            {stats.selectors} selector{stats.selectors !== 1 ? 's' : ''}
+          </span>
+          <span>
+            {stats.declarations} declaration{stats.declarations !== 1 ? 's' : ''}
+          </span>
           {stats.idSelectors > 0 && (
             <span className="text-[var(--color-warning)]">
               {stats.idSelectors} ID selector{stats.idSelectors !== 1 ? 's' : ''}
@@ -870,7 +872,10 @@ export default function CssValidator() {
                 {LINT_RULES.filter((rule) => rule.category === category).map((rule) => {
                   const disabled = state.disabledRules.includes(rule.id)
                   return (
-                    <label key={rule.id} className="flex cursor-pointer items-center gap-2 py-0.5 text-xs">
+                    <label
+                      key={rule.id}
+                      className="flex cursor-pointer items-center gap-2 py-0.5 text-xs"
+                    >
                       <input
                         type="checkbox"
                         checked={!disabled}
@@ -878,10 +883,18 @@ export default function CssValidator() {
                         className="accent-[var(--color-accent)]"
                       />
                       <div>
-                        <div className={disabled ? 'text-[var(--color-text-muted)] line-through' : 'text-[var(--color-text)]'}>
+                        <div
+                          className={
+                            disabled
+                              ? 'text-[var(--color-text-muted)] line-through'
+                              : 'text-[var(--color-text)]'
+                          }
+                        >
                           {rule.label}
                         </div>
-                        <div className="text-[10px] text-[var(--color-text-muted)]">{rule.description}</div>
+                        <div className="text-[10px] text-[var(--color-text-muted)]">
+                          {rule.description}
+                        </div>
                       </div>
                     </label>
                   )
@@ -898,9 +911,7 @@ export default function CssValidator() {
             <div
               key={`${issue.rule}-${index}`}
               className={`flex flex-wrap items-start gap-2 py-1 text-xs ${
-                issue.type === 'error'
-                  ? 'text-[var(--color-error)]'
-                  : 'text-[var(--color-warning)]'
+                issue.type === 'error' ? 'text-[var(--color-error)]' : 'text-[var(--color-warning)]'
               }`}
             >
               <span className="shrink-0 rounded bg-[var(--color-surface-hover)] px-1 py-0 text-[10px] text-[var(--color-text-muted)]">
@@ -915,7 +926,7 @@ export default function CssValidator() {
         </div>
       )}
 
-      <div className="flex-1 min-h-0">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={monacoTheme}
           language="css"

--- a/apps/cockpit/src/tools/csv-tools/CsvConvert.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvConvert.tsx
@@ -84,7 +84,7 @@ export default function CsvConvert({
       </div>
 
       {/* Output */}
-      <div className="flex-1">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={monacoTheme}
           language="json"

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -161,7 +161,7 @@ export default function CsvTools() {
         {/* Input editor — always visible as left pane when there's content, or full width for empty state */}
         {state.input.trim() ? (
           <>
-            <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+            <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
               <Editor
                 theme={monacoTheme}
                 language="plaintext"
@@ -185,7 +185,7 @@ export default function CsvTools() {
             </div>
           </>
         ) : (
-          <div className="flex-1">
+          <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
               theme={monacoTheme}
               language="plaintext"

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -346,7 +346,7 @@ export default function CurlToFetch() {
             <CopyButton text={output} className="mr-2" />
           </div>
           {parsed ? (
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language="javascript"

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -295,12 +295,12 @@ export default function DiffViewer() {
           }}
         />
       ) : (
-        <div className="flex flex-1 gap-px bg-[var(--color-border)]">
-          <div className="flex flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 gap-px overflow-hidden bg-[var(--color-border)]">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
               Left (original)
             </div>
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language={state.language}
@@ -310,11 +310,11 @@ export default function DiffViewer() {
               />
             </div>
           </div>
-          <div className="flex flex-1 flex-col">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
               Right (modified)
             </div>
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language={state.language}

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -513,9 +513,9 @@ export default function HtmlValidator() {
       <div className="flex flex-1 overflow-hidden">
         {showEditor && (
           <div
-            className={`flex flex-col ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'}`}
+            className={`flex min-h-0 flex-col overflow-hidden ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'}`}
           >
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language="html"

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -415,12 +415,12 @@ export default function JsonSchemaValidator() {
 
       {/* Editors */}
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+        <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
           <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
             <span className="text-xs text-[var(--color-text-muted)]">JSON Data</span>
             <CopyButton text={state.data} />
           </div>
-          <div className="flex-1">
+          <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
               theme={monacoTheme}
               language="json"
@@ -430,7 +430,7 @@ export default function JsonSchemaValidator() {
             />
           </div>
         </div>
-        <div className="flex w-1/2 flex-col">
+        <div className="flex min-h-0 w-1/2 flex-col overflow-hidden">
           <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
             <span className="text-xs text-[var(--color-text-muted)]">JSON Schema</span>
             <div className="flex items-center gap-2">
@@ -452,7 +452,7 @@ export default function JsonSchemaValidator() {
               <CopyButton text={state.schema} />
             </div>
           </div>
-          <div className="flex-1">
+          <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
               theme={monacoTheme}
               language="json"

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -254,7 +254,7 @@ export default function JsonTools() {
             )}
 
             {/* Editor */}
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language="json"

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -690,6 +690,7 @@ export default function MarkdownEditor() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!e.metaKey && !e.ctrlKey) return
+      if (!editorRef.current?.hasTextFocus()) return
       if (e.key === 'b') {
         e.preventDefault()
         insertFormatting('**', '**', 'bold text')
@@ -941,7 +942,7 @@ export default function MarkdownEditor() {
         {showEditor && (
           <div
             ref={editorContainerRef}
-            className={`relative h-full ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'}`}
+            className={`relative h-full min-h-0 overflow-hidden ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'}`}
           >
             <Editor
               theme={monacoTheme}

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -462,7 +462,7 @@ export default function MermaidEditor() {
         {/* Editor */}
         {showEditor && (
           <div
-            className={`${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'} h-full`}
+            className={`min-h-0 overflow-hidden ${showPreview ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'} h-full`}
           >
             <Editor
               theme={monacoTheme}

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -207,7 +207,7 @@ export default function RefactoringToolkit() {
         </div>
 
         {/* Editor area */}
-        <div className="flex-1 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-hidden">
           {preview !== null && !noChanges ? (
             <DiffEditor
               original={state.input}

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -806,7 +806,7 @@ export default function SnippetsManager() {
             </div>
 
             {/* Monaco editor */}
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language={selected.language}

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -132,7 +132,7 @@ export default function TsPlayground() {
         </div>
       )}
       <div className="flex flex-1 overflow-hidden">
-        <div className="w-1/2 border-r border-[var(--color-border)]">
+        <div className="min-h-0 w-1/2 overflow-hidden border-r border-[var(--color-border)]">
           <Editor
             theme={monacoTheme}
             language="typescript"
@@ -141,7 +141,7 @@ export default function TsPlayground() {
             options={monacoOptions}
           />
         </div>
-        <div className="w-1/2">
+        <div className="min-h-0 w-1/2 overflow-hidden">
           <Editor
             theme={monacoTheme}
             language="javascript"

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -338,7 +338,7 @@ export default function XmlTools() {
                 <pre className="whitespace-pre-wrap">{error}</pre>
               </Alert>
             )}
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language="xml"
@@ -386,7 +386,7 @@ export default function XmlTools() {
                 {jsonError}
               </Alert>
             )}
-            <div className="flex-1 overflow-auto">
+            <div className="min-h-0 flex-1 overflow-hidden">
               {jsonOutput ? (
                 <Editor
                   theme={monacoTheme}

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -242,7 +242,7 @@ export default function YamlTools() {
                 {error}
               </Alert>
             )}
-            <div className="flex-1">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <Editor
                 theme={monacoTheme}
                 language="yaml"
@@ -324,13 +324,13 @@ export default function YamlTools() {
               </Alert>
             )}
             <div className="flex flex-1 overflow-hidden">
-              <div className="flex flex-1 flex-col border-r border-[var(--color-border)]">
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-r border-[var(--color-border)]">
                 <div className="border-b border-[var(--color-border)] px-4 py-1">
                   <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
                     {convertDirection === 'yaml-to-json' ? 'YAML Input' : 'JSON Input'}
                   </span>
                 </div>
-                <div className="flex-1">
+                <div className="min-h-0 flex-1 overflow-hidden">
                   {convertDirection === 'yaml-to-json' ? (
                     <Editor
                       theme={monacoTheme}
@@ -350,13 +350,13 @@ export default function YamlTools() {
                   )}
                 </div>
               </div>
-              <div className="flex flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                 <div className="border-b border-[var(--color-border)] px-4 py-1">
                   <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
                     {convertDirection === 'yaml-to-json' ? 'JSON Output' : 'YAML Output'}
                   </span>
                 </div>
-                <div className="flex-1">
+                <div className="min-h-0 flex-1 overflow-hidden">
                   <Editor
                     theme={monacoTheme}
                     language={convertDirection === 'yaml-to-json' ? 'json' : 'yaml'}


### PR DESCRIPTION
## Summary
- Remeasure Monaco fonts after web fonts settle so Windows caret positioning uses final font metrics.
- Derive Monaco line height from the configured editor font size and stabilize editor flex containers with bounded overflow.
- Remove unsupported Vim/Emacs keybinding choices and scope Markdown bold/italic shortcuts to the focused Monaco editor.

## Test plan
- [x] `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit`
- [x] `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`
- [x] `PATH="/opt/homebrew/bin:$PATH" bun run lint`