### PR TITLE
fix(cockpit): stabilize notes and editor previews

### DIFF
--- a/apps/cockpit/src-tauri/src/mcp/mod.rs
+++ b/apps/cockpit/src-tauri/src/mcp/mod.rs
@@ -175,9 +175,10 @@ async fn start_server(
     let connect_options = SqliteConnectOptions::new()
         .filename(db_path)
         .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5))
         .create_if_missing(false);
     let pool = SqlitePoolOptions::new()
-        .max_connections(5)
+        .max_connections(1)
         .connect_with(connect_options)
         .await
         .map_err(|err| format!("Failed to connect MCP to cockpit database: {err}"))?;

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -296,6 +296,7 @@ export function NotesDrawer() {
   const [fuseVersion, setFuseVersion] = useState(0)
 
   const fuseRef = useRef<Fuse<NoteType> | null>(null)
+  const draggedNoteIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!drawerOpen) return
@@ -353,13 +354,14 @@ export function NotesDrawer() {
   )
 
   const handleNoteDragStart = useCallback(
-    (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
+    (note: NoteType, e: React.DragEvent<HTMLButtonElement>) => {
       if (!canReorderNotes || editingId === note.id) {
         e.preventDefault()
         return
       }
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', note.id)
+      draggedNoteIdRef.current = note.id
       setDraggedNoteId(note.id)
     },
     [canReorderNotes, editingId]
@@ -367,8 +369,9 @@ export function NotesDrawer() {
 
   const handleNoteDragOver = useCallback(
     (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
-      if (!draggedNoteId || draggedNoteId === note.id) return
-      const dragged = notes.find((n) => n.id === draggedNoteId)
+      const sourceId = draggedNoteIdRef.current ?? draggedNoteId
+      if (!sourceId || sourceId === note.id) return
+      const dragged = notes.find((n) => n.id === sourceId)
       if (!dragged || dragged.pinned !== note.pinned) return
 
       e.preventDefault()
@@ -381,6 +384,7 @@ export function NotesDrawer() {
   )
 
   const clearNoteDragState = useCallback(() => {
+    draggedNoteIdRef.current = null
     setDraggedNoteId(null)
     setDragOverNote(null)
   }, [])
@@ -388,7 +392,8 @@ export function NotesDrawer() {
   const handleNoteDrop = useCallback(
     (note: NoteType, e: React.DragEvent<HTMLDivElement>) => {
       e.preventDefault()
-      const sourceId = draggedNoteId ?? e.dataTransfer.getData('text/plain')
+      const sourceId =
+        draggedNoteIdRef.current ?? draggedNoteId ?? e.dataTransfer.getData('text/plain')
       const position = dragOverNote?.id === note.id ? dragOverNote.position : 'before'
       clearNoteDragState()
       if (!sourceId || sourceId === note.id) return
@@ -500,8 +505,6 @@ export function NotesDrawer() {
                     <div
                       key={note.id}
                       data-testid={`note-card-${note.id}`}
-                      draggable={canReorderNotes && editingId !== note.id}
-                      onDragStart={(e) => handleNoteDragStart(note, e)}
                       onDragOver={(e) => handleNoteDragOver(note, e)}
                       onDrop={(e) => handleNoteDrop(note, e)}
                       onDragEnd={clearNoteDragState}
@@ -530,13 +533,17 @@ export function NotesDrawer() {
                           >
                             <div className="flex items-center gap-1 text-[var(--color-text-muted)]">
                               {canReorderNotes && (
-                                <span
-                                  aria-hidden="true"
+                                <button
+                                  type="button"
+                                  draggable={editingId !== note.id}
+                                  onClick={(e) => e.stopPropagation()}
+                                  onDragStart={(e) => handleNoteDragStart(note, e)}
+                                  aria-label={`Drag ${note.title || 'untitled note'} to reorder`}
                                   className="inline-flex min-h-6 min-w-4 cursor-grab items-center justify-center rounded opacity-60 transition-opacity group-hover:opacity-100"
                                   title="Drag to reorder"
                                 >
-                                  <DotsSixVerticalIcon size={13} />
-                                </span>
+                                  <DotsSixVerticalIcon size={13} aria-hidden="true" />
+                                </button>
                               )}
                               <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
                                 <span className="truncate text-xs font-bold text-[var(--color-text)]">

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -55,6 +55,7 @@ describe('NotesDrawer', () => {
     expect(screen.getByRole('button', { name: 'Delete Test note' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Move Test note up' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Move Test note down' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Drag Test note to reorder' })).toBeInTheDocument()
     expect(screen.getByRole('separator', { name: 'Resize notes drawer' })).toHaveAttribute(
       'aria-orientation',
       'vertical'
@@ -100,8 +101,8 @@ describe('NotesDrawer', () => {
       setData: vi.fn((type: string, value: string) => data.set(type, value)),
       getData: vi.fn((type: string) => data.get(type) ?? ''),
     }
-    const firstCard = screen.getByTestId('note-card-note-1')
     const secondCard = screen.getByTestId('note-card-note-2')
+    const firstDragHandle = screen.getByRole('button', { name: 'Drag Test note to reorder' })
     Object.defineProperty(secondCard, 'getBoundingClientRect', {
       configurable: true,
       value: () => ({
@@ -117,7 +118,7 @@ describe('NotesDrawer', () => {
       }),
     })
 
-    fireEvent.dragStart(firstCard, { dataTransfer })
+    fireEvent.dragStart(firstDragHandle, { dataTransfer })
     fireEvent.dragOver(secondCard, { dataTransfer, clientY: 80 })
     fireEvent.drop(secondCard, { dataTransfer })
 

--- a/apps/cockpit/src/lib/__tests__/db.notes.test.ts
+++ b/apps/cockpit/src/lib/__tests__/db.notes.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sqlMock = vi.hoisted(() => ({
+  execute: vi.fn(),
+  select: vi.fn(),
+  load: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-sql', () => ({
+  default: {
+    load: sqlMock.load,
+  },
+}))
+
+function deferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolvePromise = res
+    reject = rej
+  })
+  const resolve = (value?: T | PromiseLike<T>) => resolvePromise(value as T)
+  return { promise, resolve, reject }
+}
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion()
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+  assertion()
+}
+
+describe('notes DB helpers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    sqlMock.execute.mockReset()
+    sqlMock.select.mockReset()
+    sqlMock.load.mockReset()
+    sqlMock.load.mockResolvedValue({
+      execute: sqlMock.execute,
+      select: sqlMock.select,
+    })
+  })
+
+  it('serializes note order transactions on the shared connection', async () => {
+    const firstUpdate = deferred<void>()
+    let updateCount = 0
+    sqlMock.execute.mockImplementation((sql: string) => {
+      if (sql === 'UPDATE notes SET sort_order = $1 WHERE id = $2') {
+        updateCount += 1
+        if (updateCount === 1) return firstUpdate.promise
+      }
+      return Promise.resolve({ rowsAffected: 0, lastInsertId: 0 })
+    })
+
+    const { saveNotesOrder } = await import('@/lib/db')
+
+    const firstSave = saveNotesOrder([{ id: 'a', sortOrder: 1024 }])
+    await waitForAssertion(() => expect(updateCount).toBe(1))
+
+    const secondSave = saveNotesOrder([{ id: 'b', sortOrder: 2048 }])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const statementsBeforeCommit = sqlMock.execute.mock.calls.map(([sql]) => sql)
+    expect(statementsBeforeCommit.filter((sql) => sql === 'BEGIN IMMEDIATE')).toHaveLength(1)
+
+    firstUpdate.resolve()
+    await Promise.all([firstSave, secondSave])
+
+    const statements = sqlMock.execute.mock.calls.map(([sql]) => sql)
+    const firstCommit = statements.indexOf('COMMIT')
+    const secondBegin = statements.indexOf(
+      'BEGIN IMMEDIATE',
+      statements.indexOf('BEGIN IMMEDIATE') + 1
+    )
+
+    expect(firstCommit).toBeGreaterThan(-1)
+    expect(secondBegin).toBeGreaterThan(-1)
+    expect(firstCommit).toBeLessThan(secondBegin)
+  })
+})

--- a/apps/cockpit/src/lib/db.ts
+++ b/apps/cockpit/src/lib/db.ts
@@ -21,15 +21,50 @@ import {
 // Promise singleton prevents TOCTOU race when multiple callers hit getDb() concurrently
 // (e.g., StrictMode double-mount or parallel store inits).
 let dbPromise: Promise<Database> | null = null
+let writeQueue: Promise<void> = Promise.resolve()
 
 export function getDb(): Promise<Database> {
   if (!dbPromise) {
     dbPromise = Database.load('sqlite:cockpit.db').then(async (conn) => {
       await conn.execute('PRAGMA journal_mode=WAL')
+      await conn.execute('PRAGMA busy_timeout=5000')
       return conn
     })
   }
   return dbPromise
+}
+
+function enqueueWrite<T>(operation: (conn: Database) => Promise<T>): Promise<T> {
+  const run = writeQueue.then(async () => {
+    const conn = await getDb()
+    return operation(conn)
+  })
+  writeQueue = run.then(
+    () => undefined,
+    () => undefined
+  )
+  return run
+}
+
+function runTransaction<T>(
+  mode: 'TRANSACTION' | 'IMMEDIATE',
+  operation: (conn: Database) => Promise<T>
+): Promise<T> {
+  return enqueueWrite(async (conn) => {
+    await conn.execute(mode === 'IMMEDIATE' ? 'BEGIN IMMEDIATE' : 'BEGIN TRANSACTION')
+    try {
+      const result = await operation(conn)
+      await conn.execute('COMMIT')
+      return result
+    } catch (err) {
+      try {
+        await conn.execute('ROLLBACK')
+      } catch (rollbackErr) {
+        console.warn('[db] transaction rollback failed', rollbackErr)
+      }
+      throw err
+    }
+  })
 }
 
 // --- Settings ---
@@ -50,10 +85,11 @@ export async function getSetting<T>(key: string, fallback: T): Promise<T> {
 }
 
 export async function setSetting<T>(key: string, value: T): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT(key) DO UPDATE SET value = $2',
-    [key, JSON.stringify(value)]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT(key) DO UPDATE SET value = $2',
+      [key, JSON.stringify(value)]
+    )
   )
 }
 
@@ -75,10 +111,11 @@ export async function loadToolState(toolId: string): Promise<Record<string, unkn
 }
 
 export async function saveToolState(toolId: string, state: Record<string, unknown>): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    'INSERT INTO tool_state (tool_id, state, updated_at) VALUES ($1, $2, $3) ON CONFLICT(tool_id) DO UPDATE SET state = $2, updated_at = $3',
-    [toolId, JSON.stringify(state), Date.now()]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      'INSERT INTO tool_state (tool_id, state, updated_at) VALUES ($1, $2, $3) ON CONFLICT(tool_id) DO UPDATE SET state = $2, updated_at = $3',
+      [toolId, JSON.stringify(state), Date.now()]
+    )
   )
 }
 
@@ -119,51 +156,45 @@ export async function loadNotes(): Promise<Note[]> {
 }
 
 export async function saveNote(note: Note): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO notes (id, title, content, color, pinned, popped_out, window_x, window_y, window_width, window_height, created_at, updated_at, tags, sort_order)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-     ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, color=$4, pinned=$5, popped_out=$6, window_x=$7, window_y=$8, window_width=$9, window_height=$10, updated_at=$12, tags=$13, sort_order=$14`,
-    [
-      note.id,
-      note.title,
-      note.content,
-      note.color,
-      note.pinned ? 1 : 0,
-      note.poppedOut ? 1 : 0,
-      note.windowBounds?.x ?? null,
-      note.windowBounds?.y ?? null,
-      note.windowBounds?.width ?? null,
-      note.windowBounds?.height ?? null,
-      note.createdAt,
-      note.updatedAt,
-      JSON.stringify(note.tags || []),
-      note.sortOrder,
-    ]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO notes (id, title, content, color, pinned, popped_out, window_x, window_y, window_width, window_height, created_at, updated_at, tags, sort_order)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+       ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, color=$4, pinned=$5, popped_out=$6, window_x=$7, window_y=$8, window_width=$9, window_height=$10, updated_at=$12, tags=$13, sort_order=$14`,
+      [
+        note.id,
+        note.title,
+        note.content,
+        note.color,
+        note.pinned ? 1 : 0,
+        note.poppedOut ? 1 : 0,
+        note.windowBounds?.x ?? null,
+        note.windowBounds?.y ?? null,
+        note.windowBounds?.width ?? null,
+        note.windowBounds?.height ?? null,
+        note.createdAt,
+        note.updatedAt,
+        JSON.stringify(note.tags || []),
+        note.sortOrder,
+      ]
+    )
   )
 }
 
 export async function saveNotesOrder(notes: Pick<Note, 'id' | 'sortOrder'>[]): Promise<void> {
   if (notes.length === 0) return
-  const conn = await getDb()
-  await conn.execute('BEGIN IMMEDIATE')
-  try {
+  await runTransaction('IMMEDIATE', async (conn) => {
     for (const note of notes) {
       await conn.execute('UPDATE notes SET sort_order = $1 WHERE id = $2', [
         note.sortOrder,
         note.id,
       ])
     }
-    await conn.execute('COMMIT')
-  } catch (err) {
-    await conn.execute('ROLLBACK')
-    throw err
-  }
+  })
 }
 
 export async function deleteNote(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM notes WHERE id = $1', [id])
+  await enqueueWrite((conn) => conn.execute('DELETE FROM notes WHERE id = $1', [id]))
 }
 
 // --- Snippets ---
@@ -195,27 +226,27 @@ export async function loadSnippets(): Promise<Snippet[]> {
 }
 
 export async function saveSnippet(snippet: Snippet): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO snippets (id, title, content, language, tags, folder, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-     ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, language=$4, tags=$5, folder=$6, updated_at=$8`,
-    [
-      snippet.id,
-      snippet.title,
-      snippet.content,
-      snippet.language,
-      JSON.stringify(snippet.tags),
-      snippet.folder,
-      snippet.createdAt,
-      snippet.updatedAt,
-    ]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO snippets (id, title, content, language, tags, folder, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT(id) DO UPDATE SET title=$2, content=$3, language=$4, tags=$5, folder=$6, updated_at=$8`,
+      [
+        snippet.id,
+        snippet.title,
+        snippet.content,
+        snippet.language,
+        JSON.stringify(snippet.tags),
+        snippet.folder,
+        snippet.createdAt,
+        snippet.updatedAt,
+      ]
+    )
   )
 }
 
 export async function deleteSnippet(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM snippets WHERE id = $1', [id])
+  await enqueueWrite((conn) => conn.execute('DELETE FROM snippets WHERE id = $1', [id]))
 }
 
 // --- Prompt Templates ---
@@ -317,43 +348,31 @@ async function executeSeedBuiltinPromptTemplate(
 }
 
 export async function saveUserPromptTemplate(template: PromptTemplate): Promise<void> {
-  const conn = await getDb()
-  await executeSaveUserPromptTemplate(conn, template)
+  await enqueueWrite((conn) => executeSaveUserPromptTemplate(conn, template))
 }
 
 export async function saveUserPromptTemplates(templates: PromptTemplate[]): Promise<void> {
   if (templates.length === 0) return
-  const conn = await getDb()
-  await conn.execute('BEGIN TRANSACTION')
-  try {
+  await runTransaction('TRANSACTION', async (conn) => {
     for (const template of templates) {
       await executeSaveUserPromptTemplate(conn, template)
     }
-    await conn.execute('COMMIT')
-  } catch (err) {
-    await conn.execute('ROLLBACK')
-    throw err
-  }
+  })
 }
 
 export async function deleteUserPromptTemplate(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute("DELETE FROM user_prompt_templates WHERE id = $1 AND author = 'user'", [id])
+  await enqueueWrite((conn) =>
+    conn.execute("DELETE FROM user_prompt_templates WHERE id = $1 AND author = 'user'", [id])
+  )
 }
 
 export async function seedBuiltinPromptTemplates(templates: PromptTemplate[]): Promise<void> {
   if (templates.length === 0) return
-  const conn = await getDb()
-  await conn.execute('BEGIN TRANSACTION')
-  try {
+  await runTransaction('TRANSACTION', async (conn) => {
     for (const template of templates) {
       await executeSeedBuiltinPromptTemplate(conn, template)
     }
-    await conn.execute('COMMIT')
-  } catch (err) {
-    await conn.execute('ROLLBACK')
-    throw err
-  }
+  })
 }
 
 // --- History ---
@@ -402,50 +421,49 @@ export async function loadHistory(tool?: string, limit: number = 100): Promise<H
 }
 
 export async function addHistoryEntry(entry: HistoryEntry): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO history (id, tool, sub_tab, input, output, timestamp, duration_ms, success, output_size, starred)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-    [
-      entry.id,
-      entry.tool,
-      entry.subTab ?? null,
-      entry.input,
-      entry.output,
-      entry.timestamp,
-      entry.durationMs ?? null,
-      entry.success ? 1 : 0,
-      entry.outputSize ?? null,
-      entry.starred ? 1 : 0,
-    ]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO history (id, tool, sub_tab, input, output, timestamp, duration_ms, success, output_size, starred)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        entry.id,
+        entry.tool,
+        entry.subTab ?? null,
+        entry.input,
+        entry.output,
+        entry.timestamp,
+        entry.durationMs ?? null,
+        entry.success ? 1 : 0,
+        entry.outputSize ?? null,
+        entry.starred ? 1 : 0,
+      ]
+    )
   )
 }
 
 export async function pruneHistory(tool: string, keepCount: number): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `DELETE FROM history WHERE tool = $1 AND id NOT IN (
-       SELECT id FROM history WHERE tool = $1 ORDER BY timestamp DESC LIMIT $2
-     )`,
-    [tool, keepCount]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `DELETE FROM history WHERE tool = $1 AND id NOT IN (
+         SELECT id FROM history WHERE tool = $1 ORDER BY timestamp DESC LIMIT $2
+       )`,
+      [tool, keepCount]
+    )
   )
 }
 
 // --- Bulk clear ---
 
 export async function clearAllNotes(): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM notes')
