### PR TITLE
fix(cockpit): improve tool UI consistency

### DIFF
--- a/apps/cockpit/src/tools/__tests__/api-client.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/api-client.test.tsx
@@ -1,9 +1,25 @@
-import { describe, expect, it } from 'vitest'
-import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
+import { useApiStore } from '@/stores/api.store'
 import ApiClient from '../api-client/ApiClient'
+import { CollectionsSidebar } from '../api-client/components/CollectionsSidebar'
+
+vi.mock('@tauri-apps/plugin-http', () => ({
+  fetch: vi.fn(async () => new Response('ok', { status: 200, statusText: 'OK' })),
+}))
 
 describe('ApiClient', () => {
+  beforeEach(() => {
+    useApiStore.setState({
+      environments: [],
+      collections: [],
+      requests: [],
+      activeEnvironmentId: null,
+      requestHistory: [],
+    })
+  })
+
   it('renders URL input', () => {
     renderTool(ApiClient)
     expect(screen.getByPlaceholderText(/\{\{baseUrl\}\}\/endpoint/i)).toBeInTheDocument()
@@ -29,5 +45,57 @@ describe('ApiClient', () => {
     expect(screen.getByText('Params')).toBeInTheDocument()
     expect(screen.getByText('Headers')).toBeInTheDocument()
     expect(screen.getByText('Body')).toBeInTheDocument()
+  })
+
+  it('starts with the response pane collapsed and lets users reveal it', () => {
+    renderTool(ApiClient)
+    const emptyResponse = screen.getByText('Send a request to see the response')
+
+    expect(screen.getByText('Show Response')).toBeInTheDocument()
+    expect(emptyResponse.parentElement).toHaveClass('hidden')
+
+    fireEvent.click(screen.getByText('Show Response'))
+
+    expect(screen.getByText('Hide Response')).toBeInTheDocument()
+    expect(emptyResponse.parentElement).not.toHaveClass('hidden')
+  })
+
+  it('keeps the response pane hidden during requests after the user hides it', async () => {
+    renderTool(ApiClient)
+    const emptyResponse = screen.getByText('Send a request to see the response')
+    const responsePanel = emptyResponse.parentElement
+
+    fireEvent.click(screen.getByText('Show Response'))
+    fireEvent.click(screen.getByText('Hide Response'))
+    fireEvent.change(screen.getByPlaceholderText(/\{\{baseUrl\}\}\/endpoint/i), {
+      target: { value: 'https://example.com' },
+    })
+    fireEvent.click(screen.getByText('Send'))
+
+    await waitFor(() => expect(screen.getByText('Show Response')).toBeInTheDocument())
+    expect(responsePanel).toHaveClass('hidden')
+  })
+
+  it('renders saved request rows as selectable buttons', () => {
+    const request = {
+      id: 'req-1',
+      collectionId: null,
+      name: 'Get User',
+      method: 'GET',
+      url: 'https://example.com/user',
+      headers: [],
+      body: '',
+      bodyMode: 'none',
+      auth: { type: 'none' as const },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+    const onSelect = vi.fn()
+    useApiStore.setState({ requests: [request], requestHistory: [] })
+
+    render(<CollectionsSidebar activeRequestId={null} onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Get User' }))
+
+    expect(onSelect).toHaveBeenCalledWith(request)
   })
 })

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import MarkdownEditor from '../markdown-editor/MarkdownEditor'
+import { MarkdownPreview } from '../markdown-editor/MarkdownPreview'
 import { LinkModal } from '../markdown-editor/modals/LinkModal'
 import { CodeBlockModal } from '../markdown-editor/modals/CodeBlockModal'
 import { TableModal } from '../markdown-editor/modals/TableModal'
@@ -74,6 +75,39 @@ describe('MarkdownEditor', () => {
     renderTool(MarkdownEditor)
     expect(screen.getByTitle('Link')).toBeInTheDocument()
     expect(screen.getByTitle('Image')).toBeInTheDocument()
+  })
+
+  it('scrolls duplicate TOC entries to the matching heading occurrence', () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView
+    let scrolledElement: Element | null = null
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: function scrollIntoView() {
+        scrolledElement = this
+      },
+    })
+
+    try {
+      render(
+        <MarkdownPreview
+          html="<h2>Repeat</h2><p>First</p><h2>Repeat</h2><p>Second</p>"
+          showToc
+          toc={[
+            { level: 2, text: 'Repeat', id: 'repeat' },
+            { level: 2, text: 'Repeat', id: 'repeat-2' },
+          ]}
+        />
+      )
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Repeat' })[1]!)
+
+      expect(scrolledElement).toBe(document.querySelectorAll('h2')[1])
+    } finally {
+      Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+    }
   })
 })
 

