### PR TITLE
feat(cockpit): add notes drag reorder

### DIFF
--- a/apps/cockpit/src-tauri/migrations/008_notes_sort_order.sql
+++ b/apps/cockpit/src-tauri/migrations/008_notes_sort_order.sql
@@ -1,0 +1,5 @@
+ALTER TABLE notes ADD COLUMN sort_order REAL NOT NULL DEFAULT 0;
+
+UPDATE notes SET sort_order = -updated_at WHERE sort_order = 0;
+
+CREATE INDEX IF NOT EXISTS idx_notes_order ON notes(pinned, sort_order);

--- a/apps/cockpit/src-tauri/src/lib.rs
+++ b/apps/cockpit/src-tauri/src/lib.rs
@@ -55,6 +55,12 @@ pub fn run() {
             sql: include_str!("../migrations/007_prompt_template_authors.sql"),
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 8,
+            description: "add notes sort order",
+            sql: include_str!("../migrations/008_notes_sort_order.sql"),
+            kind: MigrationKind::Up,
+        },
     ];
 
     tauri::Builder::default()

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -16,6 +16,8 @@ import {
   TagIcon,
   XIcon,
   DotsSixVerticalIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
 } from '@phosphor-icons/react'
 import type { NoteColor, Note as NoteType } from '@/types/models'
 import { processMarkdown } from '@/lib/markdown'
@@ -398,6 +400,16 @@ export function NotesDrawer() {
     [clearNoteDragState, dragOverNote, draggedNoteId, reorderNotes, setLastAction]
   )
 