+  await enqueueWrite((conn) => conn.execute('DELETE FROM notes'))
 }
 
 export async function clearAllSnippets(): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM snippets')
+  await enqueueWrite((conn) => conn.execute('DELETE FROM snippets'))
 }
 
 export async function clearAllHistory(): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM history')
+  await enqueueWrite((conn) => conn.execute('DELETE FROM history'))
 }
 
 // --- API Client ---
@@ -468,18 +486,18 @@ export async function loadApiEnvironments(): Promise<ApiEnvironment[]> {
 }
 
 export async function saveApiEnvironment(env: ApiEnvironment): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO api_environments (id, name, variables, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5)
-     ON CONFLICT(id) DO UPDATE SET name=$2, variables=$3, updated_at=$5`,
-    [env.id, env.name, JSON.stringify(env.variables), env.createdAt, env.updatedAt]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO api_environments (id, name, variables, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT(id) DO UPDATE SET name=$2, variables=$3, updated_at=$5`,
+      [env.id, env.name, JSON.stringify(env.variables), env.createdAt, env.updatedAt]
+    )
   )
 }
 
 export async function deleteApiEnvironment(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM api_environments WHERE id = $1', [id])
+  await enqueueWrite((conn) => conn.execute('DELETE FROM api_environments WHERE id = $1', [id]))
 }
 
 export async function loadApiCollections(): Promise<ApiCollection[]> {
@@ -500,12 +518,13 @@ export async function loadApiCollections(): Promise<ApiCollection[]> {
 }
 
 export async function saveApiCollection(col: ApiCollection): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO api_collections (id, name, created_at, updated_at)
-     VALUES ($1, $2, $3, $4)
-     ON CONFLICT(id) DO UPDATE SET name=$2, updated_at=$4`,
-    [col.id, col.name, col.createdAt, col.updatedAt]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO api_collections (id, name, created_at, updated_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT(id) DO UPDATE SET name=$2, updated_at=$4`,
+      [col.id, col.name, col.createdAt, col.updatedAt]
+    )
   )
 }
 
