### PR TITLE
fix(cockpit): polish tool bug fixes

### DIFF
--- a/apps/cockpit/src/tools/__tests__/api-client.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/api-client.test.tsx
@@ -77,6 +77,20 @@ describe('ApiClient', () => {
     expect(screen.getByText('Body')).toBeInTheDocument()
   })
 
+  it('enables a JSON body and content type when switching GET to POST', () => {
+    renderTool(ApiClient)
+
+    fireEvent.change(screen.getByDisplayValue('GET'), { target: { value: 'POST' } })
+    fireEvent.click(screen.getByText('Body'))
+
+    expect(screen.getByTestId('monaco-editor')).toBeInTheDocument()
+    expect(screen.queryByText('Body is disabled')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Headers'))
+    expect(screen.getByDisplayValue('Content-Type')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('application/json')).toBeInTheDocument()
+  })
+
   it('starts with the response pane collapsed and lets users reveal it', () => {
     renderTool(ApiClient)
     const emptyResponse = screen.getByText('Send a request to see the response')

--- a/apps/cockpit/src/tools/__tests__/base64.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/base64.test.tsx
@@ -1,9 +1,16 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import Base64Tool from '../base64/Base64Tool'
 
 describe('Base64Tool', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
   it('renders encode mode by default', () => {
     renderTool(Base64Tool)
     expect(screen.getByText('Encode →')).toBeInTheDocument()
@@ -61,5 +68,17 @@ describe('Base64Tool', () => {
     expect(screen.getByTitle('Encode a file to Base64')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Encode →')) // switch to decode
     expect(screen.queryByTitle('Encode a file to Base64')).not.toBeInTheDocument()
+  })
+
+  it('copies standard base64 in data URIs when URL-safe mode is enabled', () => {
+    renderTool(Base64Tool)
+    fireEvent.click(screen.getByLabelText('URL-safe'))
+    const input = screen.getByPlaceholderText(/enter text to encode/i)
+    fireEvent.change(input, { target: { value: '🤐' } })
+
+    expect(screen.getByText('8J-kkA')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Copy data URI'))
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('data:text/plain;base64,8J+kkA==')
   })
 })

--- a/apps/cockpit/src/tools/__tests__/color-converter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/color-converter.test.tsx
@@ -28,4 +28,15 @@ describe('ColorConverter', () => {
     renderTool(ColorConverter)
     expect(screen.getByText(/contrast/i)).toBeInTheDocument()
   })
+
+  it('rejects out-of-range RGB and HSL values', () => {
+    renderTool(ColorConverter)
+    const input = screen.getByPlaceholderText(/#39ff14/)
+
+    fireEvent.change(input, { target: { value: 'rgb(999, 0, 0)' } })
+    expect(screen.queryByText(/rgb\(999/i)).not.toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: 'hsl(120, 150%, 50%)' } })
+    expect(screen.queryByText(/hsl\(120, 150%/i)).not.toBeInTheDocument()
+  })
 })

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderTool } from '@/tools/__tests__/test-utils'
 import JsonTools, { isTabularJsonArray } from '@/tools/json-tools/JsonTools'
 
+const recordMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/useToolHistory', () => ({
+  useToolHistory: () => ({ record: recordMock }),
+}))
+
 describe('JsonTools', () => {
+  beforeEach(() => {
+    recordMock.mockClear()
+  })
+
   it('renders editor', () => {
     renderTool(JsonTools)
     expect(screen.getByTestId('monaco-editor')).toBeInTheDocument()
@@ -46,5 +56,13 @@ describe('JsonTools', () => {
     fireEvent.click(screen.getByText('Table View'))
 
     expect(screen.getByText('Table view requires a JSON array of objects')).toBeInTheDocument()
+  })
+
+  it('does not record history just because valid JSON was edited', () => {
+    renderTool(JsonTools)
+    const editor = screen.getByTestId('monaco-editor')
+    fireEvent.change(editor, { target: { value: '{"a": 1}' } })
+
+    expect(recordMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/timestamp-converter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/timestamp-converter.test.tsx
@@ -1,9 +1,24 @@
-import { describe, expect, it } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, fireEvent, act } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import TimestampConverter from '../timestamp-converter/TimestampConverter'
 
+const recordMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/useToolHistory', () => ({
+  useToolHistory: () => ({ record: recordMock }),
+}))
+
 describe('TimestampConverter', () => {
+  beforeEach(() => {
+    recordMock.mockClear()
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders preset buttons', () => {
     renderTool(TimestampConverter)
     expect(screen.getByText('Now')).toBeInTheDocument()
@@ -32,5 +47,20 @@ describe('TimestampConverter', () => {
     const input = screen.getByPlaceholderText(/unix timestamp/i)
     fireEvent.change(input, { target: { value: 'not-a-date' } })
     expect(screen.getByText(/could not parse/i)).toBeInTheDocument()
+  })
+
+  it('does not record the same timestamp again on live relative ticks', async () => {
+    vi.useFakeTimers()
+    renderTool(TimestampConverter)
+    const input = screen.getByPlaceholderText(/unix timestamp/i)
+
+    fireEvent.change(input, { target: { value: '0' } })
+
+    expect(recordMock).toHaveBeenCalledTimes(1)
+    act(() => {
+      vi.advanceTimersByTime(3_000)
+    })
+
+    expect(recordMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -21,7 +21,7 @@ import { SaveRequestModal } from './components/SaveRequestModal'
 import { ImportSpecModal } from './components/ImportSpecModal'
 import { importApiSpec } from '@/lib/api-import'
 import type { ApiImportResult, ApiRequest, ApiRequestAuth, ApiHeader } from '@/types/models'
-import { BracketsCurlyIcon, CopyIcon } from '@phosphor-icons/react'
+import { BracketsCurlyIcon, CopyIcon, XIcon } from '@phosphor-icons/react'
 
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'])
@@ -155,6 +155,30 @@ function createDefaultDraft(
     bodyMode: BODY_METHODS.has(method) ? 'json' : 'none',
     auth: { type: 'none' },
     ...patch,
+  }
+}
+
+function applyMethodDefaults(
+  draft: ApiClientState['draft'],
+  nextMethod: string
+): ApiClientState['draft'] {
+  const nextSupportsBody = BODY_METHODS.has(nextMethod)
+  const currentSupportsBody = BODY_METHODS.has(draft.method)
+
+  if (!nextSupportsBody) {
+    return { ...draft, method: nextMethod, bodyMode: 'none' }
+  }
+
+  if (currentSupportsBody) return { ...draft, method: nextMethod }
+
+  const hasContentType = draft.headers.some((h) => h.key.toLowerCase() === 'content-type')
+  return {
+    ...draft,
+    method: nextMethod,
+    bodyMode: draft.bodyMode === 'none' ? 'json' : draft.bodyMode,
+    headers: hasContentType
+      ? draft.headers
+      : [{ key: 'Content-Type', value: 'application/json', enabled: true }, ...draft.headers],
   }
 }
 
@@ -523,7 +547,12 @@ export default function ApiClient() {
     }
   })
 
-  useKeyboardShortcut({ key: 'Enter', mod: true }, handleSend)
+  useKeyboardShortcut(
+    { key: 'Enter', mod: true },
+    useCallback(() => {
+      void handleSend()
+    }, [handleSend])
+  )
 
   const handleExport = useCallback(async () => {
     try {
@@ -582,6 +611,13 @@ export default function ApiClient() {
       updateDraft({ headers: headers.filter((_, i) => i !== index) })
     },
     [headers, updateDraft]
+  )
+
+  const handleMethodChange = useCallback(
+    (nextMethod: string) => {
+      updateState({ draft: applyMethodDefaults(state.draft, nextMethod) })
+    },
+    [state.draft, updateState]
   )
 
   // ---------------------------------------------------------------------------
@@ -684,7 +720,7 @@ export default function ApiClient() {
             <Button
               variant="secondary"
               size="sm"
-              onClick={handleExport}
+              onClick={() => void handleExport()}
               title="Export all requests to clipboard (JSON)"
             >
               Export
@@ -696,7 +732,7 @@ export default function ApiClient() {
         <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
           <select
             value={method}
-            onChange={(e) => updateDraft({ method: e.target.value })}
+            onChange={(e) => handleMethodChange(e.target.value)}
             className="rounded border border-[var(--color-accent)] bg-[var(--color-surface)] px-2 py-1.5 font-mono text-xs text-[var(--color-accent)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
           >
             {METHODS.map((m) => (
@@ -712,10 +748,10 @@ export default function ApiClient() {
             size="md"
             className="flex-1"
             onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSend()
+              if (e.key === 'Enter') void handleSend()
             }}
           />
-          <Button variant="primary" size="sm" onClick={handleSend} disabled={loading}>
+          <Button variant="primary" size="sm" onClick={() => void handleSend()} disabled={loading}>
             {loading ? 'Sending…' : 'Send'}
           </Button>
           <Button
@@ -772,9 +808,10 @@ export default function ApiClient() {
                         />
                         <button
                           onClick={() => removeParam(i)}
+                          aria-label="Remove query parameter"
                           className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
                         >
-                          ×
+                          <XIcon size={14} aria-hidden />
                         </button>
                       </div>
                     ))}
@@ -827,9 +864,10 @@ export default function ApiClient() {
                       />
                       <button
                         onClick={() => removeHeader(i)}
+                        aria-label="Remove header"
                         className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
                       >
-                        ×
+                        <XIcon size={14} aria-hidden />
                       </button>
                     </div>
                   ))}

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -41,6 +41,13 @@ function isValidBase64(str: string): boolean {
   }
 }
 
+function encodeTextBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+}
+
 function toUrlSafe(b64: string): string {
   return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
@@ -246,10 +253,7 @@ export default function Base64Tool() {
     if (!state.input.trim()) return { text: '', error: null }
     try {
       if (state.mode === 'encode') {
-        const bytes = new TextEncoder().encode(state.input)
-        let binary = ''
-        for (const byte of bytes) binary += String.fromCharCode(byte)
-        let encoded = btoa(binary)
+        let encoded = encodeTextBase64(state.input)
         if (state.urlSafe) encoded = toUrlSafe(encoded)
         if (state.lineWrap) encoded = wrapLines(encoded, 76)
         return { text: encoded, error: null }
@@ -295,10 +299,9 @@ export default function Base64Tool() {
 
   // Data URI builder for text encode output
   const dataUri = useMemo(() => {
-    if (state.mode !== 'encode' || !output.text) return null
-    const raw = output.text.replace(/\n/g, '')
-    return `data:text/plain;base64,${raw}`
-  }, [state.mode, output.text])
+    if (state.mode !== 'encode' || !state.input.trim() || output.error) return null
+    return `data:text/plain;base64,${encodeTextBase64(state.input)}`
+  }, [state.mode, state.input, output.error])
 
   // Unified image source: file encode takes priority
   const activeImage = droppedFile?.dataUri ?? imagePreview

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -84,13 +84,25 @@ export default function CodeFormatter() {
 
   const handleAutoDetect = useCallback(async () => {
     if (!formatter || !state.input.trim()) return
-    const detected = await formatter.detectLanguage(state.input)
-    updateState({ language: detected })
-    setLastAction(`Detected: ${detected}`, 'info')
+    try {
+      const detected = await formatter.detectLanguage(state.input)
+      setError(null)
+      updateState({ language: detected })
+      setLastAction(`Detected: ${detected}`, 'info')
+    } catch (e) {
+      const msg = (e as Error).message
+      setError(msg)
+      setLastAction('Auto-detect failed', 'error')
+    }
   }, [formatter, state.input, updateState, setLastAction])
 
   // Cmd/Ctrl+Enter to format
-  useKeyboardShortcut({ key: 'Enter', mod: true }, handleFormat)
+  useKeyboardShortcut(
+    { key: 'Enter', mod: true },
+    useCallback(() => {
+      void handleFormat()
+    }, [handleFormat])
+  )
 
   return (
     <div className="flex h-full flex-col">
@@ -98,7 +110,7 @@ export default function CodeFormatter() {
         <Button
           variant="primary"
           size="sm"
-          onClick={handleFormat}
+          onClick={() => void handleFormat()}
           disabled={isFormatting || !state.input.trim()}
         >
           {isFormatting ? 'Formatting…' : 'Format'}
@@ -111,7 +123,7 @@ export default function CodeFormatter() {
             </option>
           ))}
         </Select>
-        <Button variant="ghost" size="sm" onClick={handleAutoDetect}>
+        <Button variant="ghost" size="sm" onClick={() => void handleAutoDetect()}>
           Auto-detect
         </Button>
         <div className="mx-2 h-4 w-px bg-[var(--color-border)]" />

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -203,13 +203,25 @@ function parseColor(input: string): RGB | null {
   // rgb(r, g, b) or rgba(r, g, b, a) — also modern space syntax
   const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)\s*[,\s]\s*(\d+)\s*[,\s]\s*(\d+)/)
   if (rgbMatch) {
-    return { r: Number(rgbMatch[1]), g: Number(rgbMatch[2]), b: Number(rgbMatch[3]) }
+    const rgb = { r: Number(rgbMatch[1]), g: Number(rgbMatch[2]), b: Number(rgbMatch[3]) }
+    if (
+      [rgb.r, rgb.g, rgb.b].every(
+        (channel) => Number.isInteger(channel) && channel >= 0 && channel <= 255
+      )
+    ) {
+      return rgb
+    }
+    return null
   }
 
   // hsl(h, s%, l%) — also modern space syntax
   const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)\s*[,\s]\s*([\d.]+)%\s*[,\s]\s*([\d.]+)%/)
   if (hslMatch) {
-    return hslToRgb({ h: Number(hslMatch[1]), s: Number(hslMatch[2]), l: Number(hslMatch[3]) })
+    const hsl = { h: Number(hslMatch[1]), s: Number(hslMatch[2]), l: Number(hslMatch[3]) }
+    if (Number.isFinite(hsl.h) && hsl.s >= 0 && hsl.s <= 100 && hsl.l >= 0 && hsl.l <= 100) {
+      return hslToRgb(hsl)
+    }
+    return null
   }
 
   // oklch(L C H) — parse and convert

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -74,23 +74,34 @@ export default function DiffViewer() {
   const [rawPatch, setRawPatch] = useState<string>('')
   const [isComparing, setIsComparing] = useState(false)
   const comparingRef = useRef(false)
+  const pendingCompareRef = useRef(false)
+  const stateRef = useRef(state)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    stateRef.current = state
+  }, [state])
 
   const stats = useMemo(() => (rawPatch ? parseDiffStats(rawPatch) : null), [rawPatch])
 
   const computeDiff = useCallback(async () => {
-    if (!worker || comparingRef.current) return
-    if (!state.left.trim() && !state.right.trim()) return
+    if (!worker) return
+    if (comparingRef.current) {
+      pendingCompareRef.current = true
+      return
+    }
+    const current = stateRef.current
+    if (!current.left.trim() && !current.right.trim()) return
     comparingRef.current = true
     setIsComparing(true)
     try {
-      const patch = await worker.computeDiff(state.left, state.right, {
-        ignoreWhitespace: state.ignoreWhitespace,
-        jsonMode: state.jsonMode,
+      const patch = await worker.computeDiff(current.left, current.right, {
+        ignoreWhitespace: current.ignoreWhitespace,
+        jsonMode: current.jsonMode,
       })
       setRawPatch(patch)
       const rendered = diff2htmlRender(patch, {
-        outputFormat: state.mode === 'side-by-side' ? 'side-by-side' : 'line-by-line',
+        outputFormat: current.mode === 'side-by-side' ? 'side-by-side' : 'line-by-line',
         drawFileList: false,
       })
       setDiffHtml(rendered)
@@ -102,18 +113,12 @@ export default function DiffViewer() {
     } finally {
       comparingRef.current = false
       setIsComparing(false)
+      if (pendingCompareRef.current) {
+        pendingCompareRef.current = false
+        setTimeout(() => void computeDiff(), 0)
+      }
     }
-  }, [
-    worker,
-    state.left,
-    state.right,
-    state.ignoreWhitespace,
-    state.jsonMode,
-    state.mode,
-    setLastAction,
-    setDiffHtml,
-    setRawPatch,
-  ])
+  }, [worker, setLastAction, setDiffHtml, setRawPatch])
 
   // Auto-compare with debounce when both sides have content
   useEffect(() => {
@@ -131,7 +136,12 @@ export default function DiffViewer() {
     }
   }, [state.left, state.right, state.ignoreWhitespace, state.jsonMode, state.mode, computeDiff])
 
-  useKeyboardShortcut({ key: 'Enter', mod: true }, computeDiff)
+  useKeyboardShortcut(
+    { key: 'Enter', mod: true },
+    useCallback(() => {
+      void computeDiff()
+    }, [computeDiff])
+  )
 
   const handleSwap = useCallback(() => {
     updateState({ left: state.right, right: state.left })
@@ -319,7 +329,7 @@ export default function DiffViewer() {
                 theme={monacoTheme}
                 language={state.language}
                 value={state.right}
-                onChange={(v) => updateState({ right: String(v) })}
+                onChange={(v) => updateState({ right: v ?? '' })}
                 options={{ ...monacoOptions, wordWrap: 'off' }}
               />
             </div>

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, useEffect, type ReactNode } from 'react'
+import { useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
@@ -157,6 +157,12 @@ export default function JsonTools() {
       updateState({ input: result })
       setError(null)
       setLastAction('Formatted JSON', 'success')
+      record({
+        input: `JSON: ${state.input.slice(0, 300)}${state.input.length > 300 ? '...' : ''}`,
+        output: result.slice(0, 1000),
+        subTab: state.activeTab,
+        success: true,
+      })
     } catch (e) {
       const msg = (e as Error).message
       setError(msg)
@@ -165,14 +171,20 @@ export default function JsonTools() {
       formattingRef.current = false
       setIsFormatting(false)
     }
-  }, [formatter, state.input, updateState, setLastAction])
+  }, [formatter, state.input, state.activeTab, updateState, setLastAction, record])
 
   const handleMinify = useCallback(() => {
     if (!parsed.ok || parsed.data === null || parsed.data === undefined) return
     updateState({ input: JSON.stringify(parsed.data) })
     setError(null)
     setLastAction('Minified JSON', 'success')
-  }, [parsed, updateState, setLastAction])
+    record({
+      input: `JSON: ${state.input.slice(0, 300)}${state.input.length > 300 ? '...' : ''}`,
+      output: JSON.stringify(parsed.data).slice(0, 1000),
+      subTab: state.activeTab,
+      success: true,
+    })
+  }, [parsed, state.input, state.activeTab, updateState, setLastAction, record])
 
   const handleSortKeys = useCallback(() => {
     if (!parsed.ok || parsed.data === null || parsed.data === undefined) return
@@ -180,19 +192,13 @@ export default function JsonTools() {
     updateState({ input: JSON.stringify(sorted, null, 2) })
     setError(null)
     setLastAction('Keys sorted', 'success')
-  }, [parsed, updateState, setLastAction])
-
-  // Record history when JSON is successfully parsed and has content
-  useEffect(() => {
-    if (state.input.trim() && parsed.ok) {
-      record({
-        input: `JSON${state.query ? ` (query: ${state.query})` : ''}: ${state.input.slice(0, 300)}${state.input.length > 300 ? '...' : ''}`,
-        output: JSON.stringify(parsed.data, null, 2).slice(0, 1000),
-        subTab: state.activeTab,
-        success: true,
-      })
-    }
-  }, [state.input, state.activeTab, state.query, parsed.ok, parsed.data, record])
+    record({
+      input: `JSON: ${state.input.slice(0, 300)}${state.input.length > 300 ? '...' : ''}`,
+      output: JSON.stringify(sorted, null, 2).slice(0, 1000),
+      subTab: state.activeTab,
+      success: true,
+    })
+  }, [parsed, state.input, state.activeTab, updateState, setLastAction, record])
 
   return (
     <div className="flex h-full flex-col">
@@ -508,11 +514,11 @@ function JsonTable({ data }: { data: Record<string, unknown>[] }) {
   }, [data])
 
   const copyCell = useCallback(
-    (value: unknown) => {
+    async (value: unknown) => {
       try {
         const text =
           typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value ?? '')
-        navigator.clipboard.writeText(text)
+        await navigator.clipboard.writeText(text)
         setLastAction('Copied cell', 'success')
       } catch {
         setLastAction('Failed to copy cell', 'error')
@@ -555,7 +561,7 @@ function JsonTable({ data }: { data: Record<string, unknown>[] }) {
                 return (
                   <td
                     key={col}
-                    onClick={() => copyCell(value)}
+                    onClick={() => void copyCell(value)}
                     className="cursor-pointer border border-[var(--color-border)] px-3 py-1.5 text-[var(--color-text)] hover:bg-[var(--color-surface)]"
                     title="Click to copy"
                   >

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -41,6 +41,7 @@ export default function RefactoringToolkit() {
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [preview, setPreview] = useState<string | null>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const previewRequestRef = useRef(0)
 
   // Filter transforms by selected language
   const availableTransforms = useMemo(
@@ -55,12 +56,20 @@ export default function RefactoringToolkit() {
       setPreview(null)
       return
     }
+    setPreview(null)
+    const requestId = ++previewRequestRef.current
     debounceRef.current = setTimeout(() => {
       const parser = state.language === 'typescript' ? 'tsx' : 'babel'
       worker
         .applyTransforms(state.input, state.selectedTransforms, parser)
-        .then((result) => setPreview(result))
-        .catch((err: Error) => setLastAction(err.message, 'error'))
+        .then((result) => {
+          if (requestId === previewRequestRef.current) setPreview(result)
+        })
+        .catch((err: Error) => {
+          if (requestId !== previewRequestRef.current) return
+          setPreview(null)
+          setLastAction(err.message, 'error')
+        })
     }, 300)
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -434,10 +434,10 @@ export default function RegexTester() {
           )}
           {mode === 'match' && matchCount > 0 && (
             <div className="ml-auto flex items-center gap-1 pr-3">
-              <Button variant="secondary" size="sm" onClick={() => exportMatches('lines')}>
+              <Button variant="secondary" size="sm" onClick={() => void exportMatches('lines')}>
                 Copy lines
               </Button>
-              <Button variant="secondary" size="sm" onClick={() => exportMatches('json')}>
+              <Button variant="secondary" size="sm" onClick={() => void exportMatches('json')}>
                 Copy JSON
               </Button>
             </div>

--- a/apps/cockpit/src/tools/timestamp-converter/TimestampConverter.tsx
+++ b/apps/cockpit/src/tools/timestamp-converter/TimestampConverter.tsx
@@ -133,9 +133,14 @@ export default function TimestampConverter() {
   const parsed = useMemo(() => {
     const date = parseInput(state.input)
     if (!date) return null
-    return { date, formats: computeFormats(date) }
+    return { date }
+  }, [state.input])
+
+  const formats = useMemo(() => {
+    if (!parsed) return []
+    return computeFormats(parsed.date)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.input, tick])
+  }, [parsed, tick])
 
   const handlePreset = useCallback(
     (preset: Preset) => {
@@ -210,7 +215,7 @@ export default function TimestampConverter() {
       <div className="flex-1 overflow-auto p-4">
         {parsed ? (
           <div className="flex flex-col gap-2">
-            {parsed.formats.map((f) => (
+            {formats.map((f) => (
               <div
                 key={f.label}
                 className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2"

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -188,6 +188,7 @@ export default function XmlTools() {
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [error, setError] = useState<string | null>(null)
   const [xpathResults, setXpathResults] = useState<string[]>([])
+  const [xpathQueried, setXpathQueried] = useState(false)
   const [jsonOutput, setJsonOutput] = useState<string>('')
   const [jsonError, setJsonError] = useState<string | null>(null)
   const [stats, setStats] = useState<{
@@ -229,59 +230,82 @@ export default function XmlTools() {
     setJsonOutput('')
     setJsonError(null)
     setXpathResults([])
+    setXpathQueried(false)
   }, [state.input])
 
   useEffect(() => {
     setXpathResults([])
+    setXpathQueried(false)
   }, [state.xpathQuery])
 
   const handleFormat = useCallback(async () => {
     if (!worker || !state.input.trim()) return
-    const result = await worker.format(state.input, state.indent)
-    if (result.valid && result.formatted) {
-      updateState({ input: result.formatted })
-      setError(null)
-      setLastAction('Formatted XML', 'success')
-    } else {
-      setError(result.errors.join('\n'))
-      setLastAction(`${result.errors.length} error(s)`, 'error')
+    try {
+      const result = await worker.format(state.input, state.indent)
+      if (result.valid && result.formatted) {
+        updateState({ input: result.formatted })
+        setError(null)
+        setLastAction('Formatted XML', 'success')
+      } else {
+        setError(result.errors.join('\n'))
+        setLastAction(`${result.errors.length} error(s)`, 'error')
+      }
+    } catch (e) {
+      setError((e as Error).message)
+      setLastAction('Format failed', 'error')
     }
   }, [worker, state.input, state.indent, updateState, setLastAction])
 
   const handleMinify = useCallback(async () => {
     if (!worker || !state.input.trim()) return
-    const result = await worker.minify(state.input)
-    if (result.valid && result.formatted) {
-      updateState({ input: result.formatted })
-      setError(null)
-      setLastAction('Minified XML', 'success')
-    } else {
-      setError(result.errors.join('\n'))
-      setLastAction(`${result.errors.length} error(s)`, 'error')
+    try {
+      const result = await worker.minify(state.input)
+      if (result.valid && result.formatted) {
+        updateState({ input: result.formatted })
+        setError(null)
+        setLastAction('Minified XML', 'success')
+      } else {
+        setError(result.errors.join('\n'))
+        setLastAction(`${result.errors.length} error(s)`, 'error')
+      }
+    } catch (e) {
+      setError((e as Error).message)
+      setLastAction('Minify failed', 'error')
     }
   }, [worker, state.input, updateState, setLastAction])
 
   const handleValidate = useCallback(async () => {
     if (!worker || !state.input.trim()) return
-    const result = await worker.validate(state.input)
-    if (result.valid) {
-      setError(null)
-      setLastAction('Valid XML', 'success')
-    } else {
-      setError(result.errors.join('\n'))
-      setLastAction(`${result.errors.length} error(s)`, 'error')
+    try {
+      const result = await worker.validate(state.input)
+      if (result.valid) {
+        setError(null)
+        setLastAction('Valid XML', 'success')
+      } else {
+        setError(result.errors.join('\n'))
+        setLastAction(`${result.errors.length} error(s)`, 'error')
+      }
+    } catch (e) {
+      setError((e as Error).message)
+      setLastAction('Validation failed', 'error')
     }
   }, [worker, state.input, setLastAction])
 
   const handleToJson = useCallback(async () => {
     if (!worker || !state.input.trim()) return
-    const result = await worker.toJson(state.input)
-    if (result.valid && result.json) {
-      setJsonOutput(result.json)
-      setJsonError(null)
-      setLastAction('Converted to JSON', 'success')
-    } else {
-      setJsonError(result.error ?? 'Conversion failed')
+    try {
+      const result = await worker.toJson(state.input)
+      if (result.valid && result.json) {
+        setJsonOutput(result.json)
+        setJsonError(null)
+        setLastAction('Converted to JSON', 'success')
+      } else {
+        setJsonError(result.error ?? 'Conversion failed')
+        setJsonOutput('')
+        setLastAction('Conversion failed', 'error')
+      }
+    } catch (e) {
+      setJsonError((e as Error).message)
       setJsonOutput('')
       setLastAction('Conversion failed', 'error')
     }
@@ -290,11 +314,19 @@ export default function XmlTools() {
   const handleXPath = useCallback(async () => {
     if (!worker || !state.input.trim() || !state.xpathQuery.trim()) {
       setXpathResults([])
+      setXpathQueried(false)
       return
     }
-    const result = await worker.queryXPath(state.input, state.xpathQuery)
-    setXpathResults(result.matches)
-    setLastAction(`${result.count} match(es)`, result.count > 0 ? 'success' : 'info')
+    try {
+      const result = await worker.queryXPath(state.input, state.xpathQuery)
+      setXpathResults(result.matches)
+      setXpathQueried(true)
+      setLastAction(`${result.count} match(es)`, result.count > 0 ? 'success' : 'info')
+    } catch (e) {
+      setXpathResults([])
+      setXpathQueried(true)
+      setLastAction((e as Error).message || 'XPath query failed', 'error')
+    }
   }, [worker, state.input, state.xpathQuery, setLastAction])
 
   const tree = useMemo(() => {
@@ -325,13 +357,13 @@ export default function XmlTools() {
         {state.activeTab === 'lint' && (
           <div className="flex h-full flex-col">
             <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
-              <Button variant="primary" size="sm" onClick={handleFormat}>
+              <Button variant="primary" size="sm" onClick={() => void handleFormat()}>
                 Format
               </Button>
-              <Button variant="secondary" size="sm" onClick={handleMinify}>
+              <Button variant="secondary" size="sm" onClick={() => void handleMinify()}>
                 Minify
               </Button>
-              <Button variant="secondary" size="sm" onClick={handleValidate}>
+              <Button variant="secondary" size="sm" onClick={() => void handleValidate()}>
                 Validate
               </Button>
               <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
@@ -389,7 +421,7 @@ export default function XmlTools() {
         {state.activeTab === 'json' && (
           <div className="flex h-full flex-col">
             <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
-              <Button variant="primary" size="sm" onClick={handleToJson}>
+              <Button variant="primary" size="sm" onClick={() => void handleToJson()}>
                 Convert
               </Button>
               {jsonOutput && <CopyButton text={jsonOutput} label="Copy JSON" />}
@@ -432,7 +464,7 @@ export default function XmlTools() {
                   if (e.key === 'Enter') void handleXPath()
                 }}
               />
-              <Button variant="primary" size="sm" onClick={handleXPath}>
+              <Button variant="primary" size="sm" onClick={() => void handleXPath()}>
                 Query
               </Button>
             </div>
@@ -454,6 +486,8 @@ export default function XmlTools() {
                     </div>
                   ))}
                 </div>
+              ) : xpathQueried ? (
+                <div className="text-sm text-[var(--color-text-muted)]">No matches</div>
               ) : (
                 <div className="text-sm text-[var(--color-text-muted)]">
                   Enter an XPath expression and click Query (or press Enter)

--- a/apps/cockpit/src/workers/typescript.worker.ts
+++ b/apps/cockpit/src/workers/typescript.worker.ts
@@ -29,6 +29,38 @@ const MODULE_MAP: Record<string, ts.ModuleKind> = {
   None: ts.ModuleKind.None,
 }
 
+const SOURCE_FILE = 'input.tsx'
+
+function collectDiagnostics(
+  code: string,
+  compilerOptions: ts.CompilerOptions
+): readonly ts.Diagnostic[] {
+  const sourceFile = ts.createSourceFile(
+    SOURCE_FILE,
+    code,
+    compilerOptions.target ?? ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TSX
+  )
+  const host: ts.CompilerHost = {
+    fileExists: (fileName) => fileName === SOURCE_FILE,
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => '',
+    getDefaultLibFileName: () => 'lib.d.ts',
+    getDirectories: () => [],
+    getNewLine: () => '\n',
+    getSourceFile: (fileName) => (fileName === SOURCE_FILE ? sourceFile : undefined),
+    readFile: (fileName) => (fileName === SOURCE_FILE ? code : undefined),
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+  }
+  const program = ts.createProgram([SOURCE_FILE], { ...compilerOptions, noLib: true }, host)
+  return [
+    ...program.getSyntacticDiagnostics(sourceFile),
+    ...program.getSemanticDiagnostics(sourceFile),
+  ]
+}
+
 const api = {
   transpile(code: string, options: TranspileOptions = {}): TranspileResult {
     const compilerOptions: ts.CompilerOptions = {
@@ -45,7 +77,7 @@ const api = {
       reportDiagnostics: true,
     })
 
-    const diagnostics = (result.diagnostics ?? []).map((d) => {
+    const diagnostics = collectDiagnostics(code, compilerOptions).map((d) => {
       const pos =
         d.file && d.start !== undefined ? d.file.getLineAndCharacterOfPosition(d.start) : undefined
       const entry: { message: string; line?: number; column?: number } = {


### PR DESCRIPTION
## Summary
- Tightens cockpit tool behavior around async actions so failed worker calls and clipboard operations surface errors instead of leaking promises.
- Fixes several user-facing tool edge cases, including API method body defaults, Base64 data URI output, timestamp history churn, stale diff/refactor previews, XML XPath empty results, and TypeScript diagnostics.
- Adds focused regression coverage for API Client, Base64, Color Converter, JSON Tools, and Timestamp Converter.

## Test plan
- [x] `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit`
- [x] `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`
- [x] `PATH="/opt/homebrew/bin:$PATH" bun run lint`
- [x] Pre-push TypeScript and test checks