+  const moveNote = useCallback(
+    (source: NoteType, target: NoteType | undefined, position: DropPosition) => {
+      if (!target) return
+      void reorderNotes(source.id, target.id, position)
+        .then(() => setLastAction('Note moved', 'success'))
+        .catch(() => setLastAction('Failed to move note', 'error'))
+    },
+    [reorderNotes, setLastAction]
+  )
+
   const setPendingSendTo = useUiStore((s) => s.setPendingSendTo)
   const handleHistoryReplay = useCallback(
     (tool: string, input: string) => {
@@ -480,8 +492,10 @@ export function NotesDrawer() {
                   <span>{section.label}</span>
                   <span>{section.notes.length}</span>
                 </div>
-                {section.notes.map((note) => {
+                {section.notes.map((note, noteIndex) => {
                   const dragPlacement = dragOverNote?.id === note.id ? dragOverNote.position : null
+                  const previousNote = section.notes[noteIndex - 1]
+                  const nextNote = section.notes[noteIndex + 1]
                   return (
                     <div
                       key={note.id}
@@ -529,6 +543,32 @@ export function NotesDrawer() {
                                   {note.title || 'Untitled'}
                                 </span>
                                 <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      moveNote(note, previousNote, 'before')
+                                    }}
+                                    disabled={!canReorderNotes || !previousNote}
+                                    aria-label={`Move ${note.title || 'untitled note'} up`}
+                                    className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:pointer-events-none disabled:opacity-30"
+                                    title="Move up"
+                                  >
+                                    <ArrowUpIcon size={12} aria-hidden="true" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      moveNote(note, nextNote, 'after')
+                                    }}
+                                    disabled={!canReorderNotes || !nextNote}
+                                    aria-label={`Move ${note.title || 'untitled note'} down`}
+                                    className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:pointer-events-none disabled:opacity-30"
+                                    title="Move down"
+                                  >
+                                    <ArrowDownIcon size={12} aria-hidden="true" />
+                                  </button>
                                   <button
                                     type="button"
                                     onClick={(e) => {

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -15,12 +15,20 @@ import {
   PaperPlaneTiltIcon,
   TagIcon,
   XIcon,
+  DotsSixVerticalIcon,
 } from '@phosphor-icons/react'
 import type { NoteColor, Note as NoteType } from '@/types/models'
 import { processMarkdown } from '@/lib/markdown'
 
 const MIN_WIDTH = 200
 const MAX_WIDTH = 600
+
+type DropPosition = 'before' | 'after'
+
+type DragOverNote = {
+  id: string
+  position: DropPosition
+}
 
 function timeAgo(ts: number): string {
   const diff = Date.now() - ts
@@ -60,6 +68,7 @@ function noteCardStyle(color: NoteColor): CSSProperties {
   return {
     backgroundColor: `color-mix(in srgb, ${token} 10%, var(--color-surface))`,
     borderColor: `color-mix(in srgb, ${token} 28%, var(--color-border))`,
+    borderLeftColor: token,
   }
 }
 
@@ -270,6 +279,7 @@ export function NotesDrawer() {
   const notes = useNotesStore((s) => s.notes)
   const addNote = useNotesStore((s) => s.add)
   const updateNote = useNotesStore((s) => s.update)
+  const reorderNotes = useNotesStore((s) => s.reorder)
   const removeNote = useNotesStore((s) => s.remove)
   const historyEntries = useHistoryStore((s) => s.entries)
   const setActiveTool = useUiStore((s) => s.setActiveTool)
@@ -279,6 +289,9 @@ export function NotesDrawer() {
   const [search, setSearch] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [historyFilter, setHistoryFilter] = useState('')
+  const [draggedNoteId, setDraggedNoteId] = useState<string | null>(null)
+  const [dragOverNote, setDragOverNote] = useState<DragOverNote | null>(null)
+  const [fuseVersion, setFuseVersion] = useState(0)
 
   const fuseRef = useRef<Fuse<NoteType> | null>(null)
 
@@ -286,13 +299,29 @@ export function NotesDrawer() {
     if (!drawerOpen) return
     import('fuse.js').then(({ default: FuseClass }) => {
       fuseRef.current = new FuseClass(notes, { keys: ['title', 'content', 'tags'], threshold: 0.3 })
+      setFuseVersion((version) => version + 1)
     })
   }, [drawerOpen, notes])
 
+  const fuseReady = fuseVersion > 0
+
   const filteredNotes = useMemo(() => {
     if (!search.trim()) return notes
-    return fuseRef.current ? fuseRef.current.search(search).map((r) => r.item) : notes
-  }, [notes, search])
+    return fuseReady && fuseRef.current ? fuseRef.current.search(search).map((r) => r.item) : notes
+  }, [fuseReady, notes, search])
+
+  const noteSections = useMemo(() => {
+    if (search.trim()) {
+      return [{ id: 'results', label: 'Results', notes: filteredNotes }]
+    }
+
+    return [
+      { id: 'pinned', label: 'Pinned', notes: filteredNotes.filter((note) => note.pinned) },
+      { id: 'notes', label: 'Notes', notes: filteredNotes.filter((note) => !note.pinned) },
+    ].filter((section) => section.notes.length > 0)
+  }, [filteredNotes, search])
+
+  const canReorderNotes = !search.trim()
 
   const filteredHistory = useMemo(() => {
     if (!historyFilter) return historyEntries
@@ -319,6 +348,54 @@ export function NotesDrawer() {
       }
     },
     [removeNote, setLastAction]
+  )
+
+  const handleNoteDragStart = useCallback(
+    (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
+      if (!canReorderNotes || editingId === note.id) {
+        e.preventDefault()
+        return
+      }
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.setData('text/plain', note.id)
+      setDraggedNoteId(note.id)
+    },
+    [canReorderNotes, editingId]
+  )
+
+  const handleNoteDragOver = useCallback(
+    (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
+      if (!draggedNoteId || draggedNoteId === note.id) return
+      const dragged = notes.find((n) => n.id === draggedNoteId)
+      if (!dragged || dragged.pinned !== note.pinned) return
+
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+      const bounds = e.currentTarget.getBoundingClientRect()
+      const position: DropPosition = e.clientY < bounds.top + bounds.height / 2 ? 'before' : 'after'
+      setDragOverNote({ id: note.id, position })
+    },
+    [draggedNoteId, notes]
+  )
+
+  const clearNoteDragState = useCallback(() => {
+    setDraggedNoteId(null)
+    setDragOverNote(null)
+  }, [])
+
+  const handleNoteDrop = useCallback(
+    (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      const sourceId = draggedNoteId ?? e.dataTransfer.getData('text/plain')
+      const position = dragOverNote?.id === note.id ? dragOverNote.position : 'before'
+      clearNoteDragState()
+      if (!sourceId || sourceId === note.id) return
+
+      void reorderNotes(sourceId, note.id, position)
+        .then(() => setLastAction('Note moved', 'success'))
+        .catch(() => setLastAction('Failed to move note', 'error'))
+    },
+    [clearNoteDragState, dragOverNote, draggedNoteId, reorderNotes, setLastAction]
   )
 
   const setPendingSendTo = useUiStore((s) => s.setPendingSendTo)
@@ -352,12 +429,24 @@ export function NotesDrawer() {
       {activeTab === 'notes' && (
         <>
           <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search notes..."
-              className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
-            />
+            <div className="flex min-w-0 flex-1 items-center gap-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 focus-within:border-[var(--color-accent)]">
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search notes..."
+                className="min-w-0 flex-1 bg-transparent text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch('')}
+                  aria-label="Clear notes search"
+                  className="inline-flex min-h-5 min-w-5 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                >
+                  <XIcon size={11} aria-hidden="true" />
+                </button>
+              )}
+            </div>
             <button
               type="button"
               onClick={() => {
@@ -369,6 +458,14 @@ export function NotesDrawer() {
               +
             </button>
           </div>
+          <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-1.5 text-[10px] text-[var(--color-text-muted)]">
+            <span>
+              {search
+                ? `${filteredNotes.length} of ${notes.length} note${notes.length === 1 ? '' : 's'}`
+                : `${notes.length} note${notes.length === 1 ? '' : 's'}`}
+            </span>
+            {canReorderNotes && notes.length > 1 && <span>Drag notes to reorder</span>}
+          </div>
           <div className="flex-1 overflow-auto p-2">
             {filteredNotes.length === 0 && (
               <div className="flex flex-col items-center gap-2 p-6 text-center text-xs text-[var(--color-text-muted)]">
@@ -377,118 +474,157 @@ export function NotesDrawer() {
                 {!search && <span className="text-[10px] opacity-60">Click + to create one</span>}
               </div>
             )}
-            {filteredNotes.map((note) => (
-              <div
-                key={note.id}
-                className={`mb-3 rounded-lg border shadow-sm transition-colors duration-150 ${editingId === note.id ? 'ring-1 ring-[var(--color-accent)]' : ''}`}
-                style={noteCardStyle(note.color)}
-              >
-                <div className="p-3">
-                  {editingId === note.id ? (
-                    <NoteEditor
-                      note={note}
-                      onUpdate={updateNote}
-                      onDone={() => setEditingId(null)}
-                    />
-                  ) : (
-                    <div className="group cursor-pointer" onClick={() => setEditingId(note.id)}>
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="truncate text-xs font-bold text-[var(--color-text)]">
-                          {note.title || 'Untitled'}
-                        </span>
-                        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              navigator.clipboard
-                                .writeText(note.content)
-                                .then(() => setLastAction('Copied to clipboard', 'info'))
-                                .catch(() => setLastAction('Failed to copy note', 'error'))
-                            }}
-                            aria-label={`Copy ${note.title || 'untitled note'} content`}
-                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
-                            title="Copy content"
+            {noteSections.map((section) => (
+              <section key={section.id} className="mb-3">
+                <div className="mb-1 flex items-center justify-between px-1 text-[10px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+                  <span>{section.label}</span>
+                  <span>{section.notes.length}</span>
+                </div>
+                {section.notes.map((note) => {
+                  const dragPlacement = dragOverNote?.id === note.id ? dragOverNote.position : null
+                  return (
+                    <div
+                      key={note.id}
+                      data-testid={`note-card-${note.id}`}
+                      draggable={canReorderNotes && editingId !== note.id}
+                      onDragStart={(e) => handleNoteDragStart(note, e)}
+                      onDragOver={(e) => handleNoteDragOver(note, e)}
+                      onDrop={(e) => handleNoteDrop(note, e)}
+                      onDragEnd={clearNoteDragState}
+                      className={`mb-3 rounded-lg border border-l-4 shadow-sm transition-colors duration-150 ${
+                        editingId === note.id ? 'ring-1 ring-[var(--color-accent)]' : ''
+                      } ${draggedNoteId === note.id ? 'opacity-60' : ''} ${
+                        dragPlacement === 'before'
+                          ? 'border-t-2 border-t-[var(--color-accent)]'
+                          : ''
+                      } ${
+                        dragPlacement === 'after' ? 'border-b-2 border-b-[var(--color-accent)]' : ''
+                      }`}
+                      style={noteCardStyle(note.color)}
+                    >
+                      <div className="p-3">
+                        {editingId === note.id ? (
+                          <NoteEditor
+                            note={note}
+                            onUpdate={updateNote}
+                            onDone={() => setEditingId(null)}
+                          />
+                        ) : (
+                          <div
+                            className="group cursor-pointer"
+                            onClick={() => setEditingId(note.id)}
                           >
-                            <CopyIcon size={12} aria-hidden="true" />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setPendingSendTo(note.content)
-                              setLastAction('Ready to send to tool', 'info')
-                            }}
-                            aria-label={`Use ${note.title || 'untitled note'} as input`}
-                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
-                            title="Use as input"
-                          >
-                            <PaperPlaneTiltIcon size={12} aria-hidden="true" />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              void updateNote(note.id, { pinned: !note.pinned }).catch(() =>
-                                setLastAction('Failed to update note', 'error')
-                              )
-                            }}
-                            aria-label={`${note.pinned ? 'Unpin' : 'Pin'} ${note.title || 'untitled note'}`}
-                            aria-pressed={note.pinned}
-                            className={`inline-flex min-h-7 min-w-7 items-center justify-center rounded transition-colors duration-150 ${note.pinned ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'}`}
-                            title={note.pinned ? 'Unpin' : 'Pin'}
-                          >
-                            <PushPinIcon
-                              size={12}
-                              weight={note.pinned ? 'fill' : 'regular'}
-                              aria-hidden="true"
-                            />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              void handleDelete(note.id)
-                            }}
-                            aria-label={`Delete ${note.title || 'untitled note'}`}
-                            className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-error)]"
-                            title="Delete note"
-                          >
-                            <TrashIcon size={12} aria-hidden="true" />
-                          </button>
-                        </div>
-                      </div>
+                            <div className="flex items-center gap-1 text-[var(--color-text-muted)]">
+                              {canReorderNotes && (
+                                <span
+                                  aria-hidden="true"
+                                  className="inline-flex min-h-6 min-w-4 cursor-grab items-center justify-center rounded opacity-60 transition-opacity group-hover:opacity-100"
+                                  title="Drag to reorder"
+                                >
+                                  <DotsSixVerticalIcon size={13} />
+                                </span>
+                              )}
+                              <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                                <span className="truncate text-xs font-bold text-[var(--color-text)]">
+                                  {note.title || 'Untitled'}
+                                </span>
+                                <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      navigator.clipboard
+                                        .writeText(note.content)
+                                        .then(() => setLastAction('Copied to clipboard', 'info'))
+                                        .catch(() => setLastAction('Failed to copy note', 'error'))
+                                    }}
+                                    aria-label={`Copy ${note.title || 'untitled note'} content`}
+                                    className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
+                                    title="Copy content"
+                                  >
+                                    <CopyIcon size={12} aria-hidden="true" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      setPendingSendTo(note.content)
+                                      setLastAction('Ready to send to tool', 'info')
+                                    }}
+                                    aria-label={`Use ${note.title || 'untitled note'} as input`}
+                                    className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-accent-dim)] hover:text-[var(--color-accent)]"
+                                    title="Use as input"
+                                  >
+                                    <PaperPlaneTiltIcon size={12} aria-hidden="true" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      void updateNote(note.id, { pinned: !note.pinned }).catch(() =>
+                                        setLastAction('Failed to update note', 'error')
+                                      )
+                                    }}
+                                    aria-label={`${note.pinned ? 'Unpin' : 'Pin'} ${note.title || 'untitled note'}`}
+                                    aria-pressed={note.pinned}
+                                    className={`inline-flex min-h-7 min-w-7 items-center justify-center rounded transition-colors duration-150 ${note.pinned ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'}`}
+                                    title={note.pinned ? 'Unpin' : 'Pin'}
+                                  >
+                                    <PushPinIcon
+                                      size={12}
+                                      weight={note.pinned ? 'fill' : 'regular'}
+                                      aria-hidden="true"
+                                    />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation()
+                                      void handleDelete(note.id)
+                                    }}
+                                    aria-label={`Delete ${note.title || 'untitled note'}`}
+                                    className="inline-flex min-h-7 min-w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-error)]"
+                                    title="Delete note"
+                                  >
+                                    <TrashIcon size={12} aria-hidden="true" />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
 
-                      {note.content && (
-                        <div className="mt-2 line-clamp-6">
-                          <MarkdownRenderer content={note.content} />
-                        </div>
-                      )}
+                            {note.content && (
+                              <div className="mt-2 line-clamp-6">
+                                <MarkdownRenderer content={note.content} />
+                              </div>
+                            )}
 
-                      {note.tags.length > 0 && (
-                        <div className="mt-2 flex flex-wrap gap-1">
-                          {note.tags.map((tag) => (
-                            <span
-                              key={tag}
-                              className="flex items-center gap-0.5 rounded-full bg-[var(--color-text-muted)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]"
-                            >
-                              <TagIcon size={8} aria-hidden="true" />
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      )}
+                            {note.tags.length > 0 && (
+                              <div className="mt-2 flex flex-wrap gap-1">
+                                {note.tags.map((tag) => (
+                                  <span
+                                    key={tag}
+                                    className="flex items-center gap-0.5 rounded-full bg-[var(--color-text-muted)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-text-muted)]"
+                                  >
+                                    <TagIcon size={8} aria-hidden="true" />
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
 
-                      <div className="mt-2 flex items-center justify-between text-[10px] text-[var(--color-text-muted)]">
-                        <span>{timeAgo(note.updatedAt)}</span>
-                        {note.content.length > 0 && (
-                          <span>{note.content.split(/\s+/).length} words</span>
+                            <div className="mt-2 flex items-center justify-between text-[10px] text-[var(--color-text-muted)]">
+                              <span>{timeAgo(note.updatedAt)}</span>
+                              {note.content.length > 0 && (
+                                <span>{note.content.split(/\s+/).length} words</span>
+                              )}
+                            </div>
+                          </div>
                         )}
                       </div>
                     </div>
-                  )}
-                </div>
-              </div>
+                  )
+                })}
+              </section>
             ))}
           </div>
         </>

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -53,6 +53,8 @@ describe('NotesDrawer', () => {
     expect(screen.getByRole('button', { name: 'Use Test note as input' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Pin Test note' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Delete Test note' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move Test note up' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move Test note down' })).toBeInTheDocument()
     expect(screen.getByRole('separator', { name: 'Resize notes drawer' })).toHaveAttribute(
       'aria-orientation',
       'vertical'
@@ -120,5 +122,17 @@ describe('NotesDrawer', () => {
     fireEvent.drop(secondCard, { dataTransfer })
 
     expect(reorder).toHaveBeenCalledWith('note-1', 'note-2', 'after')
+  })
+
+  it('supports keyboard-accessible move controls', () => {
+    const reorder = vi.fn().mockResolvedValue(undefined)
+    useNotesStore.setState({ notes: [testNote, secondNote], reorder })
+    render(<NotesDrawer />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move Test note down' }))
+
+    expect(reorder).toHaveBeenCalledWith('note-1', 'note-2', 'after')
+    expect(screen.getByRole('button', { name: 'Move Test note up' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Move Second note down' })).toBeDisabled()
   })
 })

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NotesDrawer } from '@/components/shell/NotesDrawer'
 import { useHistoryStore } from '@/stores/history.store'
@@ -17,6 +17,16 @@ const testNote: Note = {
   createdAt: 1,
   updatedAt: 1,
   tags: ['api'],
+  sortOrder: 1024,
+}
+
+const secondNote: Note = {
+  ...testNote,
+  id: 'note-2',
+  title: 'Second note',
+  content: 'Second content',
+  tags: [],
+  sortOrder: 2048,
 }
 
 beforeEach(() => {
@@ -26,6 +36,7 @@ beforeEach(() => {
     notes: [testNote],
     initialized: true,
     update: vi.fn().mockResolvedValue(undefined),
+    reorder: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
   })
   useHistoryStore.setState({ entries: [] })
@@ -60,5 +71,54 @@ describe('NotesDrawer', () => {
     expect(blue).toHaveAttribute('aria-pressed', 'false')
     expect(yellow.className).toContain('min-h-6')
     expect(yellow.className).toContain('min-w-6')
+  })
+
+  it('shows search result counts and clears search input', async () => {
+    useNotesStore.setState({ notes: [testNote, secondNote] })
+    render(<NotesDrawer />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search notes...'), {
+      target: { value: 'Second' },
+    })
+
+    await waitFor(() => expect(screen.getByText('1 of 2 notes')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Clear notes search' }))
+    expect(screen.getByPlaceholderText('Search notes...')).toHaveValue('')
+  })
+
+  it('calls reorder when a note is dropped onto another note', () => {
+    const reorder = vi.fn().mockResolvedValue(undefined)
+    useNotesStore.setState({ notes: [testNote, secondNote], reorder })
+    render(<NotesDrawer />)
+
+    const data = new Map<string, string>()
+    const dataTransfer = {
+      effectAllowed: '',
+      dropEffect: '',
+      setData: vi.fn((type: string, value: string) => data.set(type, value)),
+      getData: vi.fn((type: string) => data.get(type) ?? ''),
+    }
+    const firstCard = screen.getByTestId('note-card-note-1')
+    const secondCard = screen.getByTestId('note-card-note-2')
+    Object.defineProperty(secondCard, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }),
+    })
+
+    fireEvent.dragStart(firstCard, { dataTransfer })
+    fireEvent.dragOver(secondCard, { dataTransfer, clientY: 80 })
+    fireEvent.drop(secondCard, { dataTransfer })
+
+    expect(reorder).toHaveBeenCalledWith('note-1', 'note-2', 'after')
   })
 })

--- a/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
@@ -44,6 +44,7 @@ beforeEach(() => {
         createdAt: 1,
         updatedAt: 1,
         tags: [],
+        sortOrder: 1024,
       },
     ],
     clearAll: vi.fn().mockResolvedValue(undefined),

--- a/apps/cockpit/src/lib/db.ts
+++ b/apps/cockpit/src/lib/db.ts
@@ -143,6 +143,24 @@ export async function saveNote(note: Note): Promise<void> {
   )
 }
 
+export async function saveNotesOrder(notes: Pick<Note, 'id' | 'sortOrder'>[]): Promise<void> {
+  if (notes.length === 0) return
+  const conn = await getDb()
+  await conn.execute('BEGIN IMMEDIATE')
+  try {
+    for (const note of notes) {
+      await conn.execute('UPDATE notes SET sort_order = $1 WHERE id = $2', [
+        note.sortOrder,
+        note.id,
+      ])
+    }
+    await conn.execute('COMMIT')
+  } catch (err) {
+    await conn.execute('ROLLBACK')
+    throw err
+  }
+}
+
 export async function deleteNote(id: string): Promise<void> {
   const conn = await getDb()
   await conn.execute('DELETE FROM notes WHERE id = $1', [id])

--- a/apps/cockpit/src/lib/db.ts
+++ b/apps/cockpit/src/lib/db.ts
@@ -98,6 +98,7 @@ type NoteRow = {
   created_at: number
   updated_at: number
   tags: string
+  sort_order: number
 }
 
 function rowToNote(row: NoteRow): Note | null {
@@ -112,7 +113,7 @@ function rowToNote(row: NoteRow): Note | null {
 export async function loadNotes(): Promise<Note[]> {
   const conn = await getDb()
   const rows = await conn.select<NoteRow[]>(
-    'SELECT * FROM notes ORDER BY pinned DESC, updated_at DESC'
+    'SELECT * FROM notes ORDER BY pinned DESC, sort_order ASC, updated_at DESC'
   )
   return rows.map(rowToNote).filter((n): n is Note => n !== null)
 }
@@ -120,9 +121,9 @@ export async function loadNotes(): Promise<Note[]> {
 export async function saveNote(note: Note): Promise<void> {
   const conn = await getDb()
   await conn.execute(
-    `INSERT INTO notes (id, title, content, color, pinned, popped_out, window_x, window_y, window_width, window_height, created_at, updated_at, tags)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-     ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, color=$4, pinned=$5, popped_out=$6, window_x=$7, window_y=$8, window_width=$9, window_height=$10, updated_at=$12, tags=$13`,
+    `INSERT INTO notes (id, title, content, color, pinned, popped_out, window_x, window_y, window_width, window_height, created_at, updated_at, tags, sort_order)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+     ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, color=$4, pinned=$5, popped_out=$6, window_x=$7, window_y=$8, window_width=$9, window_height=$10, updated_at=$12, tags=$13, sort_order=$14`,
     [
       note.id,
       note.title,
@@ -137,6 +138,7 @@ export async function saveNote(note: Note): Promise<void> {
       note.createdAt,
       note.updatedAt,
       JSON.stringify(note.tags || []),
+      note.sortOrder,
     ]
   )
 }

--- a/apps/cockpit/src/lib/schemas.ts
+++ b/apps/cockpit/src/lib/schemas.ts
@@ -66,6 +66,7 @@ export const noteRowSchema = z
     created_at: z.number(),
     updated_at: z.number(),
     tags: z.string().optional(),
+    sort_order: z.number().default(0),
   })
   .transform((row): Note => {
     const note: Note = {
@@ -86,6 +87,7 @@ export const noteRowSchema = z
           return []
         }
       })(),
+      sortOrder: row.sort_order,
     }
     if (
       row.window_x != null &&

--- a/apps/cockpit/src/stores/__tests__/notes.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/notes.store.test.ts
@@ -32,6 +32,7 @@ describe('notes store', () => {
     expect(note.content).toBe('Test content')
     expect(note.color).toBe('yellow')
     expect(note.tags).toEqual([])
+    expect(note.sortOrder).toBeLessThan(0)
     expect(note.id).toBeTruthy()
 
     const { notes } = useNotesStore.getState()
@@ -82,5 +83,19 @@ describe('notes store', () => {
     const { notes } = useNotesStore.getState()
     expect(notes).toHaveLength(0)
     expect(deleteNote).toHaveBeenCalledWith(note.id)
+  })
+
+  it('reorders notes within the same pin group', async () => {
+    const first = await useNotesStore.getState().add('First')
+    const second = await useNotesStore.getState().add('Second')
+    const third = await useNotesStore.getState().add('Third')
+    ;(saveNote as any).mockClear()
+
+    await useNotesStore.getState().reorder(first.id, third.id, 'before')
+
+    const { notes } = useNotesStore.getState()
+    expect(notes.map((note) => note.id)).toEqual([first.id, third.id, second.id])
+    expect(notes.map((note) => note.sortOrder)).toEqual([1024, 2048, 3072])
+    expect(saveNote).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/cockpit/src/stores/__tests__/notes.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/notes.store.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { useNotesStore } from '../notes.store'
-import { loadNotes, saveNote, deleteNote } from '@/lib/db'
+import { loadNotes, saveNote, saveNotesOrder, deleteNote } from '@/lib/db'
 
 vi.mock('@/lib/db', () => ({
   loadNotes: vi.fn(),
   saveNote: vi.fn(),
+  saveNotesOrder: vi.fn(),
   deleteNote: vi.fn(),
 }))
 
@@ -15,6 +16,7 @@ beforeEach(() => {
   // Instead, we test the store actions directly (add, update, remove)
   ;(loadNotes as any).mockResolvedValue([])
   ;(saveNote as any).mockResolvedValue(undefined)
+  ;(saveNotesOrder as any).mockResolvedValue(undefined)
   ;(deleteNote as any).mockResolvedValue(undefined)
 })
 
@@ -90,12 +92,18 @@ describe('notes store', () => {
     const second = await useNotesStore.getState().add('Second')
     const third = await useNotesStore.getState().add('Third')
     ;(saveNote as any).mockClear()
+    ;(saveNotesOrder as any).mockClear()
 
     await useNotesStore.getState().reorder(first.id, third.id, 'before')
 
     const { notes } = useNotesStore.getState()
     expect(notes.map((note) => note.id)).toEqual([first.id, third.id, second.id])
     expect(notes.map((note) => note.sortOrder)).toEqual([1024, 2048, 3072])
-    expect(saveNote).toHaveBeenCalledTimes(3)
+    expect(saveNotesOrder).toHaveBeenCalledWith([
+      { id: first.id, sortOrder: 1024 },
+      { id: third.id, sortOrder: 2048 },
+      { id: second.id, sortOrder: 3072 },
+    ])
+    expect(saveNote).not.toHaveBeenCalled()
   })
 })

--- a/apps/cockpit/src/stores/notes.store.ts
+++ b/apps/cockpit/src/stores/notes.store.ts
@@ -4,6 +4,10 @@ import type { Note, NoteColor } from '@/types/models'
 import { loadNotes, saveNote, deleteNote, clearAllNotes } from '@/lib/db'
 import { useUiStore } from '@/stores/ui.store'
 
+const SORT_STEP = 1024
+
+type DropPosition = 'before' | 'after'
+
 type NotesStore = {
   notes: Note[]
   initialized: boolean
@@ -16,11 +20,20 @@ type NotesStore = {
       Pick<Note, 'title' | 'content' | 'color' | 'pinned' | 'poppedOut' | 'windowBounds' | 'tags'>
     >
   ) => Promise<void>
+  reorder: (sourceId: string, targetId: string, position: DropPosition) => Promise<void>
   remove: (id: string) => Promise<void>
   clearAll: () => Promise<void>
 }
 
 let initPromise: Promise<void> | null = null
+
+function sortNotes(notes: Note[]): Note[] {
+  return [...notes].sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+    if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder
+    return b.updatedAt - a.updatedAt
+  })
+}
 
 export const useNotesStore = create<NotesStore>()((set, get) => ({
   notes: [],
@@ -43,6 +56,12 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
 
   add: async (title = '', content = '', color: NoteColor = 'yellow') => {
     const now = Date.now()
+    const firstUnpinnedOrder = Math.min(
+      0,
+      ...get()
+        .notes.filter((n) => !n.pinned)
+        .map((n) => n.sortOrder)
+    )
     const note: Note = {
       id: nanoid(),
       title,
@@ -53,6 +72,7 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
       createdAt: now,
       updatedAt: now,
       tags: [],
+      sortOrder: firstUnpinnedOrder - SORT_STEP,
     }
     try {
       await saveNote(note)
@@ -61,7 +81,7 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
       useUiStore.getState().addToast('Failed to save note: ' + msg, 'error')
       throw err
     }
-    set((s) => ({ notes: [note, ...s.notes] }))
+    set((s) => ({ notes: sortNotes([note, ...s.notes]) }))
     return note
   },
 
@@ -80,8 +100,48 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
       throw err
     }
     set((s) => ({
-      notes: s.notes.map((n) => (n.id === id ? updated : n)),
+      notes: sortNotes(s.notes.map((n) => (n.id === id ? updated : n))),
     }))
+  },
+
+  reorder: async (sourceId, targetId, position) => {
+    if (sourceId === targetId) return
+
+    const notes = get().notes
+    const source = notes.find((n) => n.id === sourceId)
+    const target = notes.find((n) => n.id === targetId)
+    if (!source || !target || source.pinned !== target.pinned) return
+
+    const group = notes.filter((n) => n.pinned === source.pinned)
+    const withoutSource = group.filter((n) => n.id !== sourceId)
+    const targetIndex = withoutSource.findIndex((n) => n.id === targetId)
+    if (targetIndex < 0) return
+
+    const insertIndex = position === 'after' ? targetIndex + 1 : targetIndex
+    const reorderedGroup = [...withoutSource]
+    reorderedGroup.splice(insertIndex, 0, source)
+
+    const updatedById = new Map(
+      reorderedGroup.map((note, index) => [
+        note.id,
+        {
+          ...note,
+          sortOrder: (index + 1) * SORT_STEP,
+        },
+      ])
+    )
+    const nextNotes = sortNotes(notes.map((note) => updatedById.get(note.id) ?? note))
+    const changedNotes = nextNotes.filter((note) => updatedById.has(note.id))
+
+    try {
+      await Promise.all(changedNotes.map(saveNote))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      useUiStore.getState().addToast('Failed to reorder notes: ' + msg, 'error')
+      throw err
+    }
+
+    set({ notes: nextNotes })
   },
 
   remove: async (id) => {

--- a/apps/cockpit/src/stores/notes.store.ts
+++ b/apps/cockpit/src/stores/notes.store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { nanoid } from 'nanoid'
 import type { Note, NoteColor } from '@/types/models'
-import { loadNotes, saveNote, deleteNote, clearAllNotes } from '@/lib/db'
+import { loadNotes, saveNote, saveNotesOrder, deleteNote, clearAllNotes } from '@/lib/db'
 import { useUiStore } from '@/stores/ui.store'
 
 const SORT_STEP = 1024
@@ -134,7 +134,7 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
     const changedNotes = nextNotes.filter((note) => updatedById.has(note.id))
 
     try {
-      await Promise.all(changedNotes.map(saveNote))
+      await saveNotesOrder(changedNotes.map(({ id, sortOrder }) => ({ id, sortOrder })))
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       useUiStore.getState().addToast('Failed to reorder notes: ' + msg, 'error')

--- a/apps/cockpit/src/types/models.ts
+++ b/apps/cockpit/src/types/models.ts
@@ -145,6 +145,7 @@ export type Note = {
   createdAt: number
   updatedAt: number
   tags: string[]
+  sortOrder: number
 }
 
 export type HistoryEntry = {


### PR DESCRIPTION
## Summary

- Add persistent manual ordering for Notes with a `sort_order` migration and store-level reorder action.
- Support drag-to-reorder note cards within pinned and unpinned note groups.
- Improve Notes drawer clarity with pinned/regular sections, note counts, a search result count, clear-search action, drag hints, and stronger note color strip styling.
- Address review feedback by registering migration 008, persisting reorder updates in a single SQLite transaction, and adding keyboard-accessible Move up/down controls.

## Test plan

- [x] `PATH=/opt/homebrew/bin:$PATH npx tsc --noEmit`
- [x] `PATH=/opt/homebrew/bin:$PATH bunx vitest run`
- [x] `PATH=/opt/homebrew/bin:$PATH bun run lint`
- [x] `cargo check` from `apps/cockpit/src-tauri`

Skipped architecture and secrets subagent checks per request.