@@ -519,8 +538,7 @@ async function executeSaveApiCollection(conn: Database, col: ApiCollection): Pro
 }
 
 export async function deleteApiCollection(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM api_collections WHERE id = $1', [id])
+  await enqueueWrite((conn) => conn.execute('DELETE FROM api_collections WHERE id = $1', [id]))
 }
 
 export async function loadApiRequests(): Promise<ApiRequest[]> {
@@ -541,24 +559,25 @@ export async function loadApiRequests(): Promise<ApiRequest[]> {
 }
 
 export async function saveApiRequest(req: ApiRequest): Promise<void> {
-  const conn = await getDb()
-  await conn.execute(
-    `INSERT INTO api_requests (id, collection_id, name, method, url, headers, body, body_mode, auth, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-     ON CONFLICT(id) DO UPDATE SET collection_id=$2, name=$3, method=$4, url=$5, headers=$6, body=$7, body_mode=$8, auth=$9, updated_at=$11`,
-    [
-      req.id,
-      req.collectionId,
-      req.name,
-      req.method,
-      req.url,
-      JSON.stringify(req.headers),
-      req.body,
-      req.bodyMode,
-      JSON.stringify(req.auth),
-      req.createdAt,
-      req.updatedAt,
-    ]
+  await enqueueWrite((conn) =>
+    conn.execute(
+      `INSERT INTO api_requests (id, collection_id, name, method, url, headers, body, body_mode, auth, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       ON CONFLICT(id) DO UPDATE SET collection_id=$2, name=$3, method=$4, url=$5, headers=$6, body=$7, body_mode=$8, auth=$9, updated_at=$11`,
+      [
+        req.id,
+        req.collectionId,
+        req.name,
+        req.method,
+        req.url,
+        JSON.stringify(req.headers),
+        req.body,
+        req.bodyMode,
+        JSON.stringify(req.auth),
+        req.createdAt,
+        req.updatedAt,
+      ]
+    )
   )
 }
 
@@ -588,23 +607,16 @@ export async function saveApiImport(
   requests: ApiRequest[]
 ): Promise<void> {
   if (collections.length === 0 && requests.length === 0) return
-  const conn = await getDb()
-  await conn.execute('BEGIN TRANSACTION')
-  try {
+  await runTransaction('TRANSACTION', async (conn) => {
     for (const collection of collections) {
       await executeSaveApiCollection(conn, collection)
     }
     for (const request of requests) {
       await executeSaveApiRequest(conn, request)
     }
-    await conn.execute('COMMIT')
-  } catch (err) {
-    await conn.execute('ROLLBACK')
-    throw err
-  }
+  })
 }
 
 export async function deleteApiRequest(id: string): Promise<void> {
-  const conn = await getDb()
-  await conn.execute('DELETE FROM api_requests WHERE id = $1', [id])
+  await enqueueWrite((conn) => conn.execute('DELETE FROM api_requests WHERE id = $1', [id]))
 }

--- a/apps/cockpit/src/lib/theme.ts
+++ b/apps/cockpit/src/lib/theme.ts
@@ -27,6 +27,18 @@ export const ALL_THEMES: EffectiveTheme[] = [
   'oceanic-next',
 ]
 
+const LIGHT_EFFECTIVE_THEMES = new Set<EffectiveTheme>([
+  'soft-focus',
+  'tokyo-night-light',
+  'catppuccin-latte',
+  'github-light',
+  'solarized-light',
+])
+
+export function isLightEffectiveTheme(theme: EffectiveTheme): boolean {
+  return LIGHT_EFFECTIVE_THEMES.has(theme)
+}
+
 /** Short status-bar labels (≤6 chars) and full display names for each theme. */
 export const THEME_META: Record<EffectiveTheme, { shortLabel: string; fullLabel: string }> = {
   midnight: { shortLabel: 'Mid', fullLabel: 'Midnight Interface' },

--- a/apps/cockpit/src/stores/__tests__/notes.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/notes.store.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { useNotesStore } from '../notes.store'
-import { loadNotes, saveNote, saveNotesOrder, deleteNote } from '@/lib/db'
+import { loadNotes, saveNote, saveNotesOrder, deleteNote, clearAllNotes } from '@/lib/db'
 
 vi.mock('@/lib/db', () => ({
   loadNotes: vi.fn(),
   saveNote: vi.fn(),
   saveNotesOrder: vi.fn(),
   deleteNote: vi.fn(),
+  clearAllNotes: vi.fn(),
 }))
 
 // Reset store state between tests
@@ -18,7 +19,19 @@ beforeEach(() => {
   ;(saveNote as any).mockResolvedValue(undefined)
   ;(saveNotesOrder as any).mockResolvedValue(undefined)
   ;(deleteNote as any).mockResolvedValue(undefined)
+  ;(clearAllNotes as any).mockResolvedValue(undefined)
 })
+
+function deferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolvePromise = res
+    reject = rej
+  })
+  const resolve = (value?: T | PromiseLike<T>) => resolvePromise(value as T)
+  return { promise, resolve, reject }
+}
 
 describe('notes store', () => {
   it('starts empty and uninitialized', () => {
@@ -69,6 +82,19 @@ describe('notes store', () => {
     expect(useNotesStore.getState().notes[0]!.tags).toEqual(['tag1'])
   })
 
+  it('updates note state before the database write finishes', async () => {
+    const note = await useNotesStore.getState().add('Original')
+    const pending = deferred<void>()
+    ;(saveNote as any).mockReturnValueOnce(pending.promise)
+
+    const updatePromise = useNotesStore.getState().update(note.id, { title: 'Draft title' })
+
+    expect(useNotesStore.getState().notes[0]!.title).toBe('Draft title')
+
+    pending.resolve()
+    await updatePromise
+  })
+
   it('update with unknown ID is a no-op', async () => {
     await useNotesStore.getState().add('Note')
     await useNotesStore.getState().update('nonexistent', { title: 'Ghost' })
@@ -105,5 +131,19 @@ describe('notes store', () => {
       { id: second.id, sortOrder: 3072 },
     ])
     expect(saveNote).not.toHaveBeenCalled()
+  })
+
+  it('reorders note state before the database write finishes', async () => {
+    const first = await useNotesStore.getState().add('First')
+    const second = await useNotesStore.getState().add('Second')
+    const pending = deferred<void>()
+    ;(saveNotesOrder as any).mockReturnValueOnce(pending.promise)
+
+    const reorderPromise = useNotesStore.getState().reorder(first.id, second.id, 'after')
+
+    expect(useNotesStore.getState().notes.map((note) => note.id)).toEqual([second.id, first.id])
+
+    pending.resolve()
+    await reorderPromise
   })
 })

--- a/apps/cockpit/src/stores/notes.store.ts
+++ b/apps/cockpit/src/stores/notes.store.ts
@@ -91,17 +91,28 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
     if (idx < 0) return
     const existing = notes[idx]
     if (!existing) return
-    const updated = { ...existing, ...patch, updatedAt: Date.now() }
-    try {
-      await saveNote(updated)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      useUiStore.getState().addToast('Failed to save note: ' + msg, 'error')
-      throw err
+    const updated = {
+      ...existing,
+      ...patch,
+      updatedAt: Math.max(Date.now(), existing.updatedAt + 1),
     }
     set((s) => ({
       notes: sortNotes(s.notes.map((n) => (n.id === id ? updated : n))),
     }))
+
+    try {
+      await saveNote(updated)
+    } catch (err) {
+      const current = get().notes.find((n) => n.id === id)
+      if (current?.updatedAt === updated.updatedAt) {
+        set((s) => ({
+          notes: sortNotes(s.notes.map((n) => (n.id === id ? existing : n))),
+        }))
+      }
+      const msg = err instanceof Error ? err.message : String(err)
+      useUiStore.getState().addToast('Failed to save note: ' + msg, 'error')
+      throw err
+    }
   },
 
   reorder: async (sourceId, targetId, position) => {
@@ -132,16 +143,18 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
     )
     const nextNotes = sortNotes(notes.map((note) => updatedById.get(note.id) ?? note))
     const changedNotes = nextNotes.filter((note) => updatedById.has(note.id))
+    set({ notes: nextNotes })
 
     try {
       await saveNotesOrder(changedNotes.map(({ id, sortOrder }) => ({ id, sortOrder })))
     } catch (err) {
+      if (get().notes === nextNotes) {
+        set({ notes })
+      }
       const msg = err instanceof Error ? err.message : String(err)
       useUiStore.getState().addToast('Failed to reorder notes: ' + msg, 'error')
       throw err
     }
-
-    set({ notes: nextNotes })
   },
 
   remove: async (id) => {

--- a/apps/cockpit/src/tools/__tests__/api-client.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/api-client.test.tsx
@@ -1,16 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { renderTool } from './test-utils'
 import { useApiStore } from '@/stores/api.store'
 import ApiClient from '../api-client/ApiClient'
 import { CollectionsSidebar } from '../api-client/components/CollectionsSidebar'
 
+const fetchMock = vi.hoisted(() => vi.fn())
+
 vi.mock('@tauri-apps/plugin-http', () => ({
-  fetch: vi.fn(async () => new Response('ok', { status: 200, statusText: 'OK' })),
+  fetch: fetchMock,
 }))
+
+function base64EncodeUtf8(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
 
 describe('ApiClient', () => {
   beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200, statusText: 'OK' }))
     useApiStore.setState({
       environments: [],
       collections: [],
@@ -74,6 +86,33 @@ describe('ApiClient', () => {
 
     await waitFor(() => expect(screen.getByText('Show Response')).toBeInTheDocument())
     expect(responsePanel).toHaveClass('hidden')
+  })
+
+  it('encodes non-ASCII Basic auth credentials as UTF-8 bytes', async () => {
+    renderTool(ApiClient)
+
+    fireEvent.change(screen.getByPlaceholderText(/\{\{baseUrl\}\}\/endpoint/i), {
+      target: { value: 'https://example.com' },
+    })
+    fireEvent.click(screen.getByText('Auth'))
+    fireEvent.change(screen.getByDisplayValue('No Auth'), {
+      target: { value: 'basic' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Username'), {
+      target: { value: 'Jörg' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'päss🔐' },
+    })
+
+    fireEvent.click(screen.getByText('Send'))
+
+    await waitFor(() => expect(tauriFetch).toHaveBeenCalledOnce())
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: {
+        Authorization: `Basic ${base64EncodeUtf8('Jörg:päss🔐')}`,
+      },
+    })
   })
 
   it('renders saved request rows as selectable buttons', () => {

--- a/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
@@ -1,7 +1,148 @@
-import { describe, expect, it } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import ImageTool from '../image-tool/ImageTool'
+
+const originalFileReader = globalThis.FileReader
+const originalImage = globalThis.Image
+const originalResizeObserver = globalThis.ResizeObserver
+const originalGetBoundingClientRect = window.HTMLElement.prototype.getBoundingClientRect
+const originalCanvasGetContext = window.HTMLCanvasElement.prototype.getContext
+const originalCanvasToDataUrl = window.HTMLCanvasElement.prototype.toDataURL
+const originalCanvasToBlob = window.HTMLCanvasElement.prototype.toBlob
+
+function installImageMocks() {
+  class MockFileReader {
+    onload: ((event: { target: { result: string } }) => void) | null = null
+    readAsDataURL() {
+      this.onload?.({ target: { result: 'data:image/png;base64,AAA=' } })
+    }
+  }
+
+  class MockImage {
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    naturalWidth = 100
+    naturalHeight = 80
+    private source = ''
+
+    set src(value: string) {
+      this.source = value
+      this.onload?.()
+    }
+
+    get src() {
+      return this.source
+    }
+  }
+
+  class MockResizeObserver {
+    private readonly callback: ResizeObserverCallback
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback
+    }
+
+    observe(target: Element) {
+      this.callback([{ target } as ResizeObserverEntry], this)
+    }
+
+    disconnect() {}
+    unobserve() {}
+  }
+
+  Object.defineProperty(globalThis, 'FileReader', {
+    configurable: true,
+    value: MockFileReader,
+  })
+  Object.defineProperty(globalThis, 'Image', {
+    configurable: true,
+    value: MockImage,
+  })
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: MockResizeObserver,
+  })
+  Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width: 200,
+      height: 160,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 160,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }),
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: () => ({
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+    }),
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'toDataURL', {
+    configurable: true,
+    value: () => 'data:image/png;base64,AAA=',
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'toBlob', {
+    configurable: true,
+    value(callback: BlobCallback) {
+      callback(new Blob(['image'], { type: 'image/png' }))
+    },
+  })
+}
+
+function restoreImageMocks() {
+  Object.defineProperty(globalThis, 'FileReader', {
+    configurable: true,
+    value: originalFileReader,
+  })
+  Object.defineProperty(globalThis, 'Image', {
+    configurable: true,
+    value: originalImage,
+  })
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: originalResizeObserver,
+  })
+  Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: originalGetBoundingClientRect,
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: originalCanvasGetContext,
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'toDataURL', {
+    configurable: true,
+    value: originalCanvasToDataUrl,
+  })
+  Object.defineProperty(window.HTMLCanvasElement.prototype, 'toBlob', {
+    configurable: true,
+    value: originalCanvasToBlob,
+  })
+}
+
+async function loadMockImage() {
+  installImageMocks()
+  renderTool(ImageTool)
+  const preview = screen.getByTestId('image-preview')
+  fireEvent.drop(preview, {
+    dataTransfer: {
+      files: [new File(['image'], 'sample.png', { type: 'image/png' })],
+    },
+  })
+  await waitFor(() => expect(screen.getByText('sample.png')).toBeInTheDocument())
+  return preview
+}
+
+afterEach(() => {
+  restoreImageMocks()
+})
 
 describe('ImageTool', () => {
   // ── Empty state ──────────────────────────────────────────────────
@@ -54,6 +195,39 @@ describe('ImageTool', () => {
     renderTool(ImageTool)
     fireEvent.click(screen.getByText('Crop'))
     expect(screen.getByText(/open an image to get started/i)).toBeInTheDocument()
+  })
+
+  it('uses a keyboard-operable crop toggle with pressed state', async () => {
+    await loadMockImage()
+
+    fireEvent.click(screen.getByText('Crop'))
+    const toggle = screen.getByRole('button', { name: 'Enable crop' })
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.keyDown(toggle, { key: 'Enter' })
+    fireEvent.click(toggle)
+
+    expect(screen.getByRole('button', { name: 'Disable crop' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('stops crop dragging when mouse is released outside the preview', async () => {
+    const preview = await loadMockImage()
+    fireEvent.click(screen.getByText('Crop'))
+    fireEvent.click(screen.getByRole('button', { name: 'Enable crop' }))
+    await waitFor(() => expect(screen.getByTestId('crop-box')).toBeInTheDocument())
+
+    const xInput = screen.getAllByRole('spinbutton')[0]!
+    expect(xInput).toHaveValue(0)
+
+    fireEvent.mouseDown(screen.getByTestId('crop-box'), { clientX: 20, clientY: 20 })
+    fireEvent.mouseUp(window)
+    fireEvent.mouseMove(preview, { clientX: 80, clientY: 80 })
+
+    expect(xInput).toHaveValue(0)
   })
 
   // ── Export tab ───────────────────────────────────────────────────

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import MarkdownEditor from '../markdown-editor/MarkdownEditor'
@@ -7,6 +7,38 @@ import { LinkModal } from '../markdown-editor/modals/LinkModal'
 import { CodeBlockModal } from '../markdown-editor/modals/CodeBlockModal'
 import { TableModal } from '../markdown-editor/modals/TableModal'
 import { ImageModal } from '../markdown-editor/modals/ImageModal'
+import { useSettingsStore } from '@/stores/settings.store'
+import { DEFAULT_SETTINGS } from '@/types/models'
+
+const mermaidMock = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn(),
+}))
+
+vi.mock('mermaid', () => ({
+  default: mermaidMock,
+}))
+
+function deferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  const resolve = (value: T | PromiseLike<T>) => resolvePromise(value)
+  return { promise, resolve }
+}
+
+const originalClipboard = navigator.clipboard
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  useSettingsStore.setState(DEFAULT_SETTINGS)
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: originalClipboard,
+  })
+})
 
 describe('MarkdownEditor', () => {
   it('renders tab bar with Edit first', () => {
@@ -43,6 +75,24 @@ describe('MarkdownEditor', () => {
     expect(screen.getByText('Download .md')).toBeInTheDocument()
     expect(screen.getByText('Download .html')).toBeInTheDocument()
     expect(screen.getByText('Print / PDF')).toBeInTheDocument()
+  })
+
+  it('copies HTML from current editor content without waiting for preview debounce', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    renderTool(MarkdownEditor)
+
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: '# Fresh Export' },
+    })
+    fireEvent.click(screen.getByText('Export'))
+    fireEvent.click(screen.getByText('Copy HTML'))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce())
+    expect(writeText.mock.calls[0]?.[0]).toContain('<h1>Fresh Export</h1>')
   })
 
   it('Export dropdown closes on outside click', () => {
@@ -108,6 +158,63 @@ describe('MarkdownEditor', () => {
         value: originalScrollIntoView,
       })
     }
+  })
+
+  it('ignores stale async Mermaid renders in the preview', async () => {
+    const oldRender = deferred<{ svg: string }>()
+    const newRender = deferred<{ svg: string }>()
+    mermaidMock.render.mockImplementation((_id: string, source: string) => {
+      if (source.includes('New')) return newRender.promise
+      return oldRender.promise
+    })
+
+    const { container, rerender } = render(
+      <MarkdownPreview
+        html="<pre><code class='language-mermaid'>flowchart TD&#xA;Old</code></pre>"
+        showToc={false}
+        toc={[]}
+      />
+    )
+
+    await waitFor(() => expect(mermaidMock.render).toHaveBeenCalledTimes(1))
+
+    rerender(
+      <MarkdownPreview
+        html="<pre><code class='language-mermaid'>flowchart TD&#xA;New</code></pre>"
+        showToc={false}
+        toc={[]}
+      />
+    )
+    await waitFor(() => expect(mermaidMock.render).toHaveBeenCalledTimes(2))
+
+    newRender.resolve({ svg: '<svg><text>new diagram</text></svg>' })
+    await waitFor(() => expect(container.innerHTML).toContain('new diagram'))
+
+    oldRender.resolve({ svg: '<svg><text>old diagram</text></svg>' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(container.innerHTML).toContain('new diagram')
+    expect(container.innerHTML).not.toContain('old diagram')
+  })
+
+  it('uses the light Mermaid theme in preview when the app theme is light', async () => {
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, theme: 'github-light' })
+    mermaidMock.render.mockResolvedValue({ svg: '<svg><text>diagram</text></svg>' })
+
+    render(
+      <MarkdownPreview
+        html="<pre><code class='language-mermaid'>flowchart TD&#xA;A</code></pre>"
+        showToc={false}
+        toc={[]}
+      />
+    )
+
+    await waitFor(() =>
+      expect(mermaidMock.initialize).toHaveBeenCalledWith({
+        startOnLoad: false,
+        theme: 'default',
+      })
+    )
   })
 })
 