--- a/apps/cockpit/src/tools/__tests__/snippets.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/snippets.test.tsx
@@ -75,7 +75,10 @@ describe('SnippetsManager', () => {
     })
     renderTool(SnippetsManager)
     // Language pill shows uppercased shorthand without brackets
-    expect(screen.getByText('js')).toBeInTheDocument()
+    const languagePill = screen.getByText('js')
+    expect(languagePill).toBeInTheDocument()
+    expect(languagePill).toHaveClass('text-[var(--color-warning)]')
+    expect(languagePill).not.toHaveAttribute('style')
     expect(screen.queryByText('[JS]')).not.toBeInTheDocument()
   })
 
@@ -112,6 +115,8 @@ describe('SnippetsManager', () => {
 
     expect(item1).toHaveClass('bg-[var(--color-accent)]')
     expect(item1).toHaveClass('text-[var(--color-bg)]')
+    expect(screen.getByText('js')).toHaveClass('bg-[var(--color-bg)]')
+    expect(screen.getByText('js')).toHaveClass('text-[var(--color-accent)]')
   })
 
   it('shows the correct editor header with title and extension', () => {

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -183,9 +183,12 @@ export default function ApiClient() {
   const [showSaveModal, setShowSaveModal] = useState(false)
   const [showImportModal, setShowImportModal] = useState(false)
   const [saveMode, setSaveMode] = useState<'save' | 'save-as'>('save-as')
+  const [responseCollapsed, setResponseCollapsed] = useState(true)
+  const [responsePaneUserToggled, setResponsePaneUserToggled] = useState(false)
 
   const activeEnv = environments.find((e) => e.id === activeEnvironmentId)
   const envVars = useMemo(() => activeEnv?.variables ?? {}, [activeEnv])
+  const responseVisible = !responseCollapsed
 
   // ---------------------------------------------------------------------------
   // Query params
@@ -205,6 +208,15 @@ export default function ApiClient() {
       setParams(parseQueryParams(url))
     }
   }, [url])
+
+  useEffect(() => {
+    if (!responsePaneUserToggled && (loading || response || error)) setResponseCollapsed(false)
+  }, [loading, response, error, responsePaneUserToggled])
+
+  const toggleResponsePane = useCallback(() => {
+    setResponsePaneUserToggled(true)
+    setResponseCollapsed((collapsed) => !collapsed)
+  }, [])
 
   const handleResponseEditorMount: OnMount = useCallback((editor) => {
     setResponseEditor(editor)
@@ -686,11 +698,23 @@ export default function ApiClient() {
           <Button variant="primary" size="sm" onClick={handleSend} disabled={loading}>
             {loading ? 'Sending…' : 'Send'}
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleResponsePane}
+            aria-pressed={responseVisible}
+          >
+            {responseVisible ? 'Hide Response' : 'Show Response'}
+          </Button>
         </div>
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* ── Request panel ─────────────────────────────────── */}
-          <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
+          <div
+            className={`flex min-h-0 flex-col overflow-hidden ${
+              responseVisible ? 'w-1/2 border-r border-[var(--color-border)]' : 'w-full'
+            }`}
+          >
             <TabBar tabs={REQUEST_TABS} activeTab={requestTab} onTabChange={setRequestTab} />
 
             {/* Params tab */}
@@ -843,7 +867,9 @@ export default function ApiClient() {
           </div>
 
           {/* ── Response panel ────────────────────────────────── */}
-          <div className="flex min-h-0 w-1/2 flex-col overflow-hidden">
+          <div
+            className={`${responseVisible ? 'flex' : 'hidden'} min-h-0 w-1/2 flex-col overflow-hidden`}
+          >
             {error && (
               <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-xs text-[var(--color-error)]">
                 {error}

--- a/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
+++ b/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useApiStore } from '@/stores/api.store'
 import type { ApiCollection, ApiRequest } from '@/types/models'
+import { DotsThreeVerticalIcon } from '@phosphor-icons/react'
 
 type Props = {
   activeRequestId: string | null
@@ -371,27 +372,35 @@ type RequestRowProps = {
 function RequestRow({ req, isActive, onSelect, onContextMenu }: RequestRowProps) {
   return (
     <div
-      className={`group flex cursor-pointer items-center justify-between rounded px-2 py-1 text-xs ${
+      className={`group flex cursor-pointer items-center justify-between rounded text-xs ${
         isActive
           ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]'
           : 'text-[var(--color-text)] hover:bg-[var(--color-surface-hover)]'
       }`}
-      onClick={onSelect}
       onContextMenu={onContextMenu}
     >
-      <span className="truncate flex-1">{req.name}</span>
-      <span className={`ml-2 shrink-0 text-[8px] font-bold ${getMethodColor(req.method)}`}>
-        {req.method}
-      </span>
       <button
+        type="button"
+        className="flex min-w-0 flex-1 cursor-pointer items-center justify-between px-2 py-1 text-left outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent)]"
+        onClick={onSelect}
+        aria-label={req.name}
+        aria-current={isActive ? 'true' : undefined}
+      >
+        <span className="flex-1 truncate">{req.name}</span>
+        <span className={`ml-2 shrink-0 text-[8px] font-bold ${getMethodColor(req.method)}`}>
+          {req.method}
+        </span>
+      </button>
+      <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation()
           onContextMenu(e)
         }}
-        className="ml-1 hidden shrink-0 text-[var(--color-text-muted)] group-hover:block hover:text-[var(--color-text)]"
+        className="ml-1 hidden shrink-0 rounded p-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-text)] focus-visible:block focus-visible:ring-1 focus-visible:ring-[var(--color-accent)] group-hover:block group-focus-within:block"
         title="Options"
       >
-        ⋮
+        <DotsThreeVerticalIcon size={14} weight="bold" />
       </button>
     </div>
   )

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -3,6 +3,7 @@ import Editor, { type OnMount } from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
+import { Button } from '@/components/shared/Button'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { useDomSelectionToolbar } from '@/hooks/useDomSelectionToolbar'
@@ -14,6 +15,7 @@ import { LinkModal } from './modals/LinkModal'
 import { CodeBlockModal } from './modals/CodeBlockModal'
 import { ImageModal } from './modals/ImageModal'
 import { TableModal } from './modals/TableModal'
+import { nextHeadingId } from './heading-ids'
 import {
   ArrowsClockwiseIcon,
   CaretDownIcon,
@@ -414,15 +416,13 @@ const processor = unified()
 
 function extractToc(html: string): TocEntry[] {
   const entries: TocEntry[] = []
+  const headingCounts = new Map<string, number>()
   const re = /<h([1-6])[^>]*>(.*?)<\/h[1-6]>/gi
   let match
   while ((match = re.exec(html)) !== null) {
     const level = parseInt(match[1] as string, 10)
     const text = (match[2] as string).replace(/<[^>]+>/g, '')
-    const id = text
-      .toLowerCase()
-      .replace(/[^\w\s-]/g, '')
-      .replace(/\s+/g, '-')
+    const id = nextHeadingId(text, headingCounts)
     entries.push({ level, text, id })
   }
   return entries
@@ -814,23 +814,34 @@ export default function MarkdownEditor() {
           )}
 
           {toc.length > 0 && (
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => updateState({ showToc: !state.showToc })}
-              className={`text-xs transition-colors ${state.showToc ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}`}
+              className={
+                state.showToc ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''
+              }
               title="Table of Contents"
+              aria-pressed={state.showToc}
             >
               TOC
-            </button>
+            </Button>
           )}
 
           {/* Templates dropdown */}
           <div ref={templatesRef} className="relative">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setShowTemplates(!showTemplates)}
-              className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              className={
+                showTemplates ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''
+              }
+              aria-expanded={showTemplates}
+              aria-haspopup="menu"
             >
               Templates
-            </button>
+            </Button>
             {showTemplates && (
               <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
                 {TEMPLATES.map((t) => (
@@ -848,13 +859,17 @@ export default function MarkdownEditor() {
 
           {/* Export dropdown — consolidates Copy MD, Copy HTML, Download .md/.html, Print/PDF */}
           <div ref={exportRef} className="relative">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setShowExport(!showExport)}
-              className="flex items-center gap-0.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              className={`gap-1 ${showExport ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''}`}
+              aria-expanded={showExport}
+              aria-haspopup="menu"
             >
               Export
               <CaretDownIcon size={10} />
-            </button>
+            </Button>
             {showExport && (
               <div className="absolute right-0 top-full z-10 mt-1 min-w-[160px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
                 <button

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme } from '@/lib/theme'
+import { nextHeadingId } from './heading-ids'
 
 type TocEntry = {
   level: number
@@ -125,11 +126,9 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     function scrollToHeading(id: string) {
       if (!innerRef.current) return
       const headings = innerRef.current.querySelectorAll('h1, h2, h3, h4, h5, h6')
+      const headingCounts = new Map<string, number>()
       for (const h of headings) {
-        const hId = (h.textContent ?? '')
-          .toLowerCase()
-          .replace(/[^\w\s-]/g, '')
-          .replace(/\s+/g, '-')
+        const hId = nextHeadingId(h.textContent ?? '', headingCounts)
         if (hId === id) {
           h.scrollIntoView({ behavior: 'smooth', block: 'start' })
           break

--- a/apps/cockpit/src/tools/markdown-editor/heading-ids.ts
+++ b/apps/cockpit/src/tools/markdown-editor/heading-ids.ts
@@ -1,0 +1,16 @@
+export function slugifyHeading(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+
+  return slug || 'heading'
+}
+
+export function nextHeadingId(text: string, counts: Map<string, number>): string {
+  const slug = slugifyHeading(text)
+  const count = counts.get(slug) ?? 0
+  counts.set(slug, count + 1)
+  return count === 0 ? slug : `${slug}-${count + 1}`
+}

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -4,6 +4,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
 import { Alert } from '@/components/shared/Alert'
+import { Button } from '@/components/shared/Button'
 import { useUiStore } from '@/stores/ui.store'
 import { CaretDownIcon } from '@phosphor-icons/react'
 
@@ -345,13 +346,17 @@ export default function MermaidEditor() {
         <div className="ml-auto flex items-center gap-3 py-2">
           {/* Templates dropdown */}
           <div ref={templatesRef} className="relative">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setShowTemplates(!showTemplates)}
-              className="flex items-center gap-0.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              className={`gap-1 ${showTemplates ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''}`}
+              aria-expanded={showTemplates}
+              aria-haspopup="menu"
             >
               Templates
               <CaretDownIcon size={10} />
-            </button>
+            </Button>
             {showTemplates && (
               <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
                 {Object.keys(TEMPLATES).map((name) => (
@@ -372,13 +377,17 @@ export default function MermaidEditor() {
 
           {/* Export dropdown */}
           <div ref={exportRef} className="relative">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setShowExport(!showExport)}
-              className="flex items-center gap-0.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+              className={`gap-1 ${showExport ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''}`}
+              aria-expanded={showExport}
+              aria-haspopup="menu"
             >
               Export
               <CaretDownIcon size={10} />
-            </button>
+            </Button>
             {showExport && (
               <div className="absolute right-0 top-full z-10 mt-1 min-w-[180px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
                 <button

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -81,38 +81,47 @@ const LANG_EXTENSIONS: Record<string, string> = {
   text: 'txt',
 }
 
-// Per-language badge colours (bg + text as CSS colour values)
-type LangStyle = { bg: string; color: string }
-const LANG_STYLES: Record<string, LangStyle> = {
-  javascript: { bg: 'rgba(234,179,8,0.15)', color: '#ca8a04' },
-  typescript: { bg: 'rgba(96,165,250,0.15)', color: '#60a5fa' },
-  python: { bg: 'rgba(74,222,128,0.15)', color: '#4ade80' },
-  rust: { bg: 'rgba(251,146,60,0.15)', color: '#fb923c' },
-  go: { bg: 'rgba(34,211,238,0.15)', color: '#22d3ee' },
-  sql: { bg: 'rgba(167,139,250,0.15)', color: '#a78bfa' },
-  bash: { bg: 'rgba(74,222,128,0.18)', color: '#86efac' },
-  json: { bg: 'rgba(251,191,36,0.15)', color: '#fbbf24' },
-  css: { bg: 'rgba(249,115,22,0.15)', color: '#f97316' },
-  html: { bg: 'rgba(239,68,68,0.15)', color: '#f87171' },
-  markdown: { bg: 'rgba(148,163,184,0.15)', color: '#94a3b8' },
-  yaml: { bg: 'rgba(250,204,21,0.15)', color: '#facc15' },
-  dockerfile: { bg: 'rgba(56,189,248,0.15)', color: '#38bdf8' },
-  ruby: { bg: 'rgba(239,68,68,0.18)', color: '#fca5a5' },
-  php: { bg: 'rgba(139,92,246,0.15)', color: '#8b5cf6' },
-  java: { bg: 'rgba(249,115,22,0.18)', color: '#fdba74' },
-  kotlin: { bg: 'rgba(139,92,246,0.18)', color: '#c4b5fd' },
-  swift: { bg: 'rgba(249,115,22,0.15)', color: '#f97316' },
-  graphql: { bg: 'rgba(236,72,153,0.15)', color: '#ec4899' },
-  cpp: { bg: 'rgba(96,165,250,0.18)', color: '#93c5fd' },
-  csharp: { bg: 'rgba(139,92,246,0.15)', color: '#a78bfa' },
-  c: { bg: 'rgba(96,165,250,0.12)', color: '#7dd3fc' },
-  xml: { bg: 'rgba(148,163,184,0.15)', color: '#94a3b8' },
-  toml: { bg: 'rgba(251,191,36,0.12)', color: '#d97706' },
+type LangTone = 'accent' | 'success' | 'warning' | 'info' | 'error' | 'muted'
+
+const LANG_TONES: Record<string, LangTone> = {
+  javascript: 'warning',
+  typescript: 'info',
+  python: 'success',
+  rust: 'warning',
+  go: 'info',
+  sql: 'accent',
+  bash: 'success',
+  json: 'warning',
+  css: 'warning',
+  html: 'error',
+  markdown: 'muted',
+  yaml: 'warning',
+  dockerfile: 'info',
+  ruby: 'error',
+  php: 'accent',
+  java: 'warning',
+  kotlin: 'accent',
+  swift: 'warning',
+  graphql: 'accent',
+  cpp: 'info',
+  csharp: 'accent',
+  c: 'info',
+  xml: 'muted',
+  toml: 'warning',
 }
-const DEFAULT_LANG_STYLE: LangStyle = {
-  bg: 'var(--color-accent-dim)',
-  color: 'var(--color-accent)',
+
+const LANG_TONE_CLASSES: Record<LangTone, string> = {
+  accent: 'bg-[color-mix(in_oklab,var(--color-accent)_18%,transparent)] text-[var(--color-accent)]',
+  success:
+    'bg-[color-mix(in_oklab,var(--color-success)_18%,transparent)] text-[var(--color-success)]',
+  warning:
+    'bg-[color-mix(in_oklab,var(--color-warning)_18%,transparent)] text-[var(--color-warning)]',
+  info: 'bg-[color-mix(in_oklab,var(--color-info)_18%,transparent)] text-[var(--color-info)]',
+  error: 'bg-[color-mix(in_oklab,var(--color-error)_18%,transparent)] text-[var(--color-error)]',
+  muted: 'bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]',
 }
+
+const SELECTED_LANG_CLASS = 'bg-[var(--color-bg)] text-[var(--color-accent)]'
 
 type SortMode = 'updated' | 'created' | 'title' | 'language'
 
@@ -687,7 +696,7 @@ export default function SnippetsManager() {
           {filtered.map((snippet) => {
             const isSelected = selectedId === snippet.id
             const matches = isSelected ? undefined : matchMap.get(snippet.id)
-            const langStyle = LANG_STYLES[snippet.language] ?? DEFAULT_LANG_STYLE
+            const langTone = LANG_TONES[snippet.language] ?? 'accent'
             return (
               <button
                 key={snippet.id}
@@ -718,12 +727,9 @@ export default function SnippetsManager() {
                 <div className="flex items-center gap-2">
                   {/* Language pill */}
                   <span
-                    className="shrink-0 rounded px-1.5 py-0.5 text-[9px] font-bold uppercase"
-                    style={
-                      isSelected
-                        ? { backgroundColor: 'rgba(255,255,255,0.2)', color: 'var(--color-bg)' }
-                        : { backgroundColor: langStyle.bg, color: langStyle.color }
-                    }
+                    className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-bold uppercase ${
+                      isSelected ? SELECTED_LANG_CLASS : LANG_TONE_CLASSES[langTone]
+                    }`}
                   >
                     {LANG_EXTENSIONS[snippet.language] ?? snippet.language}
                   </span>


### PR DESCRIPTION
## Summary

- Fix Markdown preview TOC navigation for duplicate headings by sharing deterministic heading IDs between the TOC and preview scroll lookup.
- Improve API Client request row accessibility and make the response pane collapsible without overriding the user's toggle choice.
- Standardize Markdown and Mermaid header actions with shared button styling, and move snippet language pills onto semantic theme tokens.

## Test plan

- [x] `PATH=/opt/homebrew/bin:$PATH npx tsc --noEmit`
- [x] `PATH=/opt/homebrew/bin:$PATH bunx vitest run`
- [x] `PATH=/opt/homebrew/bin:$PATH bun run lint`
- [x] Before-commit secret scan
- [x] Before-commit architecture drift check