### PR TITLE
fix(cockpit): harden more cockpit tools

### DIFF
--- a/apps/cockpit/src/lib/xml-xpath.ts
+++ b/apps/cockpit/src/lib/xml-xpath.ts
@@ -1,0 +1,92 @@
+import type { Element, Node } from '@xmldom/xmldom'
+
+type XPathAxis = 'child' | 'descendant'
+
+type XPathSegment = {
+  axis: XPathAxis
+  tagName: string
+}
+
+function parseSimpleXPathExpression(expression: string): XPathSegment[] {
+  const normalized = expression.trim()
+  if (!normalized) return []
+
+  const source = normalized.startsWith('/') ? normalized : `/${normalized}`
+  const segments: XPathSegment[] = []
+  const matcher = /(\/\/|\/)([^/]+)/g
+
+  let match: RegExpExecArray | null
+  while ((match = matcher.exec(source)) !== null) {
+    const rawTag = match[2]?.trim().replace(/\[.*\]$/, '')
+    if (!rawTag) continue
+    segments.push({
+      axis: match[1] === '//' ? 'descendant' : 'child',
+      tagName: rawTag,
+    })
+  }
+
+  return segments
+}
+
+function isElementNode(node: Node | null | undefined): node is Element {
+  return Boolean(node && node.nodeType === 1)
+}
+
+function collectDescendantMatches(node: Node, tagName: string, results: Node[]) {
+  if (!node.childNodes) return
+
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = node.childNodes.item(i)
+    if (!isElementNode(child)) continue
+    if (child.tagName === tagName) results.push(child)
+    collectDescendantMatches(child, tagName, results)
+  }
+}
+
+export function evaluateSimpleXPath(
+  doc: { documentElement: Element | null },
+  expression: string
+): Node[] {
+  const root = doc.documentElement
+  if (!root) return []
+
+  const segments = parseSimpleXPathExpression(expression)
+  if (segments.length === 0) return []
+
+  let current: Node[] = [root]
+
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]
+    if (!segment) return []
+
+    const next: Node[] = []
+
+    for (const node of current) {
+      if (!isElementNode(node)) continue
+
+      if (segment.axis === 'child') {
+        if (index === 0 && node === root && node.tagName === segment.tagName) {
+          next.push(node)
+          continue
+        }
+
+        for (let i = 0; i < node.childNodes.length; i++) {
+          const child = node.childNodes.item(i)
+          if (isElementNode(child) && child.tagName === segment.tagName) {
+            next.push(child)
+          }
+        }
+        continue
+      }
+
+      if (node.tagName === segment.tagName) {
+        next.push(node)
+      }
+      collectDescendantMatches(node, segment.tagName, next)
+    }
+
+    current = next
+  }
+
+  return current
+}

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
-import { renderTool } from './test-utils'
-import JsonTools from '../json-tools/JsonTools'
+import { renderTool } from '@/tools/__tests__/test-utils'
+import JsonTools, { isTabularJsonArray } from '@/tools/json-tools/JsonTools'
 
 describe('JsonTools', () => {
   it('renders editor', () => {
@@ -31,5 +31,20 @@ describe('JsonTools', () => {
     expect(screen.getByText('Lint & Format')).toBeInTheDocument()
     expect(screen.getByText('Tree View')).toBeInTheDocument()
     expect(screen.getByText('Table View')).toBeInTheDocument()
+  })
+
+  it('treats only arrays of objects as table-compatible data', () => {
+    expect(isTabularJsonArray([{ id: 1 }, { id: 2 }])).toBe(true)
+    expect(isTabularJsonArray([1, 2, 3])).toBe(false)
+    expect(isTabularJsonArray([{ id: 1 }, null])).toBe(false)
+  })
+
+  it('shows guidance instead of an empty grid for primitive arrays', () => {
+    renderTool(JsonTools)
+    const editor = screen.getByTestId('monaco-editor')
+    fireEvent.change(editor, { target: { value: '[1,2,3]' } })
+    fireEvent.click(screen.getByText('Table View'))
+
+    expect(screen.getByText('Table view requires a JSON array of objects')).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/jwt-decoder.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/jwt-decoder.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
-import { renderTool } from './test-utils'
-import JwtDecoder from '../jwt-decoder/JwtDecoder'
+import { renderTool } from '@/tools/__tests__/test-utils'
+import JwtDecoder from '@/tools/jwt-decoder/JwtDecoder'
 
 const TEST_JWT =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+const NULL_PAYLOAD_JWT = 'eyJhbGciOiJub25lIn0.bnVsbA.'
 
 describe('JwtDecoder', () => {
   it('renders input area', () => {
@@ -37,6 +38,15 @@ describe('JwtDecoder', () => {
     fireEvent.change(screen.getByPlaceholderText(/paste a jwt/i), {
       target: { value: 'not.a.jwt' },
     })
+    expect(screen.getByText(/invalid jwt/i)).toBeInTheDocument()
+  })
+
+  it('treats non-object payloads as invalid instead of crashing', () => {
+    renderTool(JwtDecoder)
+    fireEvent.change(screen.getByPlaceholderText(/paste a jwt/i), {
+      target: { value: NULL_PAYLOAD_JWT },
+    })
+
     expect(screen.getByText(/invalid jwt/i)).toBeInTheDocument()
   })
 

--- a/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act, screen, fireEvent, render } from '@testing-library/react'
-import { renderTool } from './test-utils'
-import MermaidEditor from '../mermaid-editor/MermaidEditor'
+import { renderTool } from '@/tools/__tests__/test-utils'
+import MermaidEditor from '@/tools/mermaid-editor/MermaidEditor'
 import { useSettingsStore } from '@/stores/settings.store'
 import { DEFAULT_SETTINGS } from '@/types/models'
 
@@ -113,6 +113,20 @@ describe('MermaidEditor', () => {
       theme: 'default',
     })
   })
+
+  it('keeps the rendered preview interactive instead of disabling pointer events', async () => {
+    vi.useFakeTimers()
+    mermaidMock.render.mockResolvedValue({ svg: '<svg><a href="#node">Node</a></svg>' })
+
+    renderTool(MermaidEditor)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(screen.getByTestId('mermaid-preview-content').parentElement).not.toHaveStyle({
+      pointerEvents: 'none',
+    })
+  })
 })
 
 describe('MermaidEditor — Templates dropdown', () => {
@@ -141,6 +155,18 @@ describe('MermaidEditor — Templates dropdown', () => {
     expect(screen.getByText('flowchart')).toBeInTheDocument()
     fireEvent.mouseDown(screen.getByTestId('outside'))
     expect(screen.queryByText('flowchart')).toBeNull()
+  })
+
+  it('opens from the keyboard and closes with Escape', () => {
+    renderTool(MermaidEditor)
+    const button = screen.getByRole('button', { name: 'Templates' })
+
+    fireEvent.keyDown(button, { key: 'ArrowDown' })
+    expect(screen.getByRole('menu', { name: 'Mermaid templates' })).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByRole('menu', { name: 'Mermaid templates' }), { key: 'Escape' })
+    expect(screen.queryByRole('menu', { name: 'Mermaid templates' })).toBeNull()
+    expect(button).toHaveFocus()
   })
 })
 
@@ -196,5 +222,19 @@ describe('MermaidEditor — Export dropdown', () => {
     expect(screen.getByText('Copy SVG')).toBeInTheDocument()
     fireEvent.mouseDown(screen.getByTestId('outside'))
     expect(screen.queryByText('Copy SVG')).toBeNull()
+  })
+
+  it('opens the export menu from the keyboard and closes it with Escape', () => {
+    renderTool(MermaidEditor)
+    const button = screen.getByRole('button', { name: 'Export' })
+
+    fireEvent.keyDown(button, { key: 'ArrowDown' })
+    expect(screen.getByRole('menu', { name: 'Mermaid export actions' })).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByRole('menu', { name: 'Mermaid export actions' }), {
+      key: 'Escape',
+    })
+    expect(screen.queryByRole('menu', { name: 'Mermaid export actions' })).toBeNull()
+    expect(button).toHaveFocus()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/regex-tester-component.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/regex-tester-component.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
-import { renderTool } from './test-utils'
-import RegexTester from '../regex-tester/RegexTester'
+import { renderTool } from '@/tools/__tests__/test-utils'
+import RegexTester from '@/tools/regex-tester/RegexTester'
 
 describe('RegexTester (component)', () => {
   it('renders pattern input and test string area', () => {
@@ -110,6 +110,35 @@ describe('RegexTester (component)', () => {
     // Stats show added/removed char counts
     // "hello" (5) replaced by "hi" (2): -5 +2
     expect(screen.getByText(/chars/i)).toBeInTheDocument()
+  })
+
+  it('keeps unnamed capture groups when named groups are also present', () => {
+    renderTool(RegexTester)
+    fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), {
+      target: { value: '([A-Z])(?<digits>\\d+)' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/enter text to test/i), {
+      target: { value: 'A12' },
+    })
+
+    expect(screen.getByText('$1')).toBeInTheDocument()
+    expect(screen.getByText('digits')).toBeInTheDocument()
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+  })
+
+  it('warns when only the first 1000 matches are shown', () => {
+    renderTool(RegexTester)
+    fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), {
+      target: { value: '.' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/enter text to test/i), {
+      target: { value: 'a'.repeat(1205) },
+    })
+
+    expect(screen.getByText('1000+')).toBeInTheDocument()
+    expect(screen.getByText('Showing first 1000 matches')).toBeInTheDocument()
+    expect(screen.getByText(/First 1000 matches/)).toBeInTheDocument()
   })
 
   it('toggling Diff off returns to plain result view', () => {

--- a/apps/cockpit/src/tools/__tests__/xml-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/xml-tools.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
-import { renderTool } from './test-utils'
-import XmlTools from '../xml-tools/XmlTools'
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom'
+import { renderTool } from '@/tools/__tests__/test-utils'
+import XmlTools from '@/tools/xml-tools/XmlTools'
+import { evaluateSimpleXPath } from '@/lib/xml-xpath'
 
 describe('XmlTools', () => {
   it('renders tab bar', () => {
@@ -26,5 +28,30 @@ describe('XmlTools', () => {
     renderTool(XmlTools)
     fireEvent.click(screen.getByText('XPath'))
     expect(screen.getByPlaceholderText(/xpath/i)).toBeInTheDocument()
+  })
+
+  it('matches absolute XPath expressions that include the root element', () => {
+    const doc = new DOMParser().parseFromString('<root><child>1</child></root>', 'text/xml')
+    const serializer = new XMLSerializer()
+
+    const matches = evaluateSimpleXPath(doc, '/root/child').map((node) =>
+      serializer.serializeToString(node)
+    )
+
+    expect(matches).toEqual(['<child>1</child>'])
+  })
+
+  it('matches descendant XPath expressions', () => {
+    const doc = new DOMParser().parseFromString(
+      '<root><wrapper><child>1</child></wrapper></root>',
+      'text/xml'
+    )
+    const serializer = new XMLSerializer()
+
+    const matches = evaluateSimpleXPath(doc, '//child').map((node) =>
+      serializer.serializeToString(node)
+    )
+
+    expect(matches).toEqual(['<child>1</child>'])
   })
 })

--- a/apps/cockpit/src/tools/__tests__/yaml-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/yaml-tools.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { jsonToYaml, parseYaml, yamlToJson } from '@/tools/yaml-tools/yaml-helpers'
+
+describe('yaml-tools helpers', () => {
+  it('accepts YAML null documents as valid input', () => {
+    expect(parseYaml('null')).toEqual({ ok: true, data: null, error: null })
+  })
+
+  it('converts YAML null to JSON null', () => {
+    expect(yamlToJson('null')).toBe('null')
+  })
+
+  it('converts JSON null to YAML null', () => {
+    expect(jsonToYaml('null')).toBe('null\n')
+  })
+})

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react'
+import { useCallback, useMemo, useRef, useState, useEffect, type ReactNode } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
@@ -80,6 +80,13 @@ function queryJsonPath(data: unknown, path: string): unknown {
     current = (current as Record<string, unknown>)[part]
   }
   return current
+}
+
+export function isTabularJsonArray(data: unknown): data is Record<string, unknown>[] {
+  return (
+    Array.isArray(data) &&
+    data.every((item) => item !== null && typeof item === 'object' && !Array.isArray(item))
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -318,8 +325,8 @@ export default function JsonTools() {
         {/* ── Table View ────────────────────────────────────── */}
         {state.activeTab === 'table' && (
           <div className="h-full overflow-auto p-4">
-            {parsed.ok && Array.isArray(parsed.data) ? (
-              <JsonTable data={parsed.data as Record<string, unknown>[]} />
+            {parsed.ok && isTabularJsonArray(parsed.data) ? (
+              <JsonTable data={parsed.data} />
             ) : (
               <div className="text-sm text-[var(--color-text-muted)]">
                 {parsed.error
@@ -333,6 +340,27 @@ export default function JsonTools() {
         )}
       </div>
     </div>
+  )
+}
+
+function TreeValueButton({
+  children,
+  className,
+  onClick,
+}: {
+  children: ReactNode
+  className: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Click to copy"
+      className={`cursor-pointer rounded hover:underline ${className}`}
+    >
+      {children}
+    </button>
   )
 }
 
@@ -368,57 +396,52 @@ function JsonTree({
 
   if (data === null)
     return (
-      <span
-        className="cursor-pointer text-[var(--color-text-muted)] hover:underline"
-        onClick={() => copyValue(null)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-text-muted)]" onClick={() => copyValue(null)}>
         null
-      </span>
+      </TreeValueButton>
     )
   if (typeof data === 'boolean')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-warning)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-warning)]" onClick={() => copyValue(data)}>
         {String(data)}
-      </span>
+      </TreeValueButton>
     )
   if (typeof data === 'number')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-accent)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-accent)]" onClick={() => copyValue(data)}>
         {data}
-      </span>
+      </TreeValueButton>
     )
   if (typeof data === 'string')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-success)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-success)]" onClick={() => copyValue(data)}>
         &quot;{data}&quot;
-      </span>
+      </TreeValueButton>
     )
 
   if (Array.isArray(data)) {
+    const hasChildren = data.length > 0
     return (
       <div className="ml-4">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-        >
-          {expanded ? '▼' : '▶'}{' '}
-          <span className="cursor-pointer text-xs hover:underline" onClick={copyPath}>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => hasChildren && setExpanded(!expanded)}
+            aria-expanded={hasChildren ? expanded : undefined}
+            disabled={!hasChildren}
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            {hasChildren ? (expanded ? '▼' : '▶') : '•'}
+          </button>
+          <button
+            type="button"
+            className="text-xs text-[var(--color-text-muted)] hover:underline"
+            onClick={copyPath}
+            title="Copy path"
+          >
             [{data.length}]
-          </span>
-        </button>
+          </button>
+        </div>
         {expanded &&
           data.map((item, i) => (
             <div key={i} className="ml-4">
@@ -432,17 +455,28 @@ function JsonTree({
 
   if (typeof data === 'object') {
     const entries = Object.entries(data as Record<string, unknown>)
+    const hasChildren = entries.length > 0
     return (
       <div className="ml-4">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-        >
-          {expanded ? '▼' : '▶'}{' '}
-          <span className="cursor-pointer text-xs hover:underline" onClick={copyPath}>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => hasChildren && setExpanded(!expanded)}
+            aria-expanded={hasChildren ? expanded : undefined}
+            disabled={!hasChildren}
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            {hasChildren ? (expanded ? '▼' : '▶') : '•'}
+          </button>
+          <button
+            type="button"
+            className="text-xs text-[var(--color-text-muted)] hover:underline"
+            onClick={copyPath}
+            title="Copy path"
+          >
             {`{${entries.length}}`}
-          </span>
-        </button>
+          </button>
+        </div>
         {expanded &&
           entries.map(([key, value]) => (
             <div key={key} className="ml-4">
@@ -489,6 +523,14 @@ function JsonTable({ data }: { data: Record<string, unknown>[] }) {
 
   if (data.length === 0)
     return <div className="text-sm text-[var(--color-text-muted)]">Empty array</div>
+
+  if (columns.length === 0) {
+    return (
+      <div className="text-sm text-[var(--color-text-muted)]">
+        Table view requires a JSON array of objects
+      </div>
+    )
+  }
 
   return (
     <div className="overflow-auto">

--- a/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -53,6 +53,10 @@ function decodeBase64Url(str: string): string {
   )
 }
 
+export function isJwtObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 function decodeJwt(token: string): DecodedJwt | null {
   const parts = token.trim().split('.')
   if (parts.length !== 3) return null
@@ -61,8 +65,9 @@ function decodeJwt(token: string): DecodedJwt | null {
     const headerRaw = decodeBase64Url(parts[0]!) // safe: length === 3 checked above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const payloadRaw = decodeBase64Url(parts[1]!) // safe: length === 3 checked above
-    const header = JSON.parse(headerRaw) as Record<string, unknown>
-    const payload = JSON.parse(payloadRaw) as Record<string, unknown>
+    const header = JSON.parse(headerRaw) as unknown
+    const payload = JSON.parse(payloadRaw) as unknown
+    if (!isJwtObject(header) || !isJwtObject(payload)) return null
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return { header, payload, signature: parts[2]!, headerRaw, payloadRaw } // safe: length === 3
   } catch {

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -87,6 +87,42 @@ async function getMermaid(theme: 'default' | 'dark') {
   return mermaid
 }
 
+function getMenuItems(menu: HTMLElement | null): HTMLButtonElement[] {
+  if (!menu) return []
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')).filter(
+    (item) => !item.disabled
+  )
+}
+
+function focusFirstMenuItem(menu: HTMLElement | null) {
+  const items = getMenuItems(menu)
+  items[0]?.focus()
+}
+
+function moveMenuFocus(menu: HTMLElement | null, direction: 1 | -1) {
+  const items = getMenuItems(menu)
+  if (items.length === 0) return
+
+  const activeElement = document.activeElement
+  const currentIndex = items.findIndex((item) => item === activeElement)
+  const nextIndex =
+    currentIndex === -1
+      ? direction === 1
+        ? 0
+        : items.length - 1
+      : (currentIndex + direction + items.length) % items.length
+
+  items[nextIndex]?.focus()
+}
+
+function scheduleFrame(callback: () => void) {
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(callback)
+    return
+  }
+  setTimeout(callback, 0)
+}
+
 export default function MermaidEditor() {
   const monacoTheme = useMonacoTheme()
   const monacoOptions = useMonacoOptions()
@@ -110,6 +146,10 @@ export default function MermaidEditor() {
   const wheelCleanupRef = useRef<(() => void) | null>(null)
   const templatesRef = useRef<HTMLDivElement>(null)
   const exportRef = useRef<HTMLDivElement>(null)
+  const templatesButtonRef = useRef<HTMLButtonElement>(null)
+  const exportButtonRef = useRef<HTMLButtonElement>(null)
+  const templatesMenuRef = useRef<HTMLDivElement>(null)
+  const exportMenuRef = useRef<HTMLDivElement>(null)
 
   const mode = state.mode ?? 'split'
   const showEditor = mode === 'edit' || mode === 'split'
@@ -163,6 +203,12 @@ export default function MermaidEditor() {
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.button !== 0) return
+    if (
+      e.target instanceof Element &&
+      e.target.closest('a, button, [role="button"], [href], .clickable')
+    ) {
+      return
+    }
     isPanning.current = true
     const { x, y } = transformRef.current
     panStart.current = { mouseX: e.clientX, mouseY: e.clientY, originX: x, originY: y }
@@ -215,6 +261,18 @@ export default function MermaidEditor() {
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
+  }, [showExport])
+
+  useEffect(() => {
+    if (showTemplates) {
+      scheduleFrame(() => focusFirstMenuItem(templatesMenuRef.current))
+    }
+  }, [showTemplates])
+
+  useEffect(() => {
+    if (showExport) {
+      scheduleFrame(() => focusFirstMenuItem(exportMenuRef.current))
+    }
   }, [showExport])
 
   // ─── Mermaid rendering (debounced 500ms) ─────────────────────────
@@ -358,24 +416,57 @@ export default function MermaidEditor() {
           {/* Templates dropdown */}
           <div ref={templatesRef} className="relative">
             <Button
+              ref={templatesButtonRef}
               variant="ghost"
               size="sm"
               onClick={() => setShowTemplates(!showTemplates)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setShowTemplates(true)
+                } else if (e.key === 'Escape') {
+                  setShowTemplates(false)
+                }
+              }}
               className={`gap-1 ${showTemplates ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''}`}
               aria-expanded={showTemplates}
               aria-haspopup="menu"
+              aria-controls="mermaid-templates-menu"
             >
               Templates
               <CaretDownIcon size={10} />
             </Button>
             {showTemplates && (
-              <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
+              <div
+                id="mermaid-templates-menu"
+                ref={templatesMenuRef}
+                role="menu"
+                aria-label="Mermaid templates"
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault()
+                    setShowTemplates(false)
+                    templatesButtonRef.current?.focus()
+                  } else if (e.key === 'ArrowDown') {
+                    e.preventDefault()
+                    moveMenuFocus(templatesMenuRef.current, 1)
+                  } else if (e.key === 'ArrowUp') {
+                    e.preventDefault()
+                    moveMenuFocus(templatesMenuRef.current, -1)
+                  }
+                }}
+                className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg"
+              >
                 {Object.keys(TEMPLATES).map((name) => (
                   <button
                     key={name}
+                    type="button"
+                    role="menuitem"
+                    tabIndex={-1}
                     onClick={() => {
                       updateState({ content: TEMPLATES[name] ?? '' })
                       setShowTemplates(false)
+                      templatesButtonRef.current?.focus()
                     }}
                     className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                   >
@@ -389,19 +480,51 @@ export default function MermaidEditor() {
           {/* Export dropdown */}
           <div ref={exportRef} className="relative">
             <Button
+              ref={exportButtonRef}
               variant="ghost"
               size="sm"
               onClick={() => setShowExport(!showExport)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setShowExport(true)
+                } else if (e.key === 'Escape') {
+                  setShowExport(false)
+                }
+              }}
               className={`gap-1 ${showExport ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''}`}
               aria-expanded={showExport}
               aria-haspopup="menu"
+              aria-controls="mermaid-export-menu"
             >
               Export
               <CaretDownIcon size={10} />
             </Button>
             {showExport && (
-              <div className="absolute right-0 top-full z-10 mt-1 min-w-[180px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
+              <div
+                id="mermaid-export-menu"
+                ref={exportMenuRef}
+                role="menu"
+                aria-label="Mermaid export actions"
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault()
+                    setShowExport(false)
+                    exportButtonRef.current?.focus()
+                  } else if (e.key === 'ArrowDown') {
+                    e.preventDefault()
+                    moveMenuFocus(exportMenuRef.current, 1)
+                  } else if (e.key === 'ArrowUp') {
+                    e.preventDefault()
+                    moveMenuFocus(exportMenuRef.current, -1)
+                  }
+                }}
+                className="absolute right-0 top-full z-10 mt-1 min-w-[180px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg"
+              >
                 <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
                   onClick={handleCopySvg}
                   disabled={!svgHtml}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -409,6 +532,9 @@ export default function MermaidEditor() {
                   Copy SVG
                 </button>
                 <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
                   onClick={handleDownloadSvg}
                   disabled={!svgHtml}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -425,6 +551,9 @@ export default function MermaidEditor() {
                     {EXPORT_SCALES.map((s) => (
                       <button
                         key={s}
+                        type="button"
+                        role="menuitem"
+                        tabIndex={-1}
                         onClick={() => updateState({ exportScale: s })}
                         title={`Export PNG at ${s}× resolution`}
                         className={`px-1.5 py-0.5 text-[10px] transition-colors first:rounded-l last:rounded-r ${
@@ -439,6 +568,9 @@ export default function MermaidEditor() {
                   </div>
                 </div>
                 <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
                   onClick={handleCopyPng}
                   disabled={!svgHtml}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -446,6 +578,9 @@ export default function MermaidEditor() {
                   Copy PNG ({exportScale}×)
                 </button>
                 <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
                   onClick={handleDownloadPng}
                   disabled={!svgHtml}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -456,6 +591,9 @@ export default function MermaidEditor() {
                 <div className="my-1 border-t border-[var(--color-border)]" />
 
                 <button
+                  type="button"
+                  role="menuitem"
+                  tabIndex={-1}
                   onClick={handleCopySource}
                   className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
                 >
@@ -518,11 +656,13 @@ export default function MermaidEditor() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 padding: '1rem',
-                pointerEvents: 'none',
               }}
             >
               {svgHtml ? (
-                <div dangerouslySetInnerHTML={{ __html: svgHtml }} />
+                <div
+                  data-testid="mermaid-preview-content"
+                  dangerouslySetInnerHTML={{ __html: svgHtml }}
+                />
               ) : (
                 <div className="select-none text-center text-sm text-[var(--color-text-muted)]">
                   {isRendering ? (

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -17,7 +17,7 @@ type Match = {
   full: string
   index: number
   length: number
-  groups: Array<{ name: string | null; value: string }>
+  groups: Array<{ index: number; name: string | null; value: string }>
 }
 
 // ── Reference data ─────────────────────────────────────────────────
@@ -86,38 +86,95 @@ const MODE_TABS = [
   { id: 'replace', label: 'Replace' },
 ]
 
+const MAX_REGEX_MATCHES = 1000
+
 // ── Matching logic ─────────────────────────────────────────────────
+
+export function extractCaptureGroupNames(pattern: string): Array<string | null> {
+  const names: Array<string | null> = []
+  let inClass = false
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]
+    if (!char) break
+
+    if (char === '\\') {
+      i++
+      continue
+    }
+
+    if (char === '[') {
+      inClass = true
+      continue
+    }
+
+    if (char === ']' && inClass) {
+      inClass = false
+      continue
+    }
+
+    if (inClass || char !== '(') continue
+
+    const next = pattern[i + 1]
+    if (next !== '?') {
+      names.push(null)
+      continue
+    }
+
+    if (
+      pattern.startsWith('(?:', i) ||
+      pattern.startsWith('(?=', i) ||
+      pattern.startsWith('(?!', i)
+    ) {
+      continue
+    }
+
+    if (pattern.startsWith('(?<=', i) || pattern.startsWith('(?<!', i)) {
+      continue
+    }
+
+    if (pattern.startsWith('(?<', i)) {
+      const end = pattern.indexOf('>', i + 3)
+      if (end !== -1) {
+        names.push(pattern.slice(i + 3, end))
+      }
+    }
+  }
+
+  return names
+}
 
 function findMatches(
   pattern: string,
   flags: string,
   text: string
-): { matches: Match[]; error: string | null } {
-  if (!pattern) return { matches: [], error: null }
+): { matches: Match[]; error: string | null; truncated: boolean } {
+  if (!pattern) return { matches: [], error: null, truncated: false }
   try {
     const re = new RegExp(pattern, flags)
     const matches: Match[] = []
+    const captureGroupNames = extractCaptureGroupNames(pattern)
 
-    // Build an ordered list of named groups (preserving capture order) from a match.
-    // Using Object.entries(m.groups) directly is correct and avoids false positives
-    // when two groups capture the same value (the old value-search approach would
-    // misattribute the name in that case).
     function buildGroups(m: RegExpExecArray): Match['groups'] {
-      if (m.groups && Object.keys(m.groups).length > 0) {
-        return Object.entries(m.groups).map(([name, value]) => ({ name, value: value ?? '' }))
-      }
       const groups: Match['groups'] = []
       for (let i = 1; i < m.length; i++) {
-        groups.push({ name: null, value: m[i] ?? '' })
+        groups.push({
+          index: i,
+          name: captureGroupNames[i - 1] ?? null,
+          value: m[i] ?? '',
+        })
       }
       return groups
     }
 
+    let truncated = false
     if (flags.includes('g')) {
       let m: RegExpExecArray | null
-      let guard = 0
-      while ((m = re.exec(text)) !== null && guard < 1000) {
-        guard++
+      while ((m = re.exec(text)) !== null) {
+        if (matches.length >= MAX_REGEX_MATCHES) {
+          truncated = true
+          break
+        }
         matches.push({ full: m[0], index: m.index, length: m[0].length, groups: buildGroups(m) })
         if (m[0] === '') re.lastIndex++
       }
@@ -128,9 +185,9 @@ function findMatches(
       }
     }
 
-    return { matches, error: null }
+    return { matches, error: null, truncated }
   } catch (e) {
-    return { matches: [], error: (e as Error).message }
+    return { matches: [], error: (e as Error).message, truncated: false }
   }
 }
 
@@ -147,17 +204,24 @@ const MATCH_COLORS = [
   { bg: 'var(--color-info)', text: 'var(--color-bg)' },
 ]
 
-function highlightMatches(text: string, pattern: string, flags: string): string {
-  if (!pattern || !text) return ''
+function highlightMatches(
+  text: string,
+  pattern: string,
+  flags: string
+): { html: string; truncated: boolean } {
+  if (!pattern || !text) return { html: '', truncated: false }
   try {
     const re = new RegExp(pattern, flags.includes('g') ? flags : flags + 'g')
     const parts: string[] = []
     let lastIndex = 0
     let m: RegExpExecArray | null
-    let guard = 0
     let colorIdx = 0
-    while ((m = re.exec(text)) !== null && guard < 1000) {
-      guard++
+    let truncated = false
+    while ((m = re.exec(text)) !== null) {
+      if (colorIdx >= MAX_REGEX_MATCHES) {
+        truncated = true
+        break
+      }
       parts.push(escapeHtml(text.slice(lastIndex, m.index)))
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const c = MATCH_COLORS[colorIdx % MATCH_COLORS.length]! // safe: modulo keeps index in bounds
@@ -169,9 +233,9 @@ function highlightMatches(text: string, pattern: string, flags: string): string 
       if (m[0] === '') re.lastIndex++
     }
     parts.push(escapeHtml(text.slice(lastIndex)))
-    return parts.join('')
+    return { html: parts.join(''), truncated }
   } catch {
-    return escapeHtml(text)
+    return { html: escapeHtml(text), truncated: false }
   }
 }
 
@@ -288,14 +352,14 @@ export default function RegexTester() {
       try {
         await navigator.clipboard.writeText(text)
         setLastAction(
-          `Copied ${result.matches.length} match${result.matches.length !== 1 ? 'es' : ''} as ${format === 'json' ? 'JSON' : 'lines'}`,
+          `Copied ${result.truncated ? `first ${result.matches.length}` : result.matches.length} match${result.matches.length !== 1 ? 'es' : ''} as ${format === 'json' ? 'JSON' : 'lines'}`,
           'success'
         )
       } catch {
         setLastAction('Failed to copy', 'error')
       }
     },
-    [result.matches, setLastAction]
+    [result.matches, result.truncated, setLastAction]
   )
 
   const matchCount = result.matches.length
@@ -344,7 +408,12 @@ export default function RegexTester() {
           )}
           {!result.error && matchCount > 0 && (
             <span className="rounded-full bg-[var(--color-accent-dim)] px-2 py-0.5 text-xs font-bold text-[var(--color-accent)]">
-              {matchCount}
+              {result.truncated ? `${matchCount}+` : matchCount}
+            </span>
+          )}
+          {!result.error && result.truncated && (
+            <span className="text-xs text-[var(--color-warning)]">
+              Showing first {MAX_REGEX_MATCHES} matches
             </span>
           )}
         </div>
@@ -451,7 +520,7 @@ export default function RegexTester() {
                 className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm text-[var(--color-text)]"
                 dangerouslySetInnerHTML={{
                   __html:
-                    highlighted ||
+                    highlighted.html ||
                     '<span style="color:var(--color-text-muted)">Matches will be highlighted here</span>',
                 }}
               />
@@ -464,7 +533,8 @@ export default function RegexTester() {
           <div className="max-h-48 shrink-0 overflow-auto border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
             <div className="mb-2 flex items-center gap-2 font-mono text-xs text-[var(--color-text-muted)]">
               <span>
-                {matchCount} match{matchCount !== 1 ? 'es' : ''}
+                {result.truncated ? `First ${matchCount}` : matchCount} match
+                {matchCount !== 1 ? 'es' : ''}
                 {hasGroups
                   ? ` · ${result.matches.reduce((n, m) => n + m.groups.length, 0)} groups`
                   : ''}
@@ -489,7 +559,7 @@ export default function RegexTester() {
                         {g.name ? (
                           <span className="text-[var(--color-info)]">{g.name}</span>
                         ) : (
-                          <span className="opacity-60">${j + 1}</span>
+                          <span className="opacity-60">${g.index}</span>
                         )}
                         {'='}
                         <code className="text-[var(--color-text)]">{g.value}</code>

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -129,10 +129,13 @@ function TreeNodeRow({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
 
   return (
     <div>
-      <div
+      <button
+        type="button"
         style={{ paddingLeft: indent }}
-        className="flex cursor-pointer items-center gap-1 py-0.5 text-xs hover:bg-[var(--color-surface-hover)]"
+        className="flex w-full items-center gap-1 py-0.5 text-left text-xs hover:bg-[var(--color-surface-hover)]"
         onClick={() => hasChildren && setExpanded(!expanded)}
+        aria-expanded={hasChildren ? expanded : undefined}
+        disabled={!hasChildren}
       >
         {hasChildren ? (
           <span className="w-3 text-center text-[var(--color-text-muted)]">
@@ -151,7 +154,7 @@ function TreeNodeRow({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
         ))}
         <span className="text-[var(--color-accent)]">{hasChildren ? '>' : ' />'}</span>
         {!hasChildren && <span className="ml-1 text-[var(--color-text-muted)]">(empty)</span>}
-      </div>
+      </button>
       {expanded &&
         hasChildren &&
         node.children.map((child, i) => <TreeNodeRow key={i} node={child} depth={depth + 1} />)}
@@ -222,6 +225,16 @@ export default function XmlTools() {
     }
   }, [worker, state.input])
 
+  useEffect(() => {
+    setJsonOutput('')
+    setJsonError(null)
+    setXpathResults([])
+  }, [state.input])
+
+  useEffect(() => {
+    setXpathResults([])
+  }, [state.xpathQuery])
+
   const handleFormat = useCallback(async () => {
     if (!worker || !state.input.trim()) return
     const result = await worker.format(state.input, state.indent)
@@ -275,7 +288,10 @@ export default function XmlTools() {
   }, [worker, state.input, setLastAction])
 
   const handleXPath = useCallback(async () => {
-    if (!worker || !state.input.trim() || !state.xpathQuery.trim()) return
+    if (!worker || !state.input.trim() || !state.xpathQuery.trim()) {
+      setXpathResults([])
+      return
+    }
     const result = await worker.queryXPath(state.input, state.xpathQuery)
     setXpathResults(result.matches)
     setLastAction(`${result.count} match(es)`, result.count > 0 ? 'success' : 'info')
@@ -413,7 +429,7 @@ export default function XmlTools() {
                 placeholder="Enter XPath expression (e.g. /root/child)"
                 className="flex-1"
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleXPath()
+                  if (e.key === 'Enter') void handleXPath()
                 }}
               />
               <Button variant="primary" size="sm" onClick={handleXPath}>

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react'
+import { useCallback, useMemo, useRef, useState, useEffect, type ReactNode } from 'react'
 import Editor from '@monaco-editor/react'
 import { CheckCircleIcon, XCircleIcon } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -11,7 +11,13 @@ import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
-import { parseYaml, stringifyYaml, sortKeysDeep, yamlToJson, jsonToYaml } from './yaml-helpers'
+import {
+  parseYaml,
+  stringifyYaml,
+  sortKeysDeep,
+  yamlToJson,
+  jsonToYaml,
+} from '@/tools/yaml-tools/yaml-helpers'
 
 type YamlToolsState = {
   input: string
@@ -56,6 +62,27 @@ function yamlStats(data: unknown): { keys: number; depth: number; size: string }
   }
 }
 
+function TreeValueButton({
+  children,
+  className,
+  onClick,
+}: {
+  children: ReactNode
+  className: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title="Click to copy"
+      className={`cursor-pointer rounded hover:underline ${className}`}
+    >
+      {children}
+    </button>
+  )
+}
+
 export default function YamlTools() {
   const monacoTheme = useMonacoTheme()
   const monacoOptions = useMonacoOptions()
@@ -92,6 +119,11 @@ export default function YamlTools() {
     }
   }, [formatter])
 
+  useEffect(() => {
+    setConvertOutput('')
+    setConvertError(null)
+  }, [state.input, state.jsonInput, convertDirection])
+
   const parsed = useMemo(() => parseYaml(state.input), [state.input])
 
   const stats = useMemo(() => {
@@ -119,7 +151,7 @@ export default function YamlTools() {
   }, [formatter, state.input, updateState, setLastAction])
 
   const handleMinify = useCallback(() => {
-    if (!parsed.ok || parsed.data === null) return
+    if (!parsed.ok) return
     try {
       const minified = stringifyYaml(parsed.data).replace(/\n\s*\n/g, '\n')
       updateState({ input: minified })
@@ -133,7 +165,7 @@ export default function YamlTools() {
   }, [parsed, updateState, setLastAction])
 
   const handleSortKeys = useCallback(() => {
-    if (!parsed.ok || parsed.data === null) return
+    if (!parsed.ok) return
     try {
       const sorted = sortKeysDeep(parsed.data)
       const result = stringifyYaml(sorted)
@@ -175,6 +207,7 @@ export default function YamlTools() {
         setLastAction('Converted JSON → YAML', 'success')
       }
     } catch (e) {
+      setConvertOutput('')
       setConvertError(e instanceof Error ? e.message : String(e))
       setLastAction('Conversion failed', 'error')
     } finally {
@@ -198,25 +231,15 @@ export default function YamlTools() {
               <Button variant="primary" size="sm" onClick={handleFormat} disabled={isFormatting}>
                 {isFormatting ? 'Formatting…' : 'Format'}
               </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleMinify}
-                disabled={!parsed.ok || parsed.data === null}
-              >
+              <Button variant="secondary" size="sm" onClick={handleMinify} disabled={!parsed.ok}>
                 Minify
               </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSortKeys}
-                disabled={!parsed.ok || parsed.data === null}
-              >
+              <Button variant="secondary" size="sm" onClick={handleSortKeys} disabled={!parsed.ok}>
                 Sort Keys
               </Button>
               <CopyButton text={state.input} />
               <div className="mx-1 h-4 w-px bg-[var(--color-border)]" />
-              {parsed.ok && parsed.data !== null && (
+              {parsed.ok && (
                 <span className="flex items-center gap-1 text-xs text-[var(--color-success)]">
                   <CheckCircleIcon size={12} weight="fill" />
                   Valid
@@ -265,7 +288,7 @@ export default function YamlTools() {
               )}
             </div>
             <div className="flex-1 overflow-auto p-4">
-              {parsed.ok && parsed.data !== null ? (
+              {parsed.ok ? (
                 <YamlTree data={parsed.data} path="$" defaultExpanded={true} />
               ) : (
                 <div className="text-sm text-[var(--color-text-muted)]">
@@ -283,28 +306,26 @@ export default function YamlTools() {
           <div className="flex h-full flex-col">
             <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
               <button
+                type="button"
                 onClick={() => {
                   setConvertDirection('yaml-to-json')
-                  setConvertOutput('')
-                  setConvertError(null)
                 }}
                 className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
                   convertDirection === 'yaml-to-json'
-                    ? 'bg-[var(--color-accent)] text-white'
+                    ? 'bg-[var(--color-accent)] text-[var(--color-bg)]'
                     : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
                 }`}
               >
                 YAML → JSON
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setConvertDirection('json-to-yaml')
-                  setConvertOutput('')
-                  setConvertError(null)
                 }}
                 className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
                   convertDirection === 'json-to-yaml'
-                    ? 'bg-[var(--color-accent)] text-white'
+                    ? 'bg-[var(--color-accent)] text-[var(--color-bg)]'
                     : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
                 }`}
               >
@@ -400,53 +421,39 @@ function YamlTree({
 
   if (data === null || data === undefined)
     return (
-      <span
-        className="cursor-pointer text-[var(--color-text-muted)] hover:underline"
-        onClick={() => copyValue(null)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-text-muted)]" onClick={() => copyValue(null)}>
         null
-      </span>
+      </TreeValueButton>
     )
 
   if (typeof data === 'boolean')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-warning)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-warning)]" onClick={() => copyValue(data)}>
         {String(data)}
-      </span>
+      </TreeValueButton>
     )
 
   if (typeof data === 'number')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-accent)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-accent)]" onClick={() => copyValue(data)}>
         {data}
-      </span>
+      </TreeValueButton>
     )
 
   if (typeof data === 'string')
     return (
-      <span
-        className="cursor-pointer text-[var(--color-success)] hover:underline"
-        onClick={() => copyValue(data)}
-        title="Click to copy"
-      >
+      <TreeValueButton className="text-[var(--color-success)]" onClick={() => copyValue(data)}>
         {data}
-      </span>
+      </TreeValueButton>
     )
 
   if (Array.isArray(data)) {
     return (
       <div className="ml-4">
         <button
+          type="button"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
           className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
         >
           {expanded ? '▼' : '▶'} <span className="text-xs">[{data.length}]</span>
@@ -467,7 +474,9 @@ function YamlTree({
     return (
       <div className="ml-4">
         <button
+          type="button"
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
           className="text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
         >
           {expanded ? '▼' : '▶'} <span className="text-xs">{`{${entries.length}}`}</span>

--- a/apps/cockpit/src/tools/yaml-tools/yaml-helpers.ts
+++ b/apps/cockpit/src/tools/yaml-tools/yaml-helpers.ts
@@ -8,8 +8,6 @@ export function parseYaml(input: string): ParseResult {
   if (!input.trim()) return { ok: false, data: null, error: 'Input is empty' }
   try {
     const data = yaml.load(input)
-    if (data === null || data === undefined)
-      return { ok: false, data: null, error: 'Document resolves to null or empty' }
     return { ok: true, data, error: null }
   } catch (e) {
     return { ok: false, data: null, error: e instanceof Error ? e.message : String(e) }
@@ -32,9 +30,6 @@ export function jsonToYaml(jsonInput: string): string {
   }
   try {
     const data: unknown = JSON.parse(jsonInput)
-    if (data === null || data === undefined) {
-      throw new Error('JSON resolves to null or empty')
-    }
     return stringifyYaml(data)
   } catch (e) {
     if (e instanceof SyntaxError) {

--- a/apps/cockpit/src/workers/xml.worker.ts
+++ b/apps/cockpit/src/workers/xml.worker.ts
@@ -1,6 +1,7 @@
 import { handleRpc } from './rpc'
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom'
 import type { Node, Element } from '@xmldom/xmldom'
+import { evaluateSimpleXPath } from '@/lib/xml-xpath'
 
 type XmlResult = {
   valid: boolean
@@ -235,42 +236,6 @@ function collectStats(
   }
 
   return { elements, attributes, textNodes, depth: maxDepth }
-}
-
-// Use xmldom nodes since they don't match the DOM lib types exactly
-function evaluateSimpleXPath(
-  doc: ReturnType<DOMParser['parseFromString']>,
-  expression: string
-): Node[] {
-  const results: Node[] = []
-  try {
-    const parts = expression.replace(/^\/\//, '/').split('/').filter(Boolean)
-    const root = doc.documentElement
-    if (!root) return results
-    let nodes: Node[] = [root]
-
-    for (const part of parts) {
-      const next: Node[] = []
-      const tagName = part.replace(/\[.*\]/, '')
-      for (const node of nodes) {
-        if (node.childNodes) {
-          for (let i = 0; i < node.childNodes.length; i++) {
-            const child = node.childNodes.item(i)
-            if (child) {
-              const childEl = child as Element
-              if (childEl.tagName === tagName) {
-                next.push(child)
-              }
-            }
-          }
-        }
-      }
-      nodes = next
-    }
-    return nodes
-  } catch {
-    return results
-  }
 }
 
 export type XmlWorker = typeof api


### PR DESCRIPTION
## Summary

- fix data-tool regressions in JSON Tools, XML Tools, and YAML Tools, including XPath matching, stale derived output clearing, primitive-array table gating, null-document handling, and tree accessibility
- fix Regex Tester capture-group reporting and truncated-match visibility, prevent Jwt Decoder crashes on non-object payloads, and restore Mermaid preview/menu interaction behavior
- add regression coverage for the repaired paths across the touched cockpit tools

## Root Cause

- several tools were treating derived data as permanently valid after source changes, assuming narrower input shapes than the UI actually accepts, or exposing stateful UI behavior without guardrails for edge cases and accessibility

## Validation

- [x] `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit`
- [x] `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`
- [x] `PATH="/opt/homebrew/bin:$PATH" bun run lint`