--- a/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
@@ -1,7 +1,33 @@
-import { describe, expect, it } from 'vitest'
-import { screen, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, screen, fireEvent, render } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import MermaidEditor from '../mermaid-editor/MermaidEditor'
+import { useSettingsStore } from '@/stores/settings.store'
+import { DEFAULT_SETTINGS } from '@/types/models'
+
+const mermaidMock = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn(),
+}))
+
+vi.mock('mermaid', () => ({
+  default: mermaidMock,
+}))
+
+function deferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  const resolve = (value: T | PromiseLike<T>) => resolvePromise(value)
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  useSettingsStore.setState(DEFAULT_SETTINGS)
+})
 
 describe('MermaidEditor', () => {
   it('renders editor', () => {
@@ -29,6 +55,63 @@ describe('MermaidEditor', () => {
   it('shows persistent interaction hint', () => {
     renderTool(MermaidEditor)
     expect(screen.getByText('Scroll · Drag · Double-click to reset')).toBeInTheDocument()
+  })
+
+  it('ignores stale async renders after rapid edits', async () => {
+    vi.useFakeTimers()
+    const oldRender = deferred<{ svg: string }>()
+    const newRender = deferred<{ svg: string }>()
+    mermaidMock.render.mockImplementation((_id: string, source: string) => {
+      if (source.includes('New')) return newRender.promise
+      return oldRender.promise
+    })
+
+    const { container } = renderTool(MermaidEditor)
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: 'flowchart TD\nOld' },
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(mermaidMock.render).toHaveBeenCalledTimes(1)
+
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: 'flowchart TD\nNew' },
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(mermaidMock.render).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      newRender.resolve({ svg: '<svg><text>new diagram</text></svg>' })
+      await Promise.resolve()
+    })
+    expect(container.innerHTML).toContain('new diagram')
+
+    await act(async () => {
+      oldRender.resolve({ svg: '<svg><text>old diagram</text></svg>' })
+      await Promise.resolve()
+    })
+
+    expect(container.innerHTML).toContain('new diagram')
+    expect(container.innerHTML).not.toContain('old diagram')
+  })
+
+  it('uses the light Mermaid theme when the app theme is light', async () => {
+    vi.useFakeTimers()
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, theme: 'github-light' })
+    mermaidMock.render.mockResolvedValue({ svg: '<svg><text>diagram</text></svg>' })
+
+    renderTool(MermaidEditor)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(mermaidMock.initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      theme: 'default',
+    })
   })
 })
 

--- a/apps/cockpit/src/tools/__tests__/regex-tester-component.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/regex-tester-component.test.tsx
@@ -21,6 +21,19 @@ describe('RegexTester (component)', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
   })
 
+  it('exposes regex flag toggle pressed state', () => {
+    renderTool(RegexTester)
+
+    const globalFlag = screen.getByRole('button', { name: /global/i })
+    const caseInsensitiveFlag = screen.getByRole('button', { name: /case insensitive/i })
+
+    expect(globalFlag).toHaveAttribute('aria-pressed', 'true')
+    expect(caseInsensitiveFlag).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(caseInsensitiveFlag)
+    expect(caseInsensitiveFlag).toHaveAttribute('aria-pressed', 'true')
+  })
+
   it('shows match and replace tabs', () => {
     renderTool(RegexTester)
     expect(screen.getByText('Match')).toBeInTheDocument()

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -124,6 +124,13 @@ function interpolate(text: string, vars: Record<string, string>): string {
   })
 }
 
+function base64EncodeUtf8(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -330,7 +337,7 @@ export default function ApiClient() {
       } else if (auth.type === 'basic') {
         const u = interpolate(auth.username, envVars)
         const p = interpolate(auth.password, envVars)
-        fetchHeaders['Authorization'] = `Basic ${btoa(`${u}:${p}`)}`
+        fetchHeaders['Authorization'] = `Basic ${base64EncodeUtf8(`${u}:${p}`)}`
       }
 
       const opts: RequestInit = { method, headers: fetchHeaders }

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -416,6 +416,18 @@ export default function ImageTool() {
     cropDragRef.current = null
   }, [])
 
+  useEffect(() => {
+    if (state.activeTab !== 'crop') {
+      cropDragRef.current = null
+      return
+    }
+    window.addEventListener('mouseup', handleCropMouseUp)
+    return () => {
+      window.removeEventListener('mouseup', handleCropMouseUp)
+      cropDragRef.current = null
+    }
+  }, [handleCropMouseUp, state.activeTab])
+
   const handleResetCrop = useCallback(() => {
     if (!originalImg) return
     updateState({
@@ -572,6 +584,7 @@ export default function ImageTool() {
         {/* Preview panel */}
         <div
           ref={previewContainerRef}
+          data-testid="image-preview"
           className="relative flex flex-1 select-none items-center justify-center overflow-hidden bg-[var(--color-surface)]"
           style={{
             backgroundImage:
@@ -616,7 +629,7 @@ export default function ImageTool() {
                       left: displayMetrics?.offsetX ?? 0,
                       width: displayMetrics?.displayW ?? 0,
                       height: cropDisplayRect.top - (displayMetrics?.offsetY ?? 0),
-                      background: 'rgba(0,0,0,0.55)',
+                      background: 'color-mix(in srgb, var(--color-bg) 72%, transparent)',
                     }}
                   />
                   <div
@@ -630,7 +643,7 @@ export default function ImageTool() {
                         (displayMetrics?.offsetY ?? 0) +
                         (displayMetrics?.displayH ?? 0) -
                         (cropDisplayRect.top + cropDisplayRect.height),
-                      background: 'rgba(0,0,0,0.55)',
+                      background: 'color-mix(in srgb, var(--color-bg) 72%, transparent)',
                     }}
                   />
                   <div
@@ -640,7 +653,7 @@ export default function ImageTool() {
                       left: displayMetrics?.offsetX ?? 0,
                       width: cropDisplayRect.left - (displayMetrics?.offsetX ?? 0),
                       height: cropDisplayRect.height,
-                      background: 'rgba(0,0,0,0.55)',
+                      background: 'color-mix(in srgb, var(--color-bg) 72%, transparent)',
                     }}
                   />
                   <div
@@ -653,19 +666,20 @@ export default function ImageTool() {
                         (displayMetrics?.displayW ?? 0) -
                         (cropDisplayRect.left + cropDisplayRect.width),
                       height: cropDisplayRect.height,
-                      background: 'rgba(0,0,0,0.55)',
+                      background: 'color-mix(in srgb, var(--color-bg) 72%, transparent)',
                     }}
                   />
 
                   {/* Crop box + handles */}
                   <div
+                    data-testid="crop-box"
                     className="absolute"
                     style={{
                       left: cropDisplayRect.left,
                       top: cropDisplayRect.top,
                       width: cropDisplayRect.width,
                       height: cropDisplayRect.height,
-                      border: '1.5px solid white',
+                      border: '1.5px solid var(--color-accent)',
                       boxSizing: 'border-box',
                       cursor: 'move',
                     }}
@@ -676,7 +690,7 @@ export default function ImageTool() {
                       className="pointer-events-none absolute inset-0"
                       style={{
                         backgroundImage:
-                          'linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px)',
+                          'linear-gradient(color-mix(in srgb, var(--color-accent) 35%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 35%, transparent) 1px, transparent 1px)',
                         backgroundSize: '33.33% 33.33%',
                       }}
                     />
@@ -690,8 +704,9 @@ export default function ImageTool() {
                           position: 'absolute',
                           width: 12,
                           height: 12,
-                          background: 'white',
-                          border: '1.5px solid rgba(0,0,0,0.4)',
+                          background: 'var(--color-bg)',
+                          border:
+                            '1.5px solid color-mix(in srgb, var(--color-accent) 70%, var(--color-border))',
                           boxSizing: 'border-box',
                           ...(handle === 'nw' && {
                             top: -6,
@@ -931,17 +946,20 @@ function CropPanel({
   return (
     <div className="flex flex-col gap-4">
       {/* Enable toggle */}
-      <label className="flex cursor-pointer items-center gap-2">
-        <div
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
           onClick={onToggle}
+          aria-pressed={enabled}
+          aria-label={enabled ? 'Disable crop' : 'Enable crop'}
           className={`relative h-5 w-9 rounded-full transition-colors ${enabled ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-border)]'}`}
         >
           <div
-            className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-4' : 'translate-x-0.5'}`}
+            className={`absolute top-0.5 h-4 w-4 rounded-full bg-[var(--color-bg)] shadow transition-transform ${enabled ? 'translate-x-4' : 'translate-x-0.5'}`}
           />
-        </div>
+        </button>
         <span className="text-xs text-[var(--color-text)]">Enable crop</span>
-      </label>
+      </div>
 
       {/* Crop coordinates */}
       <div className={enabled ? '' : 'pointer-events-none opacity-40'}>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -433,6 +433,20 @@ function readingTime(words: number): string {
   return minutes <= 1 ? '< 1 min read' : `${minutes} min read`
 }
 
+async function renderMarkdownContent(content: string): Promise<string> {
+  if (!content.trim()) return ''
+  try {
+    const result = await processor.process(content)
+    return String(result)
+  } catch (e) {
+    const msg = (e as Error).message
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+    return `<p style="color: var(--color-error)">Render error: ${msg}</p>`
+  }
+}
+
 // ─── Component ───────────────────────────────────────────────────────
 
 export default function MarkdownEditor() {
@@ -485,24 +499,14 @@ export default function MarkdownEditor() {
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    let cancelled = false
     debounceRef.current = setTimeout(async () => {
-      if (!state.content.trim()) {
-        setHtml('')
-        return
-      }
-      try {
-        const result = await processor.process(state.content)
-        setHtml(String(result))
-      } catch (e) {
-        const msg = (e as Error).message
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        setHtml(`<p style="color: var(--color-error)">Render error: ${msg}</p>`)
-      }
+      const nextHtml = await renderMarkdownContent(state.content)
+      if (!cancelled) setHtml(nextHtml)
     }, 300)
 
     return () => {
+      cancelled = true
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
   }, [state.content])
@@ -706,20 +710,30 @@ export default function MarkdownEditor() {
   // ─── Export handlers ─────────────────────────────────────────────
 
   const buildFullHtml = useCallback(
-    (styles: string) =>
-      `<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>Export</title>\n<style>${styles}</style>\n</head><body>${html}</body></html>`,
-    [html]
+    (bodyHtml: string, styles: string) =>
+      `<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>Export</title>\n<style>${styles}</style>\n</head><body>${bodyHtml}</body></html>`,
+    []
   )
 
-  const handleCopyHtml = useCallback(() => {
-    navigator.clipboard.writeText(buildFullHtml(BASE_EXPORT_STYLES))
-    setLastAction('HTML copied to clipboard', 'success')
+  const buildCurrentExportHtml = useCallback(
+    async (styles: string) => buildFullHtml(await renderMarkdownContent(state.content), styles),
+    [buildFullHtml, state.content]
+  )
+
+  const handleCopyHtml = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(await buildCurrentExportHtml(BASE_EXPORT_STYLES))
+      setLastAction('HTML copied to clipboard', 'success')
+    } catch {
+      setLastAction('Failed to copy HTML', 'error')
+    }
     setShowExport(false)
-  }, [buildFullHtml, setLastAction])
+  }, [buildCurrentExportHtml, setLastAction])
 
   const handleDownload = useCallback(
-    (format: 'md' | 'html') => {
-      const content = format === 'md' ? state.content : buildFullHtml(BASE_EXPORT_STYLES)
+    async (format: 'md' | 'html') => {
+      const content =
+        format === 'md' ? state.content : await buildCurrentExportHtml(BASE_EXPORT_STYLES)
       const blob = new Blob([content], {
         type: format === 'md' ? 'text/markdown' : 'text/html',
       })
@@ -732,11 +746,11 @@ export default function MarkdownEditor() {
       setLastAction(`Downloaded as .${format}`, 'success')
       setShowExport(false)
     },
-    [buildFullHtml, state.content, setLastAction]
+    [buildCurrentExportHtml, state.content, setLastAction]
   )
 
-  const handleExportPdf = useCallback(() => {
-    const fullHtml = buildFullHtml(PRINT_STYLES)
+  const handleExportPdf = useCallback(async () => {
+    const fullHtml = await buildCurrentExportHtml(PRINT_STYLES)
     const iframe = document.createElement('iframe')
     iframe.style.cssText = 'position:fixed;width:0;height:0;border:none;left:-9999px'
     document.body.appendChild(iframe)
@@ -763,7 +777,7 @@ export default function MarkdownEditor() {
     }
     setLastAction('Print dialog opened', 'success')
     setShowExport(false)
-  }, [buildFullHtml, setLastAction])
+  }, [buildCurrentExportHtml, setLastAction])
 
   const handleTemplateSelect = useCallback(
     (content: string) => {
@@ -885,26 +899,34 @@ export default function MarkdownEditor() {
                   Copy Markdown
                 </button>
                 <button
-                  onClick={handleCopyHtml}
+                  onClick={() => {
+                    void handleCopyHtml()
+                  }}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                 >
                   Copy HTML
                 </button>
                 <div className="my-1 border-t border-[var(--color-border)]" />
                 <button
-                  onClick={() => handleDownload('md')}
+                  onClick={() => {
+                    void handleDownload('md')
+                  }}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                 >
                   Download .md
                 </button>
                 <button
-                  onClick={() => handleDownload('html')}
+                  onClick={() => {
+                    void handleDownload('html')
+                  }}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                 >
                   Download .html
                 </button>
                 <button
-                  onClick={handleExportPdf}
+                  onClick={() => {
+                    void handleExportPdf()
+                  }}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                 >
                   Print / PDF

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
-import { getEffectiveTheme } from '@/lib/theme'
+import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { nextHeadingId } from './heading-ids'
 
 type TocEntry = {
@@ -86,6 +86,7 @@ const PREVIEW_STYLES = [
 export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
   function MarkdownPreview({ html, showToc, toc }, ref) {
     const innerRef = useRef<HTMLDivElement>(null)
+    const mermaidRenderSeqRef = useRef(0)
     const theme = useSettingsStore((s) => s.theme)
 
     // Expose the inner div via forwarded ref for scroll sync
@@ -95,13 +96,16 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     // ─── Mermaid diagrams (theme-aware) ───────────────────────────
     useEffect(() => {
       if (!html || !innerRef.current) return
+      const renderSeq = (mermaidRenderSeqRef.current += 1)
+      let cancelled = false
       const mermaidBlocks = innerRef.current.querySelectorAll('code.language-mermaid')
       if (mermaidBlocks.length === 0) return
 
       const effective = getEffectiveTheme(theme)
-      const mermaidTheme = effective === 'soft-focus' ? 'default' : 'dark'
+      const mermaidTheme = isLightEffectiveTheme(effective) ? 'default' : 'dark'
 
       import('mermaid').then(({ default: mermaid }) => {
+        if (cancelled || renderSeq !== mermaidRenderSeqRef.current) return
         mermaid.initialize({ startOnLoad: false, theme: mermaidTheme })
         mermaidBlocks.forEach(async (block, i) => {
           const parent = block.parentElement
@@ -111,6 +115,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
               `mermaid-${Date.now()}-${i}`,
               block.textContent ?? ''
             )
+            if (cancelled || renderSeq !== mermaidRenderSeqRef.current) return
             const wrapper = document.createElement('div')
             wrapper.className = 'mermaid-diagram'
             wrapper.innerHTML = svg
@@ -120,6 +125,9 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           }
         })
       })
+      return () => {
+        cancelled = true
+      }
     }, [html, theme])
 
     // ─── TOC scroll ───────────────────────────────────────────────

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -6,6 +6,8 @@ import { TabBar } from '@/components/shared/TabBar'
 import { Alert } from '@/components/shared/Alert'
 import { Button } from '@/components/shared/Button'
 import { useUiStore } from '@/stores/ui.store'
+import { useSettingsStore } from '@/stores/settings.store'
+import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { CaretDownIcon } from '@phosphor-icons/react'
 
 type MermaidEditorState = {
@@ -74,13 +76,13 @@ const MIN_ZOOM = 0.1
 const MAX_ZOOM = 8
 const DEFAULT_TRANSFORM: Transform = { x: 0, y: 0, scale: 1 }
 
-// Module-level init guard — mermaid.initialize is expensive; call it once
-let mermaidInitialized = false
-async function getMermaid() {
+let initializedMermaidTheme: 'default' | 'dark' | null = null
+
+async function getMermaid(theme: 'default' | 'dark') {
   const { default: mermaid } = await import('mermaid')
-  if (!mermaidInitialized) {
-    mermaid.initialize({ startOnLoad: false, theme: 'dark' })
-    mermaidInitialized = true
+  if (initializedMermaidTheme !== theme) {
+    mermaid.initialize({ startOnLoad: false, theme })
+    initializedMermaidTheme = theme
   }
   return mermaid
 }
@@ -88,6 +90,9 @@ async function getMermaid() {
 export default function MermaidEditor() {
   const monacoTheme = useMonacoTheme()
   const monacoOptions = useMonacoOptions()
+  const appTheme = useSettingsStore((s) => s.theme)
+  const effectiveTheme = getEffectiveTheme(appTheme)
+  const mermaidTheme = isLightEffectiveTheme(effectiveTheme) ? 'default' : 'dark'
   const [state, updateState] = useToolState<MermaidEditorState>('mermaid-editor', {
     content: TEMPLATES['flowchart'] ?? '',
     exportScale: 2,
@@ -101,6 +106,7 @@ export default function MermaidEditor() {
   const [showTemplates, setShowTemplates] = useState(false)
   const [showExport, setShowExport] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const renderSeqRef = useRef(0)
   const wheelCleanupRef = useRef<(() => void) | null>(null)
   const templatesRef = useRef<HTMLDivElement>(null)
   const exportRef = useRef<HTMLDivElement>(null)
@@ -215,6 +221,7 @@ export default function MermaidEditor() {
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    const renderSeq = (renderSeqRef.current += 1)
     if (!state.content.trim()) {
       setSvgHtml('')
       setError(null)
@@ -224,22 +231,26 @@ export default function MermaidEditor() {
     setIsRendering(true)
     debounceRef.current = setTimeout(async () => {
       try {
-        const mermaid = await getMermaid()
-        const { svg } = await mermaid.render('mermaid-preview', state.content)
+        const mermaid = await getMermaid(mermaidTheme)
+        const { svg } = await mermaid.render(`mermaid-preview-${renderSeq}`, state.content)
+        if (renderSeq !== renderSeqRef.current) return
         setSvgHtml(svg)
         setError(null)
       } catch (e) {
+        if (renderSeq !== renderSeqRef.current) return
         setError((e as Error).message)
         setSvgHtml('')
       } finally {
-        setIsRendering(false)
+        if (renderSeq === renderSeqRef.current) {
+          setIsRendering(false)
+        }
       }
     }, 500)
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
-  }, [state.content])
+  }, [state.content, mermaidTheme])
 
   // ─── Export handlers ─────────────────────────────────────────────
 

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -321,6 +321,8 @@ export default function RegexTester() {
                 key={flag}
                 onClick={() => toggleFlag(flag)}
                 title={FLAG_TITLES[flag]}
+                aria-label={`${FLAG_TITLES[flag]} flag`}
+                aria-pressed={state.flags.includes(flag)}
                 className={`h-6 w-6 rounded text-xs font-bold ${
                   state.flags.includes(flag)
                     ? 'bg-[var(--color-accent)] text-[var(--color-bg)]'


### PR DESCRIPTION
Summary
- Make note edits and note reorders update the drawer immediately instead of waiting on SQLite persistence.
- Serialize SQLite writes and manual transactions through the shared frontend DB helper to prevent nested transaction and lock errors.
- Move note drag start to the visible drag handle and keep reorder buttons outside a draggable parent surface.
- Reduce MCP-side SQLite write contention by using one pooled connection with a 5s busy timeout.
- Keep Markdown HTML export fresh at click time and report clipboard failures correctly.
- Guard Markdown/Mermaid preview rendering against stale async Mermaid completions.
- Use the shared light-theme classification for Mermaid rendering in both Markdown preview and Mermaid Editor.

Test plan
- [x] PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
- [x] PATH="/opt/homebrew/bin:$PATH" bunx vitest run
- [x] PATH="/opt/homebrew/bin:$PATH" bun run lint
- [x] cargo check