### PR TITLE
fix(cockpit): resolve P0 and P1 reliability blockers

### DIFF
--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -13,7 +13,7 @@ Verified locally from `apps/cockpit` on 2026-07-30:
 | Gate        | Command                                           | Result                       |
 | ----------- | ------------------------------------------------- | ---------------------------- |
 | TypeScript  | `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit` | Passing                      |
-| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 78 files, 648 tests |
+| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 78 files, 650 tests |
 | ESLint      | `PATH="/opt/homebrew/bin:$PATH" bunx eslint src`  | Passing with zero warnings   |
 | Rust check  | `cargo check` from `src-tauri`                    | Passing                      |
 | Rust clippy | `cargo clippy -- -D warnings` from `src-tauri`    | Passing                      |
@@ -114,6 +114,11 @@ Completed 2026-07-30:
 - A key over pattern/flags/text/replacement short-circuits repeat evaluation, so a persisted
   timed-out pattern is never re-evaluated on launch — only after the user edits an input.
 - Removed roughly 170 lines of main-thread regex code from `RegexTester.tsx`.
+- Found in pre-merge review: the timeout path set `status: 'timeout'` but never retired the request
+  id, so a reply queued just before `terminate()` still passed both staleness guards and flipped the
+  pane back to `ready` — while the input stayed in `timedOutKeysRef`, wedging it as permanently
+  timed-out on the next visit. The timeout now bumps `requestIdRef`. Regression test added and
+  confirmed to fail against the pre-fix hook.
 - Caveat: the timeout regression test drives a wedged-worker stub with fake timers, not a genuinely
   catastrophic regex. A real pathological pattern cannot be executed under Vitest because the mock
   worker runs on the test thread and would hang the runner exactly as the bug hung the app. The test
@@ -195,6 +200,14 @@ Completed 2026-07-30:
   correct `immediate` flag, no JS-driven `BEGIN`/`COMMIT` reaching the plugin pool, failure
   propagation, and an empty batch skipping the invoke. The prior rollback tests mocked a single
   connection and structurally could not observe this failure mode.
+- Found in pre-merge review: the first cut hand-wrote `BEGIN`/`COMMIT`/`ROLLBACK` as raw SQL on a
+  pooled connection. sqlx has no idea a transaction is open when it is driven that way, and the
+  `COMMIT`-failure path returned without attempting a rollback — so on a full disk or lock timeout
+  the connection went back to a `max_connections(1)` pool still inside a transaction, and every
+  later batch would fail with "cannot start a transaction within a transaction" until relaunch.
+  That is a worse failure than the one being fixed. Rewritten to use `pool.begin()` /
+  `pool.begin_with("BEGIN IMMEDIATE")`, so sqlx tracks the transaction and rolls back on `Drop` for
+  every early return.
 
 ### [x] Fix `useToolState` cold-start races that discard user input
 
@@ -819,6 +832,44 @@ Area: test organisation
 `src/tools/__tests__/useToolState.test.ts` covers a hook, not a tool, and belongs in
 `src/hooks/__tests__/`. Left in place during the P0 fix to keep that diff scoped. Move it and confirm
 no other test files sit in the wrong directory.
+
+### [ ] Narrow the re-allowed `className` in the markdown sanitize schema
+
+Area: markdown rendering / defense in depth
+
+`markdownSanitizeSchema` re-allows `className` on `code` and `span` as an unrestricted string, where
+`defaultSchema` restricts it to `/^language-./`. The widening is needed for the `hljs-*` classes
+rehype-highlight emits, but it is broader than required — a prefix restriction such as
+`/^(hljs|language)-/` plus the bare `hljs` would cover the real output. Likewise `input` `type` is
+allowed as any value where only `checkbox` is ever produced.
+
+Not currently exploitable: both pipelines run `remarkRehype` with `allowDangerousHtml: false` and
+neither uses `rehype-raw`, so no user-controlled string can reach a `className` or `type` attribute —
+those elements can only be produced by remark/rehype-highlight/remark-gfm themselves. The risk is
+future: adding a raw-HTML pass without re-auditing this schema would turn it into a live CSS/class
+injection surface on user-authored notes. Tighten it while the reason is still fresh, and keep the
+`hljs` highlighting test as the guard.
+
+### [ ] Use the `void` prefix on async click handlers in the export paths
+
+Area: convention consistency
+
+`onClick={handleDownload}` in `ImageTool.tsx`, `SnippetsManager.tsx`, `MarkdownEditor.tsx`, and
+`MermaidEditor.tsx` (two sites) passes an async function directly. Harmless today — every one of
+those handlers catches internally and surfaces the failure through `setLastAction` — but `CLAUDE.md`
+documents `void handler()` for async handlers, and the current form would silently produce an
+unhandled rejection if any of them ever grows a throw outside its `try`.
+
+### [ ] Cover init-rejection recovery for the other six stores
+
+Area: test parity
+
+The P1 bootstrap fix applied a textually identical `initPromise = null` rejection clear to seven
+stores, but only `settings.store.test.ts` has a regression test for it. `snippets.store.test.ts` and
+`prompt-templates.store.test.ts` do not exist at all; the `notes`, `history`, `api`, and `mcp` test
+files exist but do not cover this path. Functional risk is low because the code is identical, but
+nothing stops one of them being refactored back. A shared helper asserting the failed-then-retried
+sequence, applied to all seven, would be cheap.
 
 ### [ ] Give `getDb()` the same rejection recovery the stores got
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -13,7 +13,7 @@ Verified locally from `apps/cockpit` on 2026-07-30:
 | Gate        | Command                                           | Result                       |
 | ----------- | ------------------------------------------------- | ---------------------------- |
 | TypeScript  | `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit` | Passing                      |
-| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 76 files, 623 tests |
+| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 78 files, 648 tests |
 | ESLint      | `PATH="/opt/homebrew/bin:$PATH" bunx eslint src`  | Passing with zero warnings   |
 | Rust check  | `cargo check` from `src-tauri`                    | Passing                      |
 | Rust clippy | `cargo clippy -- -D warnings` from `src-tauri`    | Passing                      |
@@ -41,10 +41,10 @@ Newly filed from that audit:
 | Regex Tester freezes the app on backtracking  | P0       | Reproduced: unrecoverable hang           | Fixed  |
 | `runTransaction` has no atomicity guarantee   | P0       | `tauri-plugin-sql` pool semantics        | Fixed  |
 | `useToolState` cold-start races lose edits    | P0       | Code path in `src/hooks/useToolState.ts` | Fixed  |
-| Notes preview drops tables, images, strikes   | P1       | Reproduced against the real pipeline     | Open   |
-| Blob downloads bypass the Tauri save dialog   | P1       | 5 call sites                             | Open   |
-| Bootstrap leaks listeners on early unmount    | P1       | Code path in `src/app/providers.tsx`     | Open   |
-| Failed store `init()` is cached permanently   | P1       | Shared promise-guard pattern             | Open   |
+| Notes preview drops tables, images, strikes   | P1       | Reproduced against the real pipeline     | Fixed  |
+| Blob downloads bypass the Tauri save dialog   | P1       | 5 call sites                             | Fixed  |
+| Bootstrap leaks listeners on early unmount    | P1       | Code path in `src/app/providers.tsx`     | Fixed  |
+| Failed store `init()` is cached permanently   | P1       | Shared promise-guard pattern             | Fixed  |
 | Tool capabilities duplicated across 3 id sets | P2       | Registry drift risk                      | Open   |
 | `settings.store` hand-rolls persisted object  | P2       | Silent setting loss on future fields     | Open   |
 
@@ -404,7 +404,7 @@ Completed 2026-07-30:
 
 ## P1 - High-Value Regression Coverage
 
-### [ ] Fix the Notes markdown pipeline silently destroying content
+### [x] Fix the Notes markdown pipeline silently destroying content
 
 Area: notes / markdown rendering
 
@@ -444,7 +444,20 @@ PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/lib src/components/shell
 PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
 ```
 
-### [ ] Route file downloads through the Tauri save dialog
+Completed 2026-07-30:
+
+- `src/lib/markdown.ts` now exports a single `markdownSanitizeSchema` that extends `defaultSchema`
+  and registers `remarkGfm`. `MarkdownEditor.tsx` imports that schema instead of maintaining its own
+  copy, so the two markdown surfaces can no longer drift apart.
+- New `src/lib/__tests__/markdown.test.ts` (7 tests) covers tables, images, strikethrough, and task
+  list checkboxes surviving, plus `javascript:` and `data:` hrefs still being stripped while
+  `https:` survives.
+- Syntax highlighting was a regression risk here: `defaultSchema` restricts `code` `className` to
+  `language-*`, which would have stripped the `hljs-*` classes `rehypeHighlight` emits. The schema
+  explicitly re-allows `className` on `code` and `span`; verified by running the real pipeline
+  against a fenced code block and confirming `hljs` classes survive.
+
+### [x] Route file downloads through the Tauri save dialog
 
 Area: cross-platform file export
 
@@ -481,7 +494,25 @@ PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/tools src/lib
 PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
 ```
 
-### [ ] Make bootstrap cleanup leak-free and store init recoverable
+Completed 2026-07-30:
+
+- `src/lib/file-io.ts` gained `exportFile(data, defaultName)` — one helper handling both text and
+  `Blob` payloads through the same `save()` dialog the global save shortcut uses — plus
+  `sanitizeExportBasename` / `buildExportFilename`, so filename derivation lives in one place rather
+  than being re-implemented per tool.
+- All five `<a download>` sites now call it: `SnippetsManager`, `ImageTool`, `MermaidEditor` (SVG and
+  PNG), `MarkdownEditor`.
+- One `URL.createObjectURL` remains, in `MermaidEditor.renderPngBlob` — it rasterizes the SVG into an
+  `Image` for canvas rather than triggering a download, and it already revokes in `onload`/`onerror`
+  rather than synchronously. That is the deferred-revocation case the criteria allow.
+- `src-tauri/capabilities/default.json` was not modified. `fs:allow-write-file` was already scoped to
+  `$DOWNLOAD/**` and `$HOME/**`, which covers the new binary writes.
+- Tests: 8 unit tests on the helper in `src/lib/__tests__/file-io.test.ts`, plus save-success,
+  user-cancellation, and write-failure coverage for two tools (`snippets.test.tsx`,
+  `image-tool.test.tsx`). One pre-existing image-tool assertion was wrapped in `waitFor` because the
+  handler is now async.
+
+### [x] Make bootstrap cleanup leak-free and store init recoverable
 
 Area: app bootstrap / lifecycle
 
@@ -517,6 +548,24 @@ cd apps/cockpit
 PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/app src/stores
 PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
 ```
+
+Completed 2026-07-30:
+
+- `providers.tsx` now re-checks `cancelled` immediately after every `await` that creates a resource
+  and tears that resource down on the spot rather than pushing it onto an already-drained `cleanups`
+  array. Covers `unlistenMcpChanged`, `onMoved`, `onResized`, and the debounce timer.
+- All seven stores with the promise-guard pattern — `settings`, `mcp`, `api`, `notes`,
+  `prompt-templates`, `history`, `snippets` — clear `initPromise` on rejection before rethrowing. The
+  success-path guard is untouched, so double-mount idempotency still holds.
+- The `Providers` error screen has a Retry button that re-runs bootstrap instead of requiring a
+  relaunch.
+- New `src/app/__tests__/providers.test.tsx` (3 tests): unmount while awaiting `listen()`, unmount
+  while awaiting `onMoved()`, and failed-then-retried `init()`. All three were confirmed to fail
+  against the pre-fix `providers.tsx`, so they pin the actual defects rather than passing vacuously.
+  A store-level test in `settings.store.test.ts` covers the rejection-clearing behavior in isolation.
+- Out of scope but noted: `getDb()` in `src/lib/db.ts` has the same unguarded-singleton shape and
+  never clears `dbPromise` on rejection. It is not a store, so it was left alone; worth a follow-up
+  if a DB-open failure is ever seen to latch.
 
 ### [x] Add direct `useGlobalShortcuts` dispatch coverage
 
@@ -770,6 +819,17 @@ Area: test organisation
 `src/tools/__tests__/useToolState.test.ts` covers a hook, not a tool, and belongs in
 `src/hooks/__tests__/`. Left in place during the P0 fix to keep that diff scoped. Move it and confirm
 no other test files sit in the wrong directory.
+
+### [ ] Give `getDb()` the same rejection recovery the stores got
+
+Area: SQLite / lifecycle
+
+`getDb()` in `src/lib/db.ts` caches `dbPromise` and never clears it on rejection — the same defect
+fixed in all seven Zustand stores under the P1 bootstrap item. A transient `Database.load()` failure
+latches for the process lifetime and every subsequent DB call fails. It was left alone during that
+fix because it is a documented singleton rather than a store, and no failure has been observed in
+practice. Apply the same `.catch(() => { dbPromise = null; throw err })` treatment and add a
+failed-then-successful test.
 
 ### [ ] Move tool capability flags into the tool registry
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -10,13 +10,13 @@ evidence, an expected outcome, acceptance criteria, and a verification path.
 
 Verified locally from `apps/cockpit` on 2026-07-30:
 
-| Gate        | Command                                           | Result                                            |
-| ----------- | ------------------------------------------------- | ------------------------------------------------- |
-| TypeScript  | `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit` | Passing                                           |
-| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 74 files, 593 tests                      |
-| ESLint      | `PATH="/opt/homebrew/bin:$PATH" bun run lint`     | Passing under current `--max-warnings 100` policy |
-| Rust check  | `cargo check` from `src-tauri`                    | Passing                                           |
-| Rust clippy | `cargo clippy -- -D warnings` from `src-tauri`    | Passing                                           |
+| Gate        | Command                                           | Result                       |
+| ----------- | ------------------------------------------------- | ---------------------------- |
+| TypeScript  | `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit` | Passing                      |
+| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 76 files, 623 tests |
+| ESLint      | `PATH="/opt/homebrew/bin:$PATH" bunx eslint src`  | Passing with zero warnings   |
+| Rust check  | `cargo check` from `src-tauri`                    | Passing                      |
+| Rust clippy | `cargo clippy -- -D warnings` from `src-tauri`    | Passing                      |
 
 Known context:
 
@@ -24,6 +24,32 @@ Known context:
 - The product map lists 30 registered tools across 7 groups.
 - Remaining documented gaps include native worker/SQLite integration and release smoke automation.
 - CI already runs frontend lint/typecheck/tests plus Rust `cargo check` and `cargo clippy`.
+
+### Source audit, 2026-07-30
+
+A read-through of `src/` and `src-tauri/` found defects that all four gates pass over. Every gate is
+green and the suite is at 593 tests, so **a green board is not evidence these are absent** — each
+item below was found by reading code or by direct reproduction, not by a failing test. The audit
+also confirmed several areas are in good shape: the Rust MCP server (loopback-only bind,
+constant-time bearer comparison, `busy_timeout`, `max_connections(1)`), the Markdown Editor sanitize
+schema, and Regex Tester HTML escaping are all correct as written.
+
+Newly filed from that audit:
+
+| Item                                          | Priority | Evidence                                 | Status |
+| --------------------------------------------- | -------- | ---------------------------------------- | ------ |
+| Regex Tester freezes the app on backtracking  | P0       | Reproduced: unrecoverable hang           | Fixed  |
+| `runTransaction` has no atomicity guarantee   | P0       | `tauri-plugin-sql` pool semantics        | Fixed  |
+| `useToolState` cold-start races lose edits    | P0       | Code path in `src/hooks/useToolState.ts` | Fixed  |
+| Notes preview drops tables, images, strikes   | P1       | Reproduced against the real pipeline     | Open   |
+| Blob downloads bypass the Tauri save dialog   | P1       | 5 call sites                             | Open   |
+| Bootstrap leaks listeners on early unmount    | P1       | Code path in `src/app/providers.tsx`     | Open   |
+| Failed store `init()` is cached permanently   | P1       | Shared promise-guard pattern             | Open   |
+| Tool capabilities duplicated across 3 id sets | P2       | Registry drift risk                      | Open   |
+| `settings.store` hand-rolls persisted object  | P2       | Silent setting loss on future fields     | Open   |
+
+Two further defects surfaced while fixing the P0 items, both filed in P2 below: the `lint` package
+script has never been runnable locally, and five worker mocks had never been wired up.
 
 ## How To Use This Backlog
 
@@ -34,6 +60,192 @@ Known context:
 - For each PR, update the item with links to tests, manual smoke notes, or follow-up issues.
 
 ## P0 - Reliability Blockers
+
+### [x] Stop Regex Tester from freezing the app on catastrophic backtracking
+
+Area: regex-tester / main-thread responsiveness
+
+Problem: `findMatches`, `highlightMatches`, and `computeReplace` in
+`src/tools/regex-tester/RegexTester.tsx` each compile and run a user-supplied pattern synchronously
+inside a `useMemo` on the main thread. `MAX_REGEX_MATCHES` caps how many matches are collected, but
+it cannot interrupt backtracking **inside a single `exec()` call**. A pathological pattern hangs the
+entire WebView: no re-render, no keyboard input, no way to clear the field. The user's only recourse
+is to force-quit, and because `useToolState` persists the pattern, relaunching the app can reload the
+same pattern and hang again.
+
+Evidence: reproduced directly. Pattern `(a+)+$` against 30 `a` characters plus `!` did not complete
+within a 60-second timeout and had to be killed. Thirty characters is well within what a user types
+by hand, and a regex tester is precisely where people paste hostile patterns to study them.
+
+Expected outcome: A pathological pattern produces a timeout message in the results pane. The shell
+stays interactive, and the tool recovers when the pattern is edited.
+
+Acceptance criteria:
+
+- Regex evaluation moves off the main thread into a worker using the existing `handleRpc` /
+  `useWorker` protocol, so a runaway match can be terminated.
+- The worker is terminated and respawned after a configurable budget (start at ~1s) and the tool
+  renders an explicit "pattern timed out" state rather than a silent empty result.
+- The three evaluation paths compile the pattern once and share the result instead of building
+  three separate `RegExp` objects per keystroke.
+- Persisted tool state cannot re-trigger the hang on launch: a pattern that timed out is not
+  re-evaluated automatically until the user edits it.
+- Regression test asserts a known catastrophic pattern returns a timeout result within the budget.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/tools/__tests__/regex-tester.test.tsx
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
+
+Completed 2026-07-30:
+
+- Added `src/workers/regex.api.ts` (pure evaluation, compiles the pattern once and shares it across
+  matching, highlighting, and replacement) and `src/workers/regex.worker.ts` over `handleRpc`.
+- Added `src/hooks/useRegexEvaluation.ts`, a dedicated hook rather than an extension of `useWorker`.
+  Adding terminate-and-respawn to `useWorker` would change its contract for six existing consumers —
+  a rejected request would no longer imply a live worker — and that contract is pinned by
+  `useWorker.test.ts`.
+- 1000 ms budget; on expiry the wedged worker is terminated, a replacement is spawned immediately,
+  and the tool renders an explicit timeout message in both the match and replace panes rather than a
+  silent empty result.
+- A key over pattern/flags/text/replacement short-circuits repeat evaluation, so a persisted
+  timed-out pattern is never re-evaluated on launch — only after the user edits an input.
+- Removed roughly 170 lines of main-thread regex code from `RegexTester.tsx`.
+- Caveat: the timeout regression test drives a wedged-worker stub with fake timers, not a genuinely
+  catastrophic regex. A real pathological pattern cannot be executed under Vitest because the mock
+  worker runs on the test thread and would hang the runner exactly as the bug hung the app. The test
+  asserts the timeout machinery — status, single `terminate()`, replacement spawn, no re-post of the
+  identical input, resumption on edit — not that a specific pattern trips it.
+
+### [x] Give `runTransaction` a real atomicity guarantee
+
+Area: SQLite persistence / data safety
+
+Problem: `runTransaction` in `src/lib/db.ts` issues `BEGIN`, the caller's statements, and `COMMIT` as
+separate `conn.execute()` calls. Those calls do not share a connection. `tauri-plugin-sql` 2.3.2
+stores a `DbPool::Sqlite(Pool<Sqlite>)` built with `Pool::connect(...)` (default max 10 connections)
+and runs each statement via `pool.execute(query)`, which acquires a connection from the pool
+**per statement** (`src/wrapper.rs`). Nothing pins `BEGIN`, the writes, and `COMMIT` to the same
+connection.
+
+Consequences when the statements land on different connections:
+
+- The writes auto-commit individually, so `saveNotesOrder`, `saveUserPromptTemplates`,
+  `seedBuiltinPromptTemplates`, and `saveApiImport` can persist partial results.
+- `COMMIT` on a connection with no open transaction errors, and the `ROLLBACK` in the catch block
+  silently fails on a connection it never began a transaction on.
+- Worst case, an open `BEGIN IMMEDIATE` is left stranded on a pooled connection. Every later write
+  routed to that connection fails with "cannot start a transaction within a transaction" until the
+  app restarts.
+
+The JS-side `writeQueue` serializes writes and makes the pool usually hand back the
+most-recently-released connection, which is why this has never failed in practice or in tests. It is
+a latent correctness bug, not a theoretical one. Note the contrast: the Rust MCP service opens its
+own pool with `max_connections(1)` precisely so its transactions are safe.
+
+Expected outcome: Multi-statement writes are genuinely atomic, or the code stops claiming to be.
+
+Acceptance criteria:
+
+- Pick one and document the choice in `ARCHITECTURE_DECISIONS.md`:
+  - move batch writes behind a Rust command that owns a single connection, or
+  - rewrite batch writes as single multi-statement SQL calls that SQLite executes atomically, or
+  - drop the transaction wrapper and make each batch idempotent and safely re-runnable.
+- Reads (`getSetting`, `loadNotes`, and peers) that currently bypass `writeQueue` are audited for
+  the same cross-connection assumption.
+- Tests cover partial-failure behavior for each batch writer, asserting the documented guarantee
+  rather than assuming rollback works.
+- Existing rollback tests are re-examined: they mock a single connection and therefore cannot
+  observe this failure mode.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/lib src/stores
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
+
+Completed 2026-07-30:
+
+- Confirmed the premise against the vendored `tauri-plugin-sql` 2.3.2 source before changing
+  anything: `wrapper.rs` routes every statement through `pool.execute()` on a pool with the default
+  maximum of 10 connections, so JS-side `BEGIN`/`COMMIT`/`ROLLBACK` could land on different
+  connections. The wrapper guaranteed nothing.
+- Added `src-tauri/src/batch.rs` with a `db_execute_batch(statements, immediate)` command that
+  lazily opens its own `max_connections(1)` WAL pool (5s busy timeout, path resolution mirroring
+  `mcp/mod.rs`), acquires one connection, and issues `BEGIN`/statements/`ROLLBACK`-or-`COMMIT` on
+  that single connection. Registered in `lib.rs` via `mod batch;`, `.manage(...)`, and
+  `generate_handler!`.
+- `runTransaction` in `src/lib/db.ts` became `runBatch`, invoked inside `enqueueWrite` so `getDb()`
+  and migrations still complete first. The four `executeSaveX` helpers became `buildSaveX` returning
+  statements, removing duplicated SQL.
+- Read-helper audit: `getSetting`, `loadNotes`, `loadSnippets`, `loadHistory`, `loadToolState`, and
+  the API loaders are each a single `SELECT`, so none depend on cross-statement connection affinity.
+  They are not snapshot-consistent with one another, but no caller relies on that. Recorded in the
+  ADR.
+- Documented as ADR-013 in `documentation/infrastructure/ARCHITECTURE_DECISIONS.md`, including the
+  rejected alternatives (multi-statement SQL strings — injection surface; dropping the wrapper —
+  leaves partial states user-visible).
+- Rewrote the three DB test files to assert the guarantee actually implemented rather than the one
+  previously assumed: a single `db_execute_batch` invocation carrying all statements in order, the
+  correct `immediate` flag, no JS-driven `BEGIN`/`COMMIT` reaching the plugin pool, failure
+  propagation, and an empty batch skipping the invoke. The prior rollback tests mocked a single
+  connection and structurally could not observe this failure mode.
+
+### [x] Fix `useToolState` cold-start races that discard user input
+
+Area: tool state persistence / data loss
+
+Problem: `src/hooks/useToolState.ts` has two related defects on the cold-start path, when nothing is
+in the in-memory cache and `loadToolState()` is in flight.
+
+1. **Clobbered input.** The load resolves and calls `setState({ ...defaultState, ...saved })`,
+   discarding whatever the user typed while the query was pending. The only guard is `cancelled`,
+   which covers unmount, not intervening edits. Typing into a tool immediately after a cold launch
+   can have the input replaced by the previous session's state mid-keystroke.
+2. **Dropped edits on fast unmount.** The unmount effect saves only `if (loadedRef.current)`. A user
+   who opens a tool, types, and switches tabs before the load resolves has their work silently
+   discarded, because `loadedRef.current` is still `false`.
+
+Expected outcome: A pending load never overwrites newer user input, and edits are never dropped
+because a read happened to still be in flight.
+
+Acceptance criteria:
+
+- Track whether the user has modified state since mount; if so, the resolving load does not
+  overwrite it (drop the load, or merge only keys the user has not touched).
+- The unmount save runs whenever local state has been modified, regardless of `loadedRef`.
+- Tests cover: edit-during-pending-load keeps the edit; unmount-during-pending-load persists the
+  edit; and the untouched cold path still restores saved state.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/hooks
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
+
+Completed 2026-07-30:
+
+- Added a `dirtyRef` set at the top of `update()`, tracking whether the user has modified state since
+  mount.
+- A `loadToolState()` that resolves after an edit is dropped entirely rather than merged. Tool state
+  fields are interdependent (a regex pattern and its flags, a request body and its content-type
+  header), so a partial merge would splice last session's values into state the user is actively
+  editing and produce a combination that never existed. Live input wins.
+- The unmount save now runs on `loadedRef.current || dirtyRef.current`, so an edit made while the
+  initial read was still in flight is persisted instead of silently discarded.
+- Added four tests: edit-during-pending-load keeps the edit and drops the load; unmount during a
+  pending load persists the edit; the untouched cold path still restores saved state; unmount with
+  neither an edit nor a completed load writes nothing.
+- Note: these tests extend the existing `src/tools/__tests__/useToolState.test.ts` rather than
+  `src/hooks/__tests__/`, which is contrary to the documented convention. Left in place to keep the
+  diff scoped; see the follow-up item in P2.
 
 ### [x] Restore a locally verifiable Rust clippy gate
 
@@ -191,6 +403,120 @@ Completed 2026-07-30:
   release-time evidence generated from downloaded GitHub Release artifacts.
 
 ## P1 - High-Value Regression Coverage
+
+### [ ] Fix the Notes markdown pipeline silently destroying content
+
+Area: notes / markdown rendering
+
+Problem: `src/lib/markdown.ts` — used only by `NotesDrawer` — passes `rehypeSanitize` a
+**replacement** schema rather than extending `defaultSchema`, and never registers `remarkGfm`. The
+allowed `tagNames` list omits `table`, `thead`, `tbody`, `tr`, `th`, `td`, `img`, `del`, and `input`.
+Notes containing those constructs are not rendered badly; they are rendered **wrong**, with no error
+and no indication anything was lost. `MarkdownEditor.tsx` gets this right (`...defaultSchema` plus
+`remarkGfm`), so the two markdown surfaces in the app disagree.
+
+Evidence: running the exact `processMarkdown` pipeline against representative markdown produced:
+
+- GFM table → all table tags stripped, leaving bare cell text as loose lines of prose
+- `![img](https://...)` → empty `<p></p>`
+- `~~strike~~` → plain unstyled text
+- task list `- [ ] item` → checkbox gone, leaving a stray leading space
+
+Sanitization itself is not the problem: `javascript:` and `data:` hrefs were correctly stripped
+while `https:` survived, so this is a correctness and data-fidelity bug, not a security hole. Worth
+noting the schema is a wholesale replacement, so any future protection assumed to come from
+`defaultSchema` will not be there.
+
+Expected outcome: A note renders the same markdown feature set as the Markdown Editor.
+
+Acceptance criteria:
+
+- `processMarkdown` extends `defaultSchema` and registers `remarkGfm`, matching the editor.
+- The two pipelines share one sanitize schema definition instead of maintaining separate lists.
+- Tests assert tables, images, strikethrough, and task lists survive, and that `javascript:` and
+  `data:` hrefs are still stripped.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/lib src/components/shell
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
+
+### [ ] Route file downloads through the Tauri save dialog
+
+Area: cross-platform file export
+
+Problem: Five export paths build a detached `<a download>`, call `a.click()`, and then call
+`URL.revokeObjectURL(url)` synchronously on the next line:
+
+- `src/tools/snippets/SnippetsManager.tsx:533`
+- `src/tools/image-tool/ImageTool.tsx:497`
+- `src/tools/mermaid-editor/MermaidEditor.tsx:329,344,383`
+- `src/tools/markdown-editor/MarkdownEditor.tsx:761`
+
+Two problems. The anchor is never appended to the document and the blob URL is revoked in the same
+tick the download is supposed to start, which is unreliable in WKWebView — the macOS target. And the
+app already has the correct mechanism: `saveFileDialog()` in `src/lib/file-io.ts`, which is what the
+global save shortcut uses. These tools bypass it, so exports get inconsistent behavior and no save
+location prompt.
+
+Expected outcome: One export helper, used everywhere, that saves through the Tauri dialog.
+
+Acceptance criteria:
+
+- A shared helper handles text and blob export via `saveFileDialog()`; the five call sites use it.
+- Filename derivation and sanitization live in the helper rather than being re-implemented per tool.
+- Where a blob URL is still genuinely required, revocation is deferred rather than synchronous.
+- Tests cover save success, user cancellation, and write failure for at least two tools.
+- Confirm `src-tauri/capabilities/default.json` still scopes write permissions correctly; do not
+  broaden them.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/tools src/lib
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
+
+### [ ] Make bootstrap cleanup leak-free and store init recoverable
+
+Area: app bootstrap / lifecycle
+
+Two defects in the same area, small enough to land together.
+
+**Leaked listeners.** In `src/app/providers.tsx`, `bootstrap()` pushes cleanups onto `cleanups` only
+after a long chain of `await`s — `unlistenMcpChanged` at line 83, and `onMoved` / `onResized` /
+`clearTimeout` at lines 153-155. The effect's cleanup function iterates `cleanups` at unmount time.
+If unmount happens before those pushes, the array is already empty and the listeners are registered
+afterward with nothing to remove them. The `cancelled` checks at lines 64, 68, and 108 do not cover
+the gaps around lines 74-85 or 131-155.
+
+**Unrecoverable init failure.** `settings.store`, `mcp.store`, and their peers cache `initPromise`
+and never clear it on rejection. One transient failure — a locked database at launch, for example —
+is latched for the entire process lifetime. `Providers` renders a terminal "Failed to initialize"
+screen with no retry, so the app is dead until the user relaunches.
+
+Expected outcome: Unmount during bootstrap leaves nothing registered, and a transient init failure is
+retryable.
+
+Acceptance criteria:
+
+- Register each cleanup at the moment its resource is created, and re-check `cancelled` after every
+  `await` that precedes a registration; if cancelled, tear down what was just created.
+- Store `init()` clears the cached promise on rejection so a later call retries.
+- The `Providers` error state offers a retry affordance instead of requiring a relaunch.
+- Tests cover unmount mid-bootstrap leaving no live listeners, and a failed-then-successful `init()`.
+
+Verification:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run src/app src/stores
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+```
 
 ### [x] Add direct `useGlobalShortcuts` dispatch coverage
 
@@ -389,6 +715,132 @@ Completed 2026-07-30:
   TypeScript, and ESLint.
 
 ## P2 - Quality Ratchets and Maintainability
+
+### [ ] Repair the `lint` package script
+
+Area: quality gates / tooling
+
+Problem: `"lint": "eslint src --ext ..."` in `package.json` invokes a bare `eslint`, which does not
+resolve under the minimal shell PATH. `bun run lint` exits 127 with `eslint: command not found`. The
+documented lint gate has therefore not been runnable locally, and any local "lint passing" claim made
+via that script was vacuous. `bunx eslint src --ext .ts,.tsx,.js,.jsx` works and currently reports
+zero warnings, so this is a script defect, not lint debt.
+
+Expected outcome: The documented command actually runs the linter.
+
+Acceptance criteria:
+
+- The script uses `bunx eslint` (or otherwise resolves the local binary) and exits 0.
+- Confirm whether CI invokes this script; if so, establish why CI has been reporting green and
+  whether the gate has been passing for the right reason.
+- Update `AGENTS.md` and `CLAUDE.md` command tables to match the working invocation.
+- Fold into the ESLint ratchet item below, since `--max-warnings` is meaningless until the script
+  runs.
+
+### [ ] Re-examine the five worker mocks that were never active
+
+Area: test integrity
+
+Problem: `vitest.config.ts` declared aliases as an object whose first key was a bare `'@'`. Vite
+takes the first matching alias, and `'@'` matches every `@/...` specifier, so the
+`@/workers/{typescript,formatter,refactoring,diff,xml}.worker?worker` mock entries below it never
+applied. Those five workers silently resolved to Vite's no-op worker stub for the lifetime of the
+config. The alias map was converted to an ordered array while fixing the Regex Tester, so the mocks
+are now live for the first time.
+
+The suite passes at 76 files / 623 tests with the mocks active, so nothing is currently broken. The
+concern is retrospective: any coverage those five tools' tests appeared to provide over worker
+round-trips was not real, and the previous 593-test baseline was weaker than the count suggested.
+
+Expected outcome: Confidence that worker-backed tool tests exercise what they claim to.
+
+Acceptance criteria:
+
+- Review the formatter, diff, xml, typescript, and refactoring tool tests against the now-live mocks
+  and confirm each asserts real worker round-trip behaviour rather than passing vacuously.
+- Add a guard against silent alias shadowing — a test asserting each worker specifier resolves to the
+  mock, or a comment plus ordering check in the config.
+- Cross-check the completed "Add worker RPC round-trip regression coverage" P0 item above; part of
+  its claimed coverage ran against a stub.
+
+### [ ] Relocate `useToolState` tests to the documented location
+
+Area: test organisation
+
+`src/tools/__tests__/useToolState.test.ts` covers a hook, not a tool, and belongs in
+`src/hooks/__tests__/`. Left in place during the P0 fix to keep that diff scoped. Move it and confirm
+no other test files sit in the wrong directory.
+
+### [ ] Move tool capability flags into the tool registry
+
+Area: tool registry / drift prevention
+
+Problem: `src/app/tool-registry.ts` is documented as the single source of truth for tools, but three
+hardcoded tool-id sets live outside it and must be kept in sync by hand:
+
+- `OPEN_FILE_TOOLS` and `SAVE_FILE_TOOLS` in `src/lib/tool-actions.ts`
+- `MONACO_TOOL_IDS` in `src/components/shell/Workspace.tsx`
+
+All three are currently correct — this is a latent risk, not an active bug. But nothing enforces it.
+A renamed or removed tool leaves a stale string that fails silently: the file-open shortcut reports
+"not supported by the active tool", or the workspace applies the wrong overflow mode. Neither
+surfaces as a type error or a test failure.
+
+Expected outcome: Tool capabilities are declared once, next to the tool.
+
+Acceptance criteria:
+
+- `supportsOpenFile`, `supportsSaveFile`, and `usesMonaco` become fields on the registry entry type.
+- `tool-actions.ts` and `Workspace.tsx` read from the registry; the three id sets are deleted.
+- A test asserts every capability flag refers to a registered tool id.
+
+### [ ] Derive the persisted settings object instead of hand-listing keys
+
+Area: settings persistence / silent data loss
+
+Problem: `update()` in `src/stores/settings.store.ts` builds the object it persists by enumerating
+all eighteen `AppSettings` fields by hand. Adding a field to `AppSettings` and forgetting to add it
+here compiles cleanly, passes lint, and passes tests — the setting simply never persists, and the
+user sees it silently reset on every relaunch. It is a bug waiting for the next feature.
+
+Expected outcome: Adding a settings field cannot silently skip persistence.
+
+Acceptance criteria:
+
+- Derive the persisted object from the keys of `DEFAULT_SETTINGS` rather than restating them.
+- If the explicit list is kept for typing reasons, make omission a compile error via an exhaustive
+  `Record<keyof AppSettings, true>` key map.
+- A test asserts every `AppSettings` key round-trips through `update()` and `init()`.
+
+### [ ] Tidy shell-level React and shortcut patterns
+
+Area: shell / code quality
+
+Small cleanups found while auditing; none is user-visible on its own.
+
+- `src/hooks/useGlobalShortcuts.ts` defines nine near-identical `switchWorkspaceTabN` callbacks and
+  nine `useMemo` combos that differ only by index. Generate them from a loop over indices.
+- Each `useKeyboardShortcut` call registers its own `window` keydown listener — roughly 24 listeners
+  for the shell. A single dispatching listener over a combo table would do.
+- `useKeyboardShortcut` calls `target.closest(...)` on `event.target` without confirming it is an
+  `Element`. Guard it; a non-element target throws inside the handler.
+- `Workspace.tsx` resets its error boundary by calling `errorBoundaryRef.current?.setState(...)` from
+  outside the component. Expose an imperative `reset()` method on the boundary instead of mutating
+  another component's state.
+- `NotesDrawer`'s `MarkdownRenderer` calls `processMarkdown(content).then(setHtml)` with no
+  cancellation, so rapid edits can resolve out of order and render stale HTML. Add a cancel flag.
+- `src-tauri/Cargo.toml` still declares `version = "0.1.0"` while `tauri.conf.json` and
+  `package.json` are at `0.1.51`. Cosmetic today because `getVersion()` reads the Tauri config, but
+  it makes crate metadata misleading.
+
+Verification for all three P2 items above:
+
+```bash
+cd apps/cockpit
+PATH="/opt/homebrew/bin:$PATH" bunx vitest run
+PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+PATH="/opt/homebrew/bin:$PATH" bun run lint
+```
 
 ### [ ] Ratchet ESLint warnings toward zero
 

--- a/apps/cockpit/documentation/infrastructure/ARCHITECTURE_DECISIONS.md
+++ b/apps/cockpit/documentation/infrastructure/ARCHITECTURE_DECISIONS.md
@@ -352,3 +352,68 @@ Tools persist their UI state (input text, selected options, output) so that swit
 - Tool state is always current in memory (no read-from-DB on switch if cache is populated).
 - A crash within the 2-second debounce window could lose the last keystrokes — acceptable trade-off.
 - The `toolId` passed to `useToolState` **must exactly match** the `id` in `tool-registry.ts`, or state will not be found in the cache on switch-back.
+
+---
+
+## ADR-013: Atomic batch writes go through a Rust command, not JS `BEGIN`/`COMMIT`
+
+**Status:** Accepted
+**Date:** 2026
+
+### Context
+
+`runTransaction` in `src/lib/db.ts` used to issue `BEGIN`, the caller's statements, and `COMMIT` as
+separate `conn.execute()` calls and claimed atomicity for `saveNotesOrder`,
+`saveUserPromptTemplates`, `seedBuiltinPromptTemplates`, and `saveApiImport`.
+
+That claim was false. `tauri-plugin-sql` 2.3.2 holds a `DbPool::Sqlite(Pool<Sqlite>)` created with
+`Pool::connect(...)` — the sqlx default of **10 max connections** — and runs every statement via
+`pool.execute(query)` (`src/wrapper.rs`), acquiring a connection from the pool per statement. Nothing
+pins `BEGIN`, the writes, and `COMMIT` to one connection. When they land on different connections:
+
+- the writes auto-commit individually, so a batch can persist partial results;
+- `COMMIT` on a connection with no open transaction errors, and the catch-block `ROLLBACK` silently
+  no-ops on a connection that never began one;
+- worst case an open `BEGIN IMMEDIATE` is stranded on a pooled connection, and every later write
+  routed to it fails with "cannot start a transaction within a transaction" until the app restarts.
+
+The JS-side `writeQueue` serializes writes, which usually makes the pool hand back the
+most-recently-released connection. That is why the bug was latent rather than observed. The Rust MCP
+service already sidesteps the same problem by opening its own pool with `max_connections(1)`.
+
+### Decision
+
+Batch writes move behind a Tauri command, `db_execute_batch` (`src-tauri/src/batch.rs`), which owns a
+dedicated `max_connections(1)` SQLite pool (WAL, 5s busy timeout — the same configuration as the MCP
+service) and runs the whole batch inside one transaction on one connection. Statements are sent as
+`{ sql, params }` pairs; JSON parameters are bound with sqlx using the same scalar mapping the plugin
+uses. An `immediate` flag selects `BEGIN IMMEDIATE` (used by `saveNotesOrder`) over `BEGIN`.
+
+On the JS side `runTransaction` is replaced by `runBatch(statements, immediate)`, which still goes
+through `enqueueWrite` so batches stay ordered against single-statement plugin writes, and so that
+`getDb()` has opened the database and applied migrations before the Rust pool touches the file.
+
+Rejected alternatives:
+
+- **Single multi-statement SQL string.** `conn.execute` is parameterised per statement; concatenating
+  batch upserts would mean inlining user content into SQL. Not worth the injection surface.
+- **Drop the wrapper and make batches idempotent.** All four batches already use idempotent upserts,
+  but "partially applied reorder" and "half an imported collection" are still user-visible wrong
+  states, and nothing would re-run the batch.
+
+### Consequences
+
+- Batch writes are genuinely all-or-nothing; a failure surfaces as a rejected promise with the Rust
+  error text and leaves no partial rows.
+- JS never emits `BEGIN`/`COMMIT`/`ROLLBACK`. If a future batch writer is added it must use
+  `runBatch`, not hand-rolled transaction statements.
+- Two pools now write to `cockpit.db` (the plugin's and the batch pool), as was already the case with
+  the MCP service. WAL plus the 5s busy timeout covers the contention, and `writeQueue` keeps the
+  app's own writes serialized.
+- Single-record writers (`saveUserPromptTemplate`, `saveApiCollection`, `saveApiRequest`) still go
+  through the plugin pool: one statement is atomic on its own. They now share the SQL builders with
+  the batch path instead of duplicating it.
+- Reads (`getSetting`, `loadNotes`, `loadSnippets`, `loadHistory`, `loadToolState`, the API loaders)
+  remain on the plugin pool. Each is a single `SELECT` and so needs no cross-statement connection
+  affinity. They are not snapshot-consistent with each other, but no caller depends on that — stores
+  load each table independently at boot.

--- a/apps/cockpit/src-tauri/src/batch.rs
+++ b/apps/cockpit/src-tauri/src/batch.rs
@@ -1,0 +1,170 @@
+//! Atomic multi-statement writes against the cockpit database.
+//!
+//! `tauri-plugin-sql` runs every statement through `pool.execute(...)`, acquiring a
+//! connection from a multi-connection pool per statement. A JS-side `BEGIN` / writes /
+//! `COMMIT` sequence therefore has no guarantee of landing on one connection, so it
+//! provides no atomicity. This module owns a dedicated `max_connections(1)` pool (the
+//! same approach the MCP service uses) and runs each batch inside a real sqlx
+//! transaction, so a batch either fully applies or fully rolls back.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use sqlx::{
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions},
+    Executor,
+};
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::Mutex;
+
+/// A single parameterised statement in a batch.
+#[derive(Debug, Deserialize)]
+pub struct BatchStatement {
+    pub sql: String,
+    #[serde(default)]
+    pub params: Vec<JsonValue>,
+}
+
+/// Lazily-opened single-connection pool used only for atomic batches.
+#[derive(Default)]
+pub struct BatchDb {
+    pool: Mutex<Option<SqlitePool>>,
+}
+
+fn cockpit_db_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let app_config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|err| format!("Failed to resolve app config directory: {err}"))?;
+    std::fs::create_dir_all(&app_config_dir)
+        .map_err(|err| format!("Failed to create app config directory: {err}"))?;
+    Ok(app_config_dir.join("cockpit.db"))
+}
+
+impl BatchDb {
+    async fn pool(&self, app: &AppHandle) -> Result<SqlitePool, String> {
+        let mut guard = self.pool.lock().await;
+        if let Some(pool) = guard.as_ref() {
+            return Ok(pool.clone());
+        }
+
+        let db_path = cockpit_db_path(app)?;
+        // `create_if_missing` is deliberately omitted: the plugin owns creation and
+        // migrations. If the file is absent the app has not booted far enough to write.
+        let connect_options = SqliteConnectOptions::new()
+            .filename(&db_path)
+            .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(std::time::Duration::from_secs(5));
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(connect_options)
+            .await
+            .map_err(|err| format!("Failed to open cockpit database for batch write: {err}"))?;
+
+        *guard = Some(pool.clone());
+        Ok(pool)
+    }
+}
+
+/// Binds a JSON parameter to a sqlx query.
+///
+/// JSON has no integer/float distinction at the type level, so numbers are bound as
+/// `i64` when they are integral and `f64` otherwise. Arrays and objects are bound as
+/// their serialised form, matching what `tauri-plugin-sql` does for non-scalar values.
+fn bind_param<'q>(
+    query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    value: &JsonValue,
+) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    match value {
+        JsonValue::Null => query.bind(Option::<String>::None),
+        JsonValue::Bool(b) => query.bind(*b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else {
+                query.bind(n.as_f64().unwrap_or_default())
+            }
+        }
+        JsonValue::String(s) => query.bind(s.clone()),
+        other => query.bind(other.to_string()),
+    }
+}
+
+/// Executes every statement inside one transaction on one connection.
+///
+/// `immediate` maps to `BEGIN IMMEDIATE`, which takes the write lock up front instead of
+/// upgrading mid-transaction (used where a read-then-write ordering matters).
+#[tauri::command]
+pub async fn db_execute_batch(
+    app: AppHandle,
+    db: State<'_, BatchDb>,
+    statements: Vec<BatchStatement>,
+    immediate: bool,
+) -> Result<(), String> {
+    if statements.is_empty() {
+        return Ok(());
+    }
+
+    let pool = db.pool(&app).await?;
+    let mut conn = pool
+        .acquire()
+        .await
+        .map_err(|err| format!("Failed to acquire batch connection: {err}"))?;
+
+    conn.execute(if immediate {
+        "BEGIN IMMEDIATE"
+    } else {
+        "BEGIN"
+    })
+    .await
+    .map_err(|err| format!("Failed to begin batch transaction: {err}"))?;
+
+    for statement in &statements {
+        let mut query = sqlx::query(&statement.sql);
+        for param in &statement.params {
+            query = bind_param(query, param);
+        }
+        if let Err(err) = query.execute(&mut *conn).await {
+            // Same connection, so the rollback is guaranteed to target this transaction.
+            let rollback = conn.execute("ROLLBACK").await;
+            if let Err(rollback_err) = rollback {
+                return Err(format!(
+                    "Batch statement failed ({err}); rollback also failed ({rollback_err})"
+                ));
+            }
+            return Err(format!("Batch statement failed: {err}"));
+        }
+    }
+
+    conn.execute("COMMIT")
+        .await
+        .map_err(|err| format!("Failed to commit batch transaction: {err}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_statements_with_default_params() {
+        let parsed: Vec<BatchStatement> =
+            serde_json::from_str(r#"[{"sql":"DELETE FROM notes"}]"#).expect("valid payload");
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].params.is_empty());
+    }
+
+    #[test]
+    fn deserialises_mixed_scalar_params() {
+        let parsed: Vec<BatchStatement> = serde_json::from_str(
+            r#"[{"sql":"UPDATE notes SET sort_order = $1 WHERE id = $2","params":[1024,"a"]}]"#,
+        )
+        .expect("valid payload");
+        assert_eq!(parsed[0].params.len(), 2);
+        assert!(parsed[0].params[0].is_number());
+        assert!(parsed[0].params[1].is_string());
+    }
+}

--- a/apps/cockpit/src-tauri/src/batch.rs
+++ b/apps/cockpit/src-tauri/src/batch.rs
@@ -11,10 +11,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions},
-    Executor,
-};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};
 use tauri::{AppHandle, Manager, State};
 use tokio::sync::Mutex;
 
@@ -108,17 +105,18 @@ pub async fn db_execute_batch(
     }
 
     let pool = db.pool(&app).await?;
-    let mut conn = pool
-        .acquire()
-        .await
-        .map_err(|err| format!("Failed to acquire batch connection: {err}"))?;
 
-    conn.execute(if immediate {
-        "BEGIN IMMEDIATE"
+    // A sqlx `Transaction` rather than hand-written BEGIN/COMMIT/ROLLBACK strings. sqlx
+    // tracks the transaction on the connection and rolls back on `Drop`, so every early
+    // return below — including a failed `COMMIT` — releases the connection clean. Raw SQL
+    // would leave sqlx unaware a transaction was open, and since this pool is
+    // `max_connections(1)`, one leaked transaction would poison every later batch with
+    // "cannot start a transaction within a transaction".
+    let mut tx = if immediate {
+        pool.begin_with("BEGIN IMMEDIATE").await
     } else {
-        "BEGIN"
-    })
-    .await
+        pool.begin().await
+    }
     .map_err(|err| format!("Failed to begin batch transaction: {err}"))?;
 
     for statement in &statements {
@@ -126,19 +124,13 @@ pub async fn db_execute_batch(
         for param in &statement.params {
             query = bind_param(query, param);
         }
-        if let Err(err) = query.execute(&mut *conn).await {
-            // Same connection, so the rollback is guaranteed to target this transaction.
-            let rollback = conn.execute("ROLLBACK").await;
-            if let Err(rollback_err) = rollback {
-                return Err(format!(
-                    "Batch statement failed ({err}); rollback also failed ({rollback_err})"
-                ));
-            }
-            return Err(format!("Batch statement failed: {err}"));
-        }
+        query
+            .execute(&mut *tx)
+            .await
+            .map_err(|err| format!("Batch statement failed: {err}"))?;
     }
 
-    conn.execute("COMMIT")
+    tx.commit()
         .await
         .map_err(|err| format!("Failed to commit batch transaction: {err}"))?;
 

--- a/apps/cockpit/src-tauri/src/lib.rs
+++ b/apps/cockpit/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod batch;
 mod mcp;
 
 use tauri_plugin_sql::{Migration, MigrationKind};
@@ -79,8 +80,10 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(mcp::McpManager::default())
+        .manage(batch::BatchDb::default())
         .invoke_handler(tauri::generate_handler![
             get_platform_info,
+            batch::db_execute_batch,
             mcp::mcp_apply_settings,
             mcp::mcp_rotate_key,
             mcp::mcp_restart,

--- a/apps/cockpit/src/__mocks__/regex-worker.ts
+++ b/apps/cockpit/src/__mocks__/regex-worker.ts
@@ -1,0 +1,47 @@
+// Test-environment stand-in for `@/workers/regex.worker?worker`.
+//
+// Unlike the generic worker mock this one actually runs the real evaluation, so the
+// regex tester's behaviour is exercised end to end in tests. Replies are delivered
+// asynchronously (as a real worker would) and a terminated instance goes silent.
+import { evaluateRegex } from '@/workers/regex.api'
+import type { RegexEvaluationInput } from '@/workers/regex.api'
+
+type RpcRequest = { id: number; method: string; args: unknown[] }
+
+class MockRegexWorker {
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onmessageerror: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: ErrorEvent) => void) | null = null
+  private terminated = false
+
+  postMessage(message: unknown) {
+    const { id, method, args } = message as RpcRequest
+    queueMicrotask(() => {
+      if (this.terminated) return
+      try {
+        if (method !== 'evaluate') throw new Error(`Unknown method: ${method}`)
+        const result = evaluateRegex(args[0] as RegexEvaluationInput)
+        this.onmessage?.({ data: { id, result } } as MessageEvent)
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err)
+        this.onmessage?.({ data: { id, error } } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {
+    this.terminated = true
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent(): boolean {
+    return false
+  }
+}
+
+export default function MockRegexWorkerFactory() {
+  return new MockRegexWorker()
+}
+
+export { MockRegexWorker }

--- a/apps/cockpit/src/app/__tests__/providers.test.tsx
+++ b/apps/cockpit/src/app/__tests__/providers.test.tsx
@@ -1,0 +1,211 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Providers } from '@/app/providers'
+
+async function flushMicrotasks(times = 10) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve()
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const mocks = vi.hoisted(() => ({
+  settingsInit: vi.fn(),
+  settingsState: {
+    initialized: false,
+    alwaysOnTop: false,
+    checkForUpdatesAutomatically: false,
+    downloadUpdatesAutomatically: false,
+  },
+  notesInit: vi.fn(),
+  snippetsInit: vi.fn(),
+  promptTemplatesInit: vi.fn(),
+  historyInit: vi.fn(),
+  mcpInit: vi.fn(),
+  listen: vi.fn(),
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+  getToolById: vi.fn(),
+  onMoved: vi.fn(),
+  onResized: vi.fn(),
+  setAlwaysOnTop: vi.fn(),
+  checkForUpdate: vi.fn(),
+}))
+
+vi.mock('@/stores/settings.store', () => ({
+  useSettingsStore: Object.assign(
+    (selector: (s: typeof mocks.settingsState & { init: unknown }) => unknown) =>
+      selector({ ...mocks.settingsState, init: mocks.settingsInit }),
+    { getState: () => ({ ...mocks.settingsState, init: mocks.settingsInit }) }
+  ),
+}))
+
+vi.mock('@/stores/notes.store', () => ({
+  useNotesStore: { getState: () => ({ init: mocks.notesInit, refresh: vi.fn() }) },
+}))
+
+vi.mock('@/stores/snippets.store', () => ({
+  useSnippetsStore: { getState: () => ({ init: mocks.snippetsInit, refresh: vi.fn() }) },
+}))
+
+vi.mock('@/stores/prompt-templates.store', () => ({
+  usePromptTemplatesStore: {
+    getState: () => ({ init: mocks.promptTemplatesInit, refresh: vi.fn() }),
+  },
+}))
+
+vi.mock('@/stores/history.store', () => ({
+  useHistoryStore: { getState: () => ({ init: mocks.historyInit }) },
+}))
+
+vi.mock('@/stores/api.store', () => ({
+  useApiStore: { getState: () => ({ refresh: vi.fn() }) },
+}))
+
+vi.mock('@/stores/mcp.store', () => ({
+  useMcpStore: { getState: () => ({ init: mocks.mcpInit }) },
+}))
+
+vi.mock('@/stores/ui.store', () => ({
+  useUiStore: { getState: () => ({ restoreTabs: vi.fn(), restoreActiveTool: vi.fn() }) },
+}))
+
+vi.mock('@/stores/updater.store', () => ({
+  useUpdaterStore: { getState: () => ({ checkForUpdate: mocks.checkForUpdate, updateInfo: null }) },
+  autoDownloadUpdate: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    setPosition: vi.fn(),
+    setSize: vi.fn(),
+    setAlwaysOnTop: mocks.setAlwaysOnTop,
+    onMoved: mocks.onMoved,
+    onResized: mocks.onResized,
+    scaleFactor: vi.fn().mockResolvedValue(1),
+    outerPosition: vi.fn().mockResolvedValue({ toLogical: () => ({ x: 0, y: 0 }) }),
+    outerSize: vi.fn().mockResolvedValue({ toLogical: () => ({ width: 800, height: 600 }) }),
+  }),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => mocks.listen(...args),
+}))
+
+vi.mock('@/lib/db', () => ({
+  getSetting: (...args: unknown[]) => mocks.getSetting(...args),
+  setSetting: (...args: unknown[]) => mocks.setSetting(...args),
+}))
+
+vi.mock('@/app/tool-registry', () => ({
+  getToolById: (...args: unknown[]) => mocks.getToolById(...args),
+}))
+
+describe('Providers bootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.settingsState.initialized = false
+    mocks.getSetting.mockResolvedValue(null)
+    mocks.setSetting.mockResolvedValue(undefined)
+    mocks.getToolById.mockReturnValue(undefined)
+    mocks.notesInit.mockResolvedValue(undefined)
+    mocks.snippetsInit.mockResolvedValue(undefined)
+    mocks.promptTemplatesInit.mockResolvedValue(undefined)
+    mocks.historyInit.mockResolvedValue(undefined)
+    mocks.mcpInit.mockResolvedValue(undefined)
+    mocks.checkForUpdate.mockResolvedValue(undefined)
+    mocks.settingsInit.mockImplementation(async () => {
+      mocks.settingsState.initialized = true
+    })
+  })
+
+  afterEach(() => {
+    mocks.settingsState.initialized = false
+  })
+
+  it('tears down a listener created just before unmount instead of leaking it', async () => {
+    const unlistenMcp = vi.fn()
+    const mcpListenGate = deferred<() => void>()
+    mocks.listen.mockReturnValue(mcpListenGate.promise)
+
+    const { unmount } = render(<Providers>content</Providers>)
+
+    // Let bootstrap progress through the preceding store-init awaits so it
+    // reaches (and suspends on) `await listen(...)`.
+    await act(async () => {
+      await flushMicrotasks()
+    })
+    expect(mocks.listen).toHaveBeenCalledTimes(1)
+
+    // Unmount while still awaiting `listen()` — before the fix, `cleanups`
+    // would already have been iterated (empty) by the time `listen()`
+    // resolves and pushes the unlisten fn into it.
+    unmount()
+
+    await act(async () => {
+      mcpListenGate.resolve(unlistenMcp)
+      await flushMicrotasks()
+    })
+
+    expect(unlistenMcp).toHaveBeenCalledTimes(1)
+  })
+
+  it('tears down window listeners created just before unmount', async () => {
+    const unlistenMoved = vi.fn()
+    const unlistenResized = vi.fn()
+    mocks.listen.mockResolvedValue(vi.fn())
+    const onMovedGate = deferred<() => void>()
+    mocks.onMoved.mockReturnValue(onMovedGate.promise)
+    mocks.onResized.mockResolvedValue(unlistenResized)
+
+    const { unmount } = render(<Providers>content</Providers>)
+    // Let bootstrap progress up to the `onMoved()` await.
+    await act(async () => {
+      await flushMicrotasks()
+    })
+    expect(mocks.onMoved).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await act(async () => {
+      onMovedGate.resolve(unlistenMoved)
+      await flushMicrotasks()
+    })
+
+    expect(unlistenMoved).toHaveBeenCalledTimes(1)
+    expect(unlistenResized).not.toHaveBeenCalled()
+  })
+
+  it('recovers from a failed init() and offers a retry that succeeds', async () => {
+    mocks.settingsInit
+      .mockImplementationOnce(async () => {
+        throw new Error('database is locked')
+      })
+      .mockImplementationOnce(async () => {
+        mocks.settingsState.initialized = true
+      })
+    mocks.listen.mockResolvedValue(vi.fn())
+    mocks.onMoved.mockResolvedValue(vi.fn())
+    mocks.onResized.mockResolvedValue(vi.fn())
+
+    const { getByText, getByRole } = render(<Providers>content</Providers>)
+
+    await waitFor(() => expect(getByText(/Failed to initialize/)).toBeTruthy())
+
+    await act(async () => {
+      getByRole('button', { name: /retry/i }).click()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(mocks.settingsInit).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/cockpit/src/app/providers.tsx
+++ b/apps/cockpit/src/app/providers.tsx
@@ -19,6 +19,7 @@ export function Providers({ children }: { children: ReactNode }) {
   const init = useSettingsStore((s) => s.init)
   const initialized = useSettingsStore((s) => s.initialized)
   const [error, setError] = useState<string | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
   const geometryRestored = useRef(false)
 
   useEffect(() => {
@@ -80,6 +81,14 @@ export function Providers({ children }: { children: ReactNode }) {
           void useApiStore.getState().refresh()
         }
       })
+      // Register (or, if unmount already happened while we were awaiting
+      // `listen()`, immediately tear down) right at the moment the listener
+      // is created — pushing to `cleanups` after the effect's own cleanup
+      // function has already run would leak the listener forever.
+      if (cancelled) {
+        unlistenMcpChanged()
+        return
+      }
       cleanups.push(unlistenMcpChanged)
 
       await useMcpStore.getState().init()
@@ -151,20 +160,38 @@ export function Providers({ children }: { children: ReactNode }) {
         }, 2000)
       }
       const unlistenMoved = await win.onMoved(persistBounds)
+      if (cancelled) {
+        unlistenMoved()
+        clearTimeout(saveTimer)
+        return
+      }
       const unlistenResized = await win.onResized(persistBounds)
+      if (cancelled) {
+        unlistenMoved()
+        unlistenResized()
+        clearTimeout(saveTimer)
+        return
+      }
       cleanups.push(unlistenMoved, unlistenResized, () => clearTimeout(saveTimer))
     }
 
-    bootstrap().catch((err) => {
-      console.error('Failed to initialize:', err)
-      setError(String(err))
-    })
+    bootstrap()
+      .then(() => setError(null))
+      .catch((err) => {
+        console.error('Failed to initialize:', err)
+        setError(String(err))
+      })
 
     return () => {
       cancelled = true
       cleanups.forEach((fn) => fn())
     }
-  }, [init])
+  }, [init, retryCount])
+
+  const handleRetry = () => {
+    setError(null)
+    setRetryCount((count) => count + 1)
+  }
 
   // Warm up heavy modules during browser idle time after app init.
   // Fallback to setTimeout if requestIdleCallback is not available (e.g., Tauri WebView).
@@ -188,8 +215,15 @@ export function Providers({ children }: { children: ReactNode }) {
 
   if (error) {
     return (
-      <div className="flex h-full items-center justify-center p-8">
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8">
         <div className="text-[var(--color-error)]">Failed to initialize: {error}</div>
+        <button
+          type="button"
+          onClick={handleRetry}
+          className="rounded border border-[var(--color-border)] px-3 py-1.5 text-sm text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)]"
+        >
+          Retry
+        </button>
       </div>
     )
   }

--- a/apps/cockpit/src/hooks/__tests__/useRegexEvaluation.test.ts
+++ b/apps/cockpit/src/hooks/__tests__/useRegexEvaluation.test.ts
@@ -1,0 +1,165 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { REGEX_TIMEOUT_MS, useRegexEvaluation } from '@/hooks/useRegexEvaluation'
+
+/**
+ * A worker that accepts requests and never answers — exactly how the real worker behaves
+ * while it is stuck inside `exec()` on a catastrophic pattern. It cannot be simulated by
+ * running the real evaluation here: `(a+)+$` against 30 `a`s plus `!` does not complete,
+ * so it would wedge the test runner the same way it wedged the app.
+ */
+class WedgedWorker {
+  static instances: WedgedWorker[] = []
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: ErrorEvent) => void) | null = null
+  postMessage = vi.fn()
+  terminate = vi.fn()
+  addEventListener = vi.fn()
+  removeEventListener = vi.fn()
+  dispatchEvent = vi.fn(() => false)
+
+  constructor() {
+    WedgedWorker.instances.push(this)
+  }
+}
+
+vi.mock('@/workers/regex.worker?worker', () => ({
+  default: function WedgedWorkerFactory() {
+    return new WedgedWorker()
+  },
+}))
+
+// The exact reproduction from the bug report.
+const CATASTROPHIC = {
+  pattern: '(a+)+$',
+  flags: 'g',
+  text: `${'a'.repeat(30)}!`,
+  replacement: '',
+}
+
+describe('useRegexEvaluation', () => {
+  beforeEach(() => {
+    WedgedWorker.instances = []
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reports a timeout for a catastrophic pattern once the budget elapses', () => {
+    const { result } = renderHook(() => useRegexEvaluation(CATASTROPHIC))
+
+    expect(result.current.status).toBe('evaluating')
+
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS - 1)
+    })
+    expect(result.current.status).toBe('evaluating')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current.status).toBe('timeout')
+    // Explicitly not a silent empty result.
+    expect(result.current.result).toBeNull()
+  })
+
+  it('terminates the wedged worker and respawns a replacement', () => {
+    renderHook(() => useRegexEvaluation(CATASTROPHIC))
+    const wedged = WedgedWorker.instances[0]
+    expect(wedged?.postMessage).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS)
+    })
+
+    expect(wedged?.terminate).toHaveBeenCalledTimes(1)
+    expect(WedgedWorker.instances).toHaveLength(2)
+  })
+
+  it('does not re-evaluate a timed-out input when it is restored from persisted state', () => {
+    const { result, rerender, unmount } = renderHook((input) => useRegexEvaluation(input), {
+      initialProps: CATASTROPHIC,
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS)
+    })
+    expect(result.current.status).toBe('timeout')
+
+    const postCallsAfterTimeout = WedgedWorker.instances.reduce(
+      (n, w) => n + w.postMessage.mock.calls.length,
+      0
+    )
+
+    // Re-render with the identical input, as a reload of persisted tool state would.
+    rerender({ ...CATASTROPHIC })
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS * 3)
+    })
+
+    expect(result.current.status).toBe('timeout')
+    expect(WedgedWorker.instances.reduce((n, w) => n + w.postMessage.mock.calls.length, 0)).toBe(
+      postCallsAfterTimeout
+    )
+
+    unmount()
+  })
+
+  it('evaluates again as soon as the user edits the pattern', () => {
+    const { result, rerender } = renderHook((input) => useRegexEvaluation(input), {
+      initialProps: CATASTROPHIC,
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS)
+    })
+    expect(result.current.status).toBe('timeout')
+
+    rerender({ ...CATASTROPHIC, pattern: 'a+' })
+    expect(result.current.status).toBe('evaluating')
+
+    const live = WedgedWorker.instances[WedgedWorker.instances.length - 1]
+    const request = live?.postMessage.mock.calls.at(-1)?.[0] as { id: number; args: unknown[] }
+    expect(request.args[0]).toMatchObject({ pattern: 'a+' })
+  })
+
+  it('resolves an empty pattern on the main thread without touching the worker', () => {
+    const { result } = renderHook(() =>
+      useRegexEvaluation({ pattern: '', flags: 'g', text: 'abc', replacement: '' })
+    )
+
+    expect(result.current.status).toBe('ready')
+    expect(result.current.result?.replaceResult).toBe('abc')
+    expect(WedgedWorker.instances).toHaveLength(0)
+  })
+
+  it('ignores a reply that arrives after its request was superseded', () => {
+    const { result, rerender } = renderHook((input) => useRegexEvaluation(input), {
+      initialProps: { pattern: 'a', flags: 'g', text: 'aaa', replacement: '' },
+    })
+
+    const worker = WedgedWorker.instances[0]
+    const staleId = (worker?.postMessage.mock.calls[0]?.[0] as { id: number }).id
+
+    rerender({ pattern: 'b', flags: 'g', text: 'aaa', replacement: '' })
+
+    act(() => {
+      worker?.onmessage?.({
+        data: { id: staleId, result: { matches: [{ full: 'stale' }] } },
+      } as MessageEvent)
+    })
+
+    expect(result.current.status).toBe('evaluating')
+  })
+
+  it('terminates the worker on unmount', () => {
+    const { unmount } = renderHook(() => useRegexEvaluation(CATASTROPHIC))
+    const worker = WedgedWorker.instances[0]
+
+    unmount()
+
+    expect(worker?.terminate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cockpit/src/hooks/__tests__/useRegexEvaluation.test.ts
+++ b/apps/cockpit/src/hooks/__tests__/useRegexEvaluation.test.ts
@@ -154,6 +154,29 @@ describe('useRegexEvaluation', () => {
     expect(result.current.status).toBe('evaluating')
   })
 
+  it('ignores a reply that lands after its own request timed out', () => {
+    const { result } = renderHook(() => useRegexEvaluation(CATASTROPHIC))
+    const worker = WedgedWorker.instances[0]
+    const requestId = (worker?.postMessage.mock.calls[0]?.[0] as { id: number }).id
+
+    act(() => {
+      vi.advanceTimersByTime(REGEX_TIMEOUT_MS)
+    })
+    expect(result.current.status).toBe('timeout')
+
+    // `terminate()` does not cancel a reply already queued as a task on this thread, so a
+    // match that finished just under the wire can still be delivered afterwards. It must
+    // not resurrect a `ready` state for an input now recorded as timed out.
+    act(() => {
+      worker?.onmessage?.({
+        data: { id: requestId, result: { matches: [{ full: 'late' }] } },
+      } as MessageEvent)
+    })
+
+    expect(result.current.status).toBe('timeout')
+    expect(result.current.result).toBeNull()
+  })
+
   it('terminates the worker on unmount', () => {
     const { unmount } = renderHook(() => useRegexEvaluation(CATASTROPHIC))
     const worker = WedgedWorker.instances[0]

--- a/apps/cockpit/src/hooks/useRegexEvaluation.ts
+++ b/apps/cockpit/src/hooks/useRegexEvaluation.ts
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react'
+import RegexWorkerFactory from '@/workers/regex.worker?worker'
+import { emptyEvaluation } from '@/workers/regex.api'
+import type { RegexEvaluation, RegexEvaluationInput } from '@/workers/regex.api'
+
+/**
+ * Evaluates a user-supplied regex in a worker under a hard time budget.
+ *
+ * Why not `useWorker`: that hook owns a worker for the lifetime of the component and only
+ * terminates it on unmount. A pattern with catastrophic backtracking never yields, so the
+ * only recovery is `terminate()` + respawn — a lifecycle `useWorker` has no concept of.
+ * Adding it there would change the contract for its six existing consumers (a rejected
+ * request would no longer imply a live worker), so this tool gets its own hook instead.
+ *
+ * Guarantees:
+ * - Exactly one in-flight request; stale replies are ignored by request id.
+ * - On timeout the worker is terminated (killing the runaway match), respawned, and the
+ *   caller gets an explicit `timeout` status — never a silently empty result.
+ * - Inputs that timed out are remembered, so persisted tool state cannot burn the budget
+ *   again on every launch. Any edit produces a new key and is evaluated normally.
+ */
+
+export const REGEX_TIMEOUT_MS = 1000
+
+export type RegexEvaluationState =
+  | { status: 'evaluating'; result: RegexEvaluation | null }
+  | { status: 'ready'; result: RegexEvaluation }
+  | { status: 'timeout'; result: null }
+
+function inputKey(input: RegexEvaluationInput): string {
+  // NUL separator: it cannot come from a keystroke, so distinct inputs cannot collide.
+  return [input.pattern, input.flags, input.text, input.replacement].join('\u0000')
+}
+
+export function useRegexEvaluation(input: RegexEvaluationInput): RegexEvaluationState {
+  const [state, setState] = useState<RegexEvaluationState>(() => ({
+    status: 'ready',
+    result: emptyEvaluation(input.text),
+  }))
+
+  const workerRef = useRef<Worker | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const requestIdRef = useRef(0)
+  const timedOutKeysRef = useRef(new Set<string>())
+
+  const key = inputKey(input)
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+      workerRef.current?.terminate()
+      workerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    // Any new request invalidates replies still in flight for the previous one.
+    const requestId = ++requestIdRef.current
+
+    // No pattern means no user code to run — resolve on the main thread.
+    if (!input.pattern) {
+      setState({ status: 'ready', result: emptyEvaluation(input.text) })
+      return
+    }
+
+    if (timedOutKeysRef.current.has(key)) {
+      setState({ status: 'timeout', result: null })
+      return
+    }
+
+    setState((prev) => ({
+      status: 'evaluating',
+      // Keep showing the last good result while the new one is computed.
+      result: prev.status === 'ready' ? prev.result : null,
+    }))
+
+    if (!workerRef.current) workerRef.current = new RegexWorkerFactory()
+    const worker = workerRef.current
+
+    const settle = (next: RegexEvaluationState) => {
+      if (requestIdRef.current !== requestId) return
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      setState(next)
+    }
+
+    worker.onmessage = (ev: MessageEvent) => {
+      const { id, result, error } = ev.data as {
+        id: number
+        result?: RegexEvaluation
+        error?: string
+      }
+      if (id !== requestId) return
+      if (error || !result) {
+        settle({
+          status: 'ready',
+          result: { ...emptyEvaluation(input.text), matchError: error ?? 'Regex worker failed' },
+        })
+        return
+      }
+      settle({ status: 'ready', result })
+    }
+
+    worker.onerror = (ev) => {
+      console.error('[useRegexEvaluation] Worker error:', ev)
+      settle({
+        status: 'ready',
+        result: {
+          ...emptyEvaluation(input.text),
+          matchError: ev.message || 'Regex worker failed',
+        },
+      })
+    }
+
+    try {
+      worker.postMessage({ id: requestId, method: 'evaluate', args: [input] })
+    } catch (err) {
+      settle({
+        status: 'ready',
+        result: {
+          ...emptyEvaluation(input.text),
+          matchError: err instanceof Error ? err.message : String(err),
+        },
+      })
+      return
+    }
+
+    timerRef.current = setTimeout(() => {
+      if (requestIdRef.current !== requestId) return
+      timerRef.current = null
+      timedOutKeysRef.current.add(key)
+      // The worker is wedged inside exec(); terminate is the only way out.
+      workerRef.current?.terminate()
+      workerRef.current = new RegexWorkerFactory()
+      setState({ status: 'timeout', result: null })
+    }, REGEX_TIMEOUT_MS)
+    // `input` is fully described by `key`; depending on the object itself would re-run
+    // this effect on every render because callers pass an inline literal.
+  }, [key]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return state
+}

--- a/apps/cockpit/src/hooks/useRegexEvaluation.ts
+++ b/apps/cockpit/src/hooks/useRegexEvaluation.ts
@@ -134,6 +134,12 @@ export function useRegexEvaluation(input: RegexEvaluationInput): RegexEvaluation
     timerRef.current = setTimeout(() => {
       if (requestIdRef.current !== requestId) return
       timerRef.current = null
+      // Retire this request id before terminating. `terminate()` does not cancel a reply
+      // already queued as a task on this thread, so without this a match that finished
+      // just under the wire would still be delivered and flip the pane back to `ready` —
+      // while the key stays in `timedOutKeysRef`, wedging that input as permanently
+      // timed-out the next time the user returns to it.
+      requestIdRef.current++
       timedOutKeysRef.current.add(key)
       // The worker is wedged inside exec(); terminate is the only way out.
       workerRef.current?.terminate()

--- a/apps/cockpit/src/hooks/useToolState.ts
+++ b/apps/cockpit/src/hooks/useToolState.ts
@@ -12,6 +12,10 @@ import { useToolStateCache } from '@/stores/tool-state.store'
  * to the cache immediately, which eliminates the race condition where a rapid
  * switch-away-and-back could load stale state from SQLite before the unmount
  * save completes.
+ *
+ * On the cold path the user can type before the read resolves. Local edits always win:
+ * a resolving load is dropped once the state is dirty, and the unmount save runs for
+ * dirty state even if the read never resolved.
  */
 export function useToolState<T extends Record<string, unknown>>(
   toolId: string,
@@ -29,6 +33,9 @@ export function useToolState<T extends Record<string, unknown>>(
   const stateRef = useRef(state)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const loadedRef = useRef(!!cacheGet(toolId))
+  // True once the user has changed state via update(). Guards the cold-start race
+  // where a slow loadToolState() resolves after the user has already typed.
+  const dirtyRef = useRef(false)
 
   // Load from SQLite on mount only if no cached value
   useEffect(() => {
@@ -36,6 +43,15 @@ export function useToolState<T extends Record<string, unknown>>(
     let cancelled = false
     loadToolState(toolId).then((saved) => {
       if (cancelled) return
+      // The user edited while the read was in flight — drop the load entirely rather
+      // than merging untouched keys. Tool state fields are interdependent (e.g. a regex
+      // pattern and its flags, or a request body and its content-type header), so a
+      // partial merge would splice last session's values into the state the user is
+      // actively editing and produce a combination that never existed. Live input wins.
+      if (dirtyRef.current) {
+        loadedRef.current = true
+        return
+      }
       if (saved) {
         const merged = { ...defaultState, ...saved } as T
         setState(merged)
@@ -55,6 +71,7 @@ export function useToolState<T extends Record<string, unknown>>(
   // Debounced save to SQLite (cache is updated synchronously)
   const update = useCallback(
     (patch: Partial<T>) => {
+      dirtyRef.current = true
       setState((prev) => {
         const next = { ...prev, ...patch }
         stateRef.current = next
@@ -70,11 +87,13 @@ export function useToolState<T extends Record<string, unknown>>(
     [toolId, cacheSet]
   )
 
-  // Save immediately on unmount (cache already up to date)
+  // Save immediately on unmount (cache already up to date).
+  // `dirtyRef` is checked alongside `loadedRef` so edits made while the initial read
+  // was still in flight are persisted instead of being silently discarded.
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
-      if (loadedRef.current) {
+      if (loadedRef.current || dirtyRef.current) {
         saveToolState(toolId, stateRef.current)
       }
     }

--- a/apps/cockpit/src/lib/__tests__/db.api-client.test.ts
+++ b/apps/cockpit/src/lib/__tests__/db.api-client.test.ts
@@ -13,6 +13,11 @@ vi.mock('@tauri-apps/plugin-sql', () => ({
   },
 }))
 
+const coreMock = vi.hoisted(() => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: coreMock.invoke }))
+
+type BatchPayload = { statements: Array<{ sql: string; params: unknown[] }>; immediate: boolean }
+
 const environment: ApiEnvironment = {
   id: 'env-1',
   name: 'Production',
@@ -46,6 +51,7 @@ describe('API Client DB helpers', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    coreMock.invoke.mockResolvedValue(undefined)
     sqlMock.execute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 })
     sqlMock.load.mockResolvedValue({
       execute: sqlMock.execute,
@@ -122,33 +128,43 @@ describe('API Client DB helpers', () => {
     await expect(loadApiRequests()).resolves.toEqual([request])
   })
 
-  it('saves imports atomically with collections before their related requests', async () => {
+  it('saves imports through the atomic batch command, collections before requests', async () => {
     const { saveApiImport } = await import('@/lib/db')
 
     await saveApiImport([collection], [request])
 
-    const statements = sqlMock.execute.mock.calls.map(([sql]) => String(sql).trim())
-    expect(statements).toEqual([
-      'PRAGMA journal_mode=WAL',
-      'PRAGMA busy_timeout=5000',
-      'BEGIN TRANSACTION',
+    // The whole import is one command invocation, so the Rust side can wrap it in a
+    // single transaction on a single connection. Nothing is written via the plugin pool.
+    expect(coreMock.invoke).toHaveBeenCalledTimes(1)
+    const [command, payload] = coreMock.invoke.mock.calls[0] as [string, BatchPayload]
+    expect(command).toBe('db_execute_batch')
+    expect(payload.immediate).toBe(false)
+    expect(payload.statements.map((s) => s.sql.trim())).toEqual([
       expect.stringContaining('INSERT INTO api_collections'),
       expect.stringContaining('INSERT INTO api_requests'),
-      'COMMIT',
     ])
+    expect(payload.statements[1]?.params[1]).toBe(collection.id)
+
+    const pluginStatements = sqlMock.execute.mock.calls.map(([sql]) => String(sql).trim())
+    expect(pluginStatements).not.toContain('BEGIN TRANSACTION')
+    expect(pluginStatements).not.toContain('COMMIT')
   })
 
-  it('rolls back the complete import when a request cannot be persisted', async () => {
-    sqlMock.execute.mockImplementation((sql: string) => {
-      if (sql.includes('INSERT INTO api_requests')) {
-        return Promise.reject(new Error('request write failed'))
-      }
-      return Promise.resolve({ rowsAffected: 0, lastInsertId: 0 })
-    })
+  it('propagates a failed import batch instead of leaving partial state claims', async () => {
+    coreMock.invoke.mockRejectedValueOnce(new Error('Batch statement failed: request write failed'))
     const { saveApiImport } = await import('@/lib/db')
 
     await expect(saveApiImport([collection], [request])).rejects.toThrow('request write failed')
-    expect(sqlMock.execute).toHaveBeenCalledWith('ROLLBACK')
-    expect(sqlMock.execute).not.toHaveBeenCalledWith('COMMIT')
+    // Rollback is the Rust transaction's job — JS must not emit ROLLBACK on a pooled
+    // connection that may never have had a transaction open on it.
+    expect(sqlMock.execute).not.toHaveBeenCalledWith('ROLLBACK')
+  })
+
+  it('does not invoke the batch command for an empty import', async () => {
+    const { saveApiImport } = await import('@/lib/db')
+
+    await saveApiImport([], [])
+
+    expect(coreMock.invoke).not.toHaveBeenCalled()
   })
 })

--- a/apps/cockpit/src/lib/__tests__/db.notes.test.ts
+++ b/apps/cockpit/src/lib/__tests__/db.notes.test.ts
@@ -12,6 +12,9 @@ vi.mock('@tauri-apps/plugin-sql', () => ({
   },
 }))
 
+const coreMock = vi.hoisted(() => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: coreMock.invoke }))
+
 function deferred<T>() {
   let resolvePromise!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void
@@ -41,46 +44,74 @@ describe('notes DB helpers', () => {
     sqlMock.execute.mockReset()
     sqlMock.select.mockReset()
     sqlMock.load.mockReset()
+    coreMock.invoke.mockReset()
+    coreMock.invoke.mockResolvedValue(undefined)
+    sqlMock.execute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 })
     sqlMock.load.mockResolvedValue({
       execute: sqlMock.execute,
       select: sqlMock.select,
     })
   })
 
-  it('serializes note order transactions on the shared connection', async () => {
-    const firstUpdate = deferred<void>()
-    let updateCount = 0
-    sqlMock.execute.mockImplementation((sql: string) => {
-      if (sql === 'UPDATE notes SET sort_order = $1 WHERE id = $2') {
-        updateCount += 1
-        if (updateCount === 1) return firstUpdate.promise
-      }
-      return Promise.resolve({ rowsAffected: 0, lastInsertId: 0 })
+  it('sends the whole reorder as one immediate batch command', async () => {
+    const { saveNotesOrder } = await import('@/lib/db')
+
+    await saveNotesOrder([
+      { id: 'a', sortOrder: 1024 },
+      { id: 'b', sortOrder: 2048 },
+    ])
+
+    expect(coreMock.invoke).toHaveBeenCalledTimes(1)
+    expect(coreMock.invoke).toHaveBeenCalledWith('db_execute_batch', {
+      immediate: true,
+      statements: [
+        { sql: 'UPDATE notes SET sort_order = $1 WHERE id = $2', params: [1024, 'a'] },
+        { sql: 'UPDATE notes SET sort_order = $1 WHERE id = $2', params: [2048, 'b'] },
+      ],
+    })
+    // No JS-driven transaction control: it cannot be pinned to one pooled connection.
+    const pluginStatements = sqlMock.execute.mock.calls.map(([sql]) => sql)
+    expect(pluginStatements).not.toContain('BEGIN IMMEDIATE')
+    expect(pluginStatements).not.toContain('COMMIT')
+  })
+
+  it('serializes reorder batches against other writes on the write queue', async () => {
+    const firstBatch = deferred<void>()
+    let batchCount = 0
+    coreMock.invoke.mockImplementation(() => {
+      batchCount += 1
+      if (batchCount === 1) return firstBatch.promise
+      return Promise.resolve()
     })
 
     const { saveNotesOrder } = await import('@/lib/db')
 
     const firstSave = saveNotesOrder([{ id: 'a', sortOrder: 1024 }])
-    await waitForAssertion(() => expect(updateCount).toBe(1))
+    await waitForAssertion(() => expect(batchCount).toBe(1))
 
     const secondSave = saveNotesOrder([{ id: 'b', sortOrder: 2048 }])
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    const statementsBeforeCommit = sqlMock.execute.mock.calls.map(([sql]) => sql)
-    expect(statementsBeforeCommit.filter((sql) => sql === 'BEGIN IMMEDIATE')).toHaveLength(1)
+    // The second batch must not start until the first has settled.
+    expect(batchCount).toBe(1)
 
-    firstUpdate.resolve()
+    firstBatch.resolve()
     await Promise.all([firstSave, secondSave])
+    expect(batchCount).toBe(2)
+  })
 
-    const statements = sqlMock.execute.mock.calls.map(([sql]) => sql)
-    const firstCommit = statements.indexOf('COMMIT')
-    const secondBegin = statements.indexOf(
-      'BEGIN IMMEDIATE',
-      statements.indexOf('BEGIN IMMEDIATE') + 1
-    )
+  it('propagates batch failures to the caller', async () => {
+    coreMock.invoke.mockRejectedValueOnce(new Error('Batch statement failed: disk full'))
+    const { saveNotesOrder } = await import('@/lib/db')
 
-    expect(firstCommit).toBeGreaterThan(-1)
-    expect(secondBegin).toBeGreaterThan(-1)
-    expect(firstCommit).toBeLessThan(secondBegin)
+    await expect(saveNotesOrder([{ id: 'a', sortOrder: 1 }])).rejects.toThrow('disk full')
+  })
+
+  it('skips the batch command entirely for an empty reorder', async () => {
+    const { saveNotesOrder } = await import('@/lib/db')
+
+    await saveNotesOrder([])
+
+    expect(coreMock.invoke).not.toHaveBeenCalled()
   })
 })

--- a/apps/cockpit/src/lib/__tests__/db.prompt-templates.test.ts
+++ b/apps/cockpit/src/lib/__tests__/db.prompt-templates.test.ts
@@ -13,6 +13,11 @@ vi.mock('@tauri-apps/plugin-sql', () => ({
   },
 }))
 
+const coreMock = vi.hoisted(() => ({ invoke: vi.fn() }))
+vi.mock('@tauri-apps/api/core', () => ({ invoke: coreMock.invoke }))
+
+type BatchPayload = { statements: Array<{ sql: string; params: unknown[] }>; immediate: boolean }
+
 function makeTemplate(id: string): PromptTemplate {
   return {
     id,
@@ -38,22 +43,36 @@ describe('prompt template DB helpers', () => {
     sqlMock.execute.mockReset()
     sqlMock.select.mockReset()
     sqlMock.load.mockReset()
+    coreMock.invoke.mockReset()
+    coreMock.invoke.mockResolvedValue(undefined)
+    sqlMock.execute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 })
     sqlMock.load.mockResolvedValue({
       execute: sqlMock.execute,
       select: sqlMock.select,
     })
   })
 
-  it('rolls back batch prompt template saves when one insert fails', async () => {
-    let insertCount = 0
-    sqlMock.execute.mockImplementation((sql: string) => {
-      if (sql.startsWith('INSERT INTO user_prompt_templates')) {
-        insertCount += 1
-        if (insertCount === 2) return Promise.reject(new Error('insert failed'))
-      }
-      return Promise.resolve({ rowsAffected: 0, lastInsertId: 0 })
-    })
+  it('sends a batch template save as one atomic command', async () => {
+    const { saveUserPromptTemplates } = await import('@/lib/db')
 
+    await saveUserPromptTemplates([makeTemplate('a'), makeTemplate('b')])
+
+    expect(coreMock.invoke).toHaveBeenCalledTimes(1)
+    const [command, payload] = coreMock.invoke.mock.calls[0] as [string, BatchPayload]
+    expect(command).toBe('db_execute_batch')
+    expect(payload.immediate).toBe(false)
+    expect(payload.statements).toHaveLength(2)
+    expect(payload.statements[0]?.params[0]).toBe('a')
+    expect(payload.statements[1]?.params[0]).toBe('b')
+    // Nothing reaches the plugin pool, so there is no split-connection transaction.
+    expect(sqlMock.execute).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_prompt_templates'),
+      expect.anything()
+    )
+  })
+
+  it('surfaces a failed batch and issues no JS-side rollback', async () => {
+    coreMock.invoke.mockRejectedValueOnce(new Error('Batch statement failed: insert failed'))
     const { saveUserPromptTemplates } = await import('@/lib/db')
 
     await expect(saveUserPromptTemplates([makeTemplate('a'), makeTemplate('b')])).rejects.toThrow(
@@ -61,8 +80,30 @@ describe('prompt template DB helpers', () => {
     )
 
     const statements = sqlMock.execute.mock.calls.map(([sql]) => sql)
-    expect(statements).toContain('BEGIN TRANSACTION')
-    expect(statements).toContain('ROLLBACK')
+    expect(statements).not.toContain('BEGIN TRANSACTION')
+    expect(statements).not.toContain('ROLLBACK')
     expect(statements).not.toContain('COMMIT')
+  })
+
+  it('seeds builtin templates through the same atomic batch path', async () => {
+    const { seedBuiltinPromptTemplates } = await import('@/lib/db')
+
+    await seedBuiltinPromptTemplates([makeTemplate('a')])
+
+    const [command, payload] = coreMock.invoke.mock.calls[0] as [string, BatchPayload]
+    expect(command).toBe('db_execute_batch')
+    expect(payload.statements[0]?.sql).toContain("author = 'builtin'")
+  })
+
+  it('still writes a single template through the plugin connection', async () => {
+    const { saveUserPromptTemplate } = await import('@/lib/db')
+
+    await saveUserPromptTemplate(makeTemplate('a'))
+
+    expect(coreMock.invoke).not.toHaveBeenCalled()
+    expect(sqlMock.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_prompt_templates'),
+      expect.arrayContaining(['a'])
+    )
   })
 })

--- a/apps/cockpit/src/lib/__tests__/file-io.test.ts
+++ b/apps/cockpit/src/lib/__tests__/file-io.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { open, save } from '@tauri-apps/plugin-dialog'
-import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs'
+import { readTextFile, writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
 import {
-  isLikelyBinaryText,
+  buildExportFilename,
+  exportFile,
   filenameFromPath,
+  isLikelyBinaryText,
   openFileDialog,
   readSupportedTextFile,
+  sanitizeExportBasename,
   saveFileDialog,
 } from '@/lib/file-io'
 
@@ -17,6 +20,7 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
 vi.mock('@tauri-apps/plugin-fs', () => ({
   readTextFile: vi.fn(),
   writeTextFile: vi.fn(),
+  writeFile: vi.fn(),
 }))
 
 describe('file I/O', () => {
@@ -24,6 +28,7 @@ describe('file I/O', () => {
     vi.clearAllMocks()
     vi.mocked(readTextFile).mockResolvedValue('hello')
     vi.mocked(writeTextFile).mockResolvedValue()
+    vi.mocked(writeFile).mockResolvedValue()
   })
 
   it('returns null without reading when open is cancelled', async () => {
@@ -84,5 +89,60 @@ describe('file I/O', () => {
     vi.mocked(writeTextFile).mockRejectedValue(new Error('disk full'))
 
     await expect(saveFileDialog('content')).rejects.toThrow('disk full')
+  })
+
+  describe('sanitizeExportBasename / buildExportFilename', () => {
+    it('replaces filesystem-illegal characters with underscores', () => {
+      expect(sanitizeExportBasename('my/weird:name?')).toBe('my_weird_name_')
+    })
+
+    it('falls back to a generic name when nothing usable remains', () => {
+      expect(sanitizeExportBasename('///')).toBe('export')
+    })
+
+    it('joins a sanitized base with an extension', () => {
+      expect(buildExportFilename('my snippet!', 'ts')).toBe('my_snippet_.ts')
+    })
+
+    it('strips a leading dot from the extension', () => {
+      expect(buildExportFilename('name', '.svg')).toBe('name.svg')
+    })
+  })
+
+  describe('exportFile', () => {
+    it('returns null without writing when the save dialog is cancelled', async () => {
+      vi.mocked(save).mockResolvedValue(null)
+
+      await expect(exportFile('content', 'file.txt')).resolves.toBeNull()
+      expect(writeTextFile).not.toHaveBeenCalled()
+      expect(writeFile).not.toHaveBeenCalled()
+    })
+
+    it('writes text content through writeTextFile and returns the path', async () => {
+      vi.mocked(save).mockResolvedValue('/tmp/file.txt')
+
+      await expect(exportFile('hello world', 'file.txt')).resolves.toBe('/tmp/file.txt')
+      expect(writeTextFile).toHaveBeenCalledWith('/tmp/file.txt', 'hello world')
+      expect(writeFile).not.toHaveBeenCalled()
+    })
+
+    it('writes blob content through writeFile as bytes', async () => {
+      vi.mocked(save).mockResolvedValue('/tmp/image.png')
+      const blob = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+
+      await expect(exportFile(blob, 'image.png')).resolves.toBe('/tmp/image.png')
+      expect(writeFile).toHaveBeenCalledTimes(1)
+      const [path, bytes] = vi.mocked(writeFile).mock.calls[0] as [string, Uint8Array]
+      expect(path).toBe('/tmp/image.png')
+      expect(Array.from(bytes)).toEqual([1, 2, 3])
+      expect(writeTextFile).not.toHaveBeenCalled()
+    })
+
+    it('propagates write failures for user feedback', async () => {
+      vi.mocked(save).mockResolvedValue('/tmp/file.txt')
+      vi.mocked(writeTextFile).mockRejectedValue(new Error('disk full'))
+
+      await expect(exportFile('content', 'file.txt')).rejects.toThrow('disk full')
+    })
   })
 })

--- a/apps/cockpit/src/lib/__tests__/markdown.test.ts
+++ b/apps/cockpit/src/lib/__tests__/markdown.test.ts
@@ -27,6 +27,15 @@ describe('processMarkdown', () => {
     expect(html).toContain('checked')
   })
 
+  it('keeps syntax highlighting classes on fenced code', async () => {
+    // `defaultSchema` restricts `code` className to `language-*`, which would strip the
+    // `hljs-*` classes rehype-highlight emits. The schema re-allows className on `code`
+    // and `span` specifically to prevent that; this pins it.
+    const html = await processMarkdown('```js\nconst a = 1\n```\n')
+    expect(html).toContain('hljs')
+    expect(html).toContain('<span class="hljs-keyword">const</span>')
+  })
+
   it('strips javascript: hrefs', async () => {
     const html = await processMarkdown('[click](javascript:alert(1))')
     expect(html).not.toContain('javascript:')

--- a/apps/cockpit/src/lib/__tests__/markdown.test.ts
+++ b/apps/cockpit/src/lib/__tests__/markdown.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { processMarkdown } from '@/lib/markdown'
+
+describe('processMarkdown', () => {
+  it('renders GFM tables', async () => {
+    const html = await processMarkdown('| A | B |\n| --- | --- |\n| 1 | 2 |\n')
+    expect(html).toContain('<table>')
+    expect(html).toContain('<th>A</th>')
+    expect(html).toContain('<td>1</td>')
+  })
+
+  it('renders images', async () => {
+    const html = await processMarkdown('![alt text](https://example.com/img.png)')
+    expect(html).toContain('<img')
+    expect(html).toContain('src="https://example.com/img.png"')
+    expect(html).toContain('alt="alt text"')
+  })
+
+  it('renders strikethrough', async () => {
+    const html = await processMarkdown('~~strike~~')
+    expect(html).toContain('<del>strike</del>')
+  })
+
+  it('renders task list checkboxes', async () => {
+    const html = await processMarkdown('- [ ] todo\n- [x] done\n')
+    expect(html).toContain('type="checkbox"')
+    expect(html).toContain('checked')
+  })
+
+  it('strips javascript: hrefs', async () => {
+    const html = await processMarkdown('[click](javascript:alert(1))')
+    expect(html).not.toContain('javascript:')
+  })
+
+  it('strips data: hrefs', async () => {
+    const html = await processMarkdown('[click](data:text/html,<script>alert(1)</script>)')
+    expect(html).not.toContain('data:text/html')
+  })
+
+  it('keeps https: hrefs', async () => {
+    const html = await processMarkdown('[click](https://example.com)')
+    expect(html).toContain('href="https://example.com"')
+  })
+})

--- a/apps/cockpit/src/lib/db.ts
+++ b/apps/cockpit/src/lib/db.ts
@@ -1,4 +1,5 @@
 import Database from '@tauri-apps/plugin-sql'
+import { invoke } from '@tauri-apps/api/core'
 import type {
   Note,
   Snippet,
@@ -46,24 +47,29 @@ function enqueueWrite<T>(operation: (conn: Database) => Promise<T>): Promise<T> 
   return run
 }
 
-function runTransaction<T>(
-  mode: 'TRANSACTION' | 'IMMEDIATE',
-  operation: (conn: Database) => Promise<T>
-): Promise<T> {
-  return enqueueWrite(async (conn) => {
-    await conn.execute(mode === 'IMMEDIATE' ? 'BEGIN IMMEDIATE' : 'BEGIN TRANSACTION')
-    try {
-      const result = await operation(conn)
-      await conn.execute('COMMIT')
-      return result
-    } catch (err) {
-      try {
-        await conn.execute('ROLLBACK')
-      } catch (rollbackErr) {
-        console.warn('[db] transaction rollback failed', rollbackErr)
-      }
-      throw err
-    }
+/** A parameterised statement destined for the atomic batch command. */
+export type BatchStatement = { sql: string; params: unknown[] }
+
+/**
+ * Runs a group of statements atomically.
+ *
+ * These cannot be driven from JS with `BEGIN` / `COMMIT` through
+ * `@tauri-apps/plugin-sql`: the plugin executes every statement via `pool.execute(...)`
+ * on a multi-connection pool, so the statements of a "transaction" can land on different
+ * connections — auto-committing individually, erroring on `COMMIT`, or stranding an open
+ * transaction on a pooled connection. The `db_execute_batch` Tauri command owns a
+ * dedicated single-connection pool and wraps the batch in a real sqlx transaction.
+ * See ADR-013 in documentation/infrastructure/ARCHITECTURE_DECISIONS.md.
+ *
+ * Still routed through `writeQueue` so batches stay ordered against single-statement
+ * writes going through the plugin pool.
+ */
+function runBatch(statements: BatchStatement[], immediate = false): Promise<void> {
+  if (statements.length === 0) return Promise.resolve()
+  // enqueueWrite awaits getDb() first, which guarantees the plugin has opened the
+  // database and applied migrations before the Rust pool touches the same file.
+  return enqueueWrite(async () => {
+    await invoke('db_execute_batch', { statements, immediate })
   })
 }
 
@@ -183,14 +189,13 @@ export async function saveNote(note: Note): Promise<void> {
 
 export async function saveNotesOrder(notes: Pick<Note, 'id' | 'sortOrder'>[]): Promise<void> {
   if (notes.length === 0) return
-  await runTransaction('IMMEDIATE', async (conn) => {
-    for (const note of notes) {
-      await conn.execute('UPDATE notes SET sort_order = $1 WHERE id = $2', [
-        note.sortOrder,
-        note.id,
-      ])
-    }
-  })
+  await runBatch(
+    notes.map((note) => ({
+      sql: 'UPDATE notes SET sort_order = $1 WHERE id = $2',
+      params: [note.sortOrder, note.id],
+    })),
+    true
+  )
 }
 
 export async function deleteNote(id: string): Promise<void> {
@@ -287,18 +292,15 @@ export async function loadUserPromptTemplates(): Promise<PromptTemplate[]> {
     .filter((template): template is PromptTemplate => template !== null)
 }
 
-async function executeSaveUserPromptTemplate(
-  conn: Database,
-  template: PromptTemplate
-): Promise<void> {
-  await conn.execute(
-    `INSERT INTO user_prompt_templates
+function buildSaveUserPromptTemplate(template: PromptTemplate): BatchStatement {
+  return {
+    sql: `INSERT INTO user_prompt_templates
       (id, name, description, category, tags, prompt, variables_schema, estimated_tokens, optimized_for, author, version, tips, created_at, updated_at)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
      ON CONFLICT(id) DO UPDATE SET
       name=$2, description=$3, category=$4, tags=$5, prompt=$6, variables_schema=$7,
       estimated_tokens=$8, optimized_for=$9, author=$10, version=$11, tips=$12, updated_at=$14`,
-    [
+    params: [
       template.id,
       template.name,
       template.description,
@@ -313,23 +315,20 @@ async function executeSaveUserPromptTemplate(
       JSON.stringify(template.tips ?? []),
       template.createdAt ?? Date.now(),
       template.updatedAt ?? Date.now(),
-    ]
-  )
+    ],
+  }
 }
 
-async function executeSeedBuiltinPromptTemplate(
-  conn: Database,
-  template: PromptTemplate
-): Promise<void> {
-  await conn.execute(
-    `INSERT INTO user_prompt_templates
+function buildSeedBuiltinPromptTemplate(template: PromptTemplate): BatchStatement {
+  return {
+    sql: `INSERT INTO user_prompt_templates
       (id, name, description, category, tags, prompt, variables_schema, estimated_tokens, optimized_for, author, version, tips, created_at, updated_at)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'builtin', $10, $11, $12, $13)
      ON CONFLICT(id) DO UPDATE SET
       name=$2, description=$3, category=$4, tags=$5, prompt=$6, variables_schema=$7,
       estimated_tokens=$8, optimized_for=$9, author='builtin', version=$10, tips=$11, updated_at=$13
      WHERE author = 'builtin'`,
-    [
+    params: [
       template.id,
       template.name,
       template.description,
@@ -343,21 +342,17 @@ async function executeSeedBuiltinPromptTemplate(
       JSON.stringify(template.tips ?? []),
       template.createdAt ?? Date.now(),
       template.updatedAt ?? Date.now(),
-    ]
-  )
+    ],
+  }
 }
 
 export async function saveUserPromptTemplate(template: PromptTemplate): Promise<void> {
-  await enqueueWrite((conn) => executeSaveUserPromptTemplate(conn, template))
+  const statement = buildSaveUserPromptTemplate(template)
+  await enqueueWrite((conn) => conn.execute(statement.sql, statement.params))
 }
 
 export async function saveUserPromptTemplates(templates: PromptTemplate[]): Promise<void> {
-  if (templates.length === 0) return
-  await runTransaction('TRANSACTION', async (conn) => {
-    for (const template of templates) {
-      await executeSaveUserPromptTemplate(conn, template)
-    }
-  })
+  await runBatch(templates.map(buildSaveUserPromptTemplate))
 }
 
 export async function deleteUserPromptTemplate(id: string): Promise<void> {
@@ -367,12 +362,7 @@ export async function deleteUserPromptTemplate(id: string): Promise<void> {
 }
 
 export async function seedBuiltinPromptTemplates(templates: PromptTemplate[]): Promise<void> {
-  if (templates.length === 0) return
-  await runTransaction('TRANSACTION', async (conn) => {
-    for (const template of templates) {
-      await executeSeedBuiltinPromptTemplate(conn, template)
-    }
-  })
+  await runBatch(templates.map(buildSeedBuiltinPromptTemplate))
 }
 
 // --- History ---
@@ -517,24 +507,18 @@ export async function loadApiCollections(): Promise<ApiCollection[]> {
     .filter((x): x is ApiCollection => x !== null)
 }
 
-export async function saveApiCollection(col: ApiCollection): Promise<void> {
-  await enqueueWrite((conn) =>
-    conn.execute(
-      `INSERT INTO api_collections (id, name, created_at, updated_at)
+function buildSaveApiCollection(col: ApiCollection): BatchStatement {
+  return {
+    sql: `INSERT INTO api_collections (id, name, created_at, updated_at)
        VALUES ($1, $2, $3, $4)
        ON CONFLICT(id) DO UPDATE SET name=$2, updated_at=$4`,
-      [col.id, col.name, col.createdAt, col.updatedAt]
-    )
-  )
+    params: [col.id, col.name, col.createdAt, col.updatedAt],
+  }
 }
 
-async function executeSaveApiCollection(conn: Database, col: ApiCollection): Promise<void> {
-  await conn.execute(
-    `INSERT INTO api_collections (id, name, created_at, updated_at)
-     VALUES ($1, $2, $3, $4)
-     ON CONFLICT(id) DO UPDATE SET name=$2, updated_at=$4`,
-    [col.id, col.name, col.createdAt, col.updatedAt]
-  )
+export async function saveApiCollection(col: ApiCollection): Promise<void> {
+  const statement = buildSaveApiCollection(col)
+  await enqueueWrite((conn) => conn.execute(statement.sql, statement.params))
 }
 
 export async function deleteApiCollection(id: string): Promise<void> {
@@ -558,35 +542,12 @@ export async function loadApiRequests(): Promise<ApiRequest[]> {
     .filter((x): x is ApiRequest => x !== null)
 }
 
-export async function saveApiRequest(req: ApiRequest): Promise<void> {
-  await enqueueWrite((conn) =>
-    conn.execute(
-      `INSERT INTO api_requests (id, collection_id, name, method, url, headers, body, body_mode, auth, created_at, updated_at)
+function buildSaveApiRequest(req: ApiRequest): BatchStatement {
+  return {
+    sql: `INSERT INTO api_requests (id, collection_id, name, method, url, headers, body, body_mode, auth, created_at, updated_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        ON CONFLICT(id) DO UPDATE SET collection_id=$2, name=$3, method=$4, url=$5, headers=$6, body=$7, body_mode=$8, auth=$9, updated_at=$11`,
-      [
-        req.id,
-        req.collectionId,
-        req.name,
-        req.method,
-        req.url,
-        JSON.stringify(req.headers),
-        req.body,
-        req.bodyMode,
-        JSON.stringify(req.auth),
-        req.createdAt,
-        req.updatedAt,
-      ]
-    )
-  )
-}
-
-async function executeSaveApiRequest(conn: Database, req: ApiRequest): Promise<void> {
-  await conn.execute(
-    `INSERT INTO api_requests (id, collection_id, name, method, url, headers, body, body_mode, auth, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-     ON CONFLICT(id) DO UPDATE SET collection_id=$2, name=$3, method=$4, url=$5, headers=$6, body=$7, body_mode=$8, auth=$9, updated_at=$11`,
-    [
+    params: [
       req.id,
       req.collectionId,
       req.name,
@@ -598,23 +559,21 @@ async function executeSaveApiRequest(conn: Database, req: ApiRequest): Promise<v
       JSON.stringify(req.auth),
       req.createdAt,
       req.updatedAt,
-    ]
-  )
+    ],
+  }
+}
+
+export async function saveApiRequest(req: ApiRequest): Promise<void> {
+  const statement = buildSaveApiRequest(req)
+  await enqueueWrite((conn) => conn.execute(statement.sql, statement.params))
 }
 
 export async function saveApiImport(
   collections: ApiCollection[],
   requests: ApiRequest[]
 ): Promise<void> {
-  if (collections.length === 0 && requests.length === 0) return
-  await runTransaction('TRANSACTION', async (conn) => {
-    for (const collection of collections) {
-      await executeSaveApiCollection(conn, collection)
-    }
-    for (const request of requests) {
-      await executeSaveApiRequest(conn, request)
-    }
-  })
+  // Collections first: api_requests.collection_id references them.
+  await runBatch([...collections.map(buildSaveApiCollection), ...requests.map(buildSaveApiRequest)])
 }
 
 export async function deleteApiRequest(id: string): Promise<void> {

--- a/apps/cockpit/src/lib/file-io.ts
+++ b/apps/cockpit/src/lib/file-io.ts
@@ -1,5 +1,5 @@
 import { open, save } from '@tauri-apps/plugin-dialog'
-import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs'
+import { readTextFile, writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
 
 export function isLikelyBinaryText(content: string): boolean {
   if (content.includes('\0')) return true
@@ -79,5 +79,40 @@ export async function saveFileDialog(
   })
   if (!path) return null
   await writeTextFile(path, content)
+  return path
+}
+
+/**
+ * Sanitizes a user-provided base filename (no extension) so it is safe to use
+ * across platforms — strips path separators and other filesystem-illegal
+ * characters, falling back to a generic name if nothing usable remains.
+ */
+export function sanitizeExportBasename(name: string): string {
+  const cleaned = name.trim().replace(/[^a-zA-Z0-9_.-]/g, '_')
+  return /[a-zA-Z0-9]/.test(cleaned) ? cleaned : 'export'
+}
+
+/** Builds a sanitized `<basename>.<extension>` filename for exports. */
+export function buildExportFilename(base: string, extension: string): string {
+  return `${sanitizeExportBasename(base)}.${extension.replace(/^\./, '')}`
+}
+
+/**
+ * Shared export helper for tool "download" actions. Opens the native save
+ * dialog (same mechanism as the global save shortcut) and writes either text
+ * or binary (Blob) content to the chosen path — no detached `<a download>`
+ * anchors or `URL.createObjectURL`/`revokeObjectURL` calls required.
+ *
+ * Returns the saved path, or `null` if the user cancelled the dialog.
+ */
+export async function exportFile(data: string | Blob, defaultName: string): Promise<string | null> {
+  const path = await save({ defaultPath: defaultName })
+  if (!path) return null
+  if (typeof data === 'string') {
+    await writeTextFile(path, data)
+  } else {
+    const bytes = new Uint8Array(await data.arrayBuffer())
+    await writeFile(path, bytes)
+  }
   return path
 }

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -1,42 +1,36 @@
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
 import remarkRehype from 'remark-rehype'
-import rehypeSanitize from 'rehype-sanitize'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
 import rehypeHighlight from 'rehype-highlight'
+
+/**
+ * Shared sanitize schema for all markdown rendering surfaces (Notes drawer,
+ * Markdown Editor). Extends rehype-sanitize's `defaultSchema` rather than
+ * replacing it, so GFM tables/images/task-list checkboxes survive while
+ * `javascript:`/`data:` hrefs are still stripped by the defaults.
+ */
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes?.['a'] ?? []), 'target', 'rel'],
+    code: [...(defaultSchema.attributes?.['code'] ?? []), 'className'],
+    span: [...(defaultSchema.attributes?.['span'] ?? []), 'className'],
+    input: [...(defaultSchema.attributes?.['input'] ?? []), 'type', 'checked', 'disabled'],
+  },
+  tagNames: [...(defaultSchema.tagNames ?? []), 'input'],
+}
 
 export async function processMarkdown(content: string): Promise<string> {
   const file = await unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeHighlight)
-    .use(rehypeSanitize, {
-      tagNames: [
-        'span',
-        'pre',
-        'code',
-        'p',
-        'ul',
-        'ol',
-        'li',
-        'strong',
-        'em',
-        'blockquote',
-        'a',
-        'h1',
-        'h2',
-        'h3',
-        'h4',
-        'h5',
-        'h6',
-        'br',
-        'hr',
-      ],
-      attributes: {
-        '*': ['className', 'class'],
-        a: ['href', 'target', 'rel'],
-      },
-    })
+    .use(rehypeSanitize, markdownSanitizeSchema)
     .use(rehypeStringify)
     .process(content)
 

--- a/apps/cockpit/src/stores/__tests__/settings.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/settings.store.test.ts
@@ -63,6 +63,20 @@ describe('settings store initialization', () => {
 
     expect(getSetting).toHaveBeenCalledOnce()
   })
+
+  it('init() clears the cached promise on rejection so a later call retries', async () => {
+    const { useSettingsStore } = await import('../settings.store')
+    useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: false })
+    ;(getSetting as any).mockRejectedValueOnce(new Error('db locked'))
+
+    await expect(useSettingsStore.getState().init()).rejects.toThrow('db locked')
+    expect(useSettingsStore.getState().initialized).toBe(false)
+    ;(getSetting as any).mockResolvedValueOnce({ editorFontSize: 16 })
+    await useSettingsStore.getState().init()
+
+    expect(useSettingsStore.getState().initialized).toBe(true)
+    expect(getSetting).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('settings store updates', () => {

--- a/apps/cockpit/src/stores/api.store.ts
+++ b/apps/cockpit/src/stores/api.store.ts
@@ -73,7 +73,12 @@ export const useApiStore = create<ApiStore>((set) => ({
           // Could restore this from settings later
           activeEnvironmentId: envs[0]?.id ?? null,
         })
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a later call retries
+        // instead of latching a transient error for the process lifetime.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/history.store.ts
+++ b/apps/cockpit/src/stores/history.store.ts
@@ -35,7 +35,12 @@ export const useHistoryStore = create<HistoryStore>()((set) => ({
       initPromise = (async () => {
         const entries = await loadHistory(undefined, 200)
         set({ entries, initialized: true })
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a later call retries
+        // instead of latching a transient error for the process lifetime.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/mcp.store.ts
+++ b/apps/cockpit/src/stores/mcp.store.ts
@@ -155,7 +155,13 @@ export const useMcpStore = create<McpStore>()((set, get) => ({
           })
           useUiStore.getState().addToast('Failed to initialize MCP server: ' + msg, 'error')
         }
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a transient error doesn't
+        // latch the app in a broken state for the rest of the process
+        // lifetime — a later init() call retries.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/notes.store.ts
+++ b/apps/cockpit/src/stores/notes.store.ts
@@ -44,7 +44,12 @@ export const useNotesStore = create<NotesStore>()((set, get) => ({
       initPromise = (async () => {
         const notes = await loadNotes()
         set({ notes, initialized: true })
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a later call retries
+        // instead of latching a transient error for the process lifetime.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/prompt-templates.store.ts
+++ b/apps/cockpit/src/stores/prompt-templates.store.ts
@@ -75,7 +75,12 @@ export const usePromptTemplatesStore = create<PromptTemplatesStore>()((set, get)
         await seedBuiltinPromptTemplates(BUILTIN_PROMPT_TEMPLATES)
         const userTemplates = await loadUserPromptTemplates()
         set({ userTemplates, initialized: true })
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a later call retries
+        // instead of latching a transient error for the process lifetime.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/settings.store.ts
+++ b/apps/cockpit/src/stores/settings.store.ts
@@ -27,7 +27,13 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => ({
         if (merged.editorKeybindingMode !== 'standard') merged.editorKeybindingMode = 'standard'
         set({ ...merged, initialized: true })
         applyTheme(merged.theme)
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a transient error (e.g. a
+        // locked database at launch) doesn't latch the app in a broken state
+        // for the rest of the process lifetime — a later init() call retries.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/snippets.store.ts
+++ b/apps/cockpit/src/stores/snippets.store.ts
@@ -42,7 +42,12 @@ export const useSnippetsStore = create<SnippetsStore>()((set, get) => ({
       initPromise = (async () => {
         const snippets = await loadSnippets()
         set({ snippets, initialized: true })
-      })()
+      })().catch((err: unknown) => {
+        // Clear the cached promise on failure so a later call retries
+        // instead of latching a transient error for the process lifetime.
+        initPromise = null
+        throw err
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/image-tool.test.tsx
@@ -1,8 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import ImageTool from '../image-tool/ImageTool'
 import { useUiStore } from '@/stores/ui.store'
+import { exportFile } from '@/lib/file-io'
+
+vi.mock('@/lib/file-io', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/file-io')>('@/lib/file-io')
+  return { ...actual, exportFile: vi.fn() }
+})
 
 const originalFileReader = globalThis.FileReader
 const originalImage = globalThis.Image
@@ -140,6 +146,11 @@ async function loadMockImage() {
   await waitFor(() => expect(screen.getByText('sample.png')).toBeInTheDocument())
   return preview
 }
+
+beforeEach(() => {
+  vi.mocked(exportFile).mockReset()
+  useUiStore.setState({ lastAction: null })
+})
 
 afterEach(() => {
   restoreImageMocks()
@@ -305,10 +316,54 @@ describe('ImageTool', () => {
     fireEvent.click(screen.getByText('Export'))
     fireEvent.click(screen.getByRole('button', { name: /Download PNG/i }))
 
-    expect(useUiStore.getState().lastAction).toMatchObject({
-      message: 'Image export failed',
-      type: 'error',
-    })
+    await waitFor(() =>
+      expect(useUiStore.getState().lastAction).toMatchObject({
+        message: 'Image export failed',
+        type: 'error',
+      })
+    )
+  })
+
+  it('saves through exportFile and reports success', async () => {
+    vi.mocked(exportFile).mockResolvedValue('/tmp/sample.png')
+    await loadMockImage()
+    useUiStore.setState({ lastAction: null })
+
+    fireEvent.click(screen.getByText('Export'))
+    fireEvent.click(screen.getByRole('button', { name: /Download PNG/i }))
+
+    await waitFor(() => expect(useUiStore.getState().lastAction?.message).toMatch(/^Saved as PNG/))
+    expect(exportFile).toHaveBeenCalledTimes(1)
+    const [blob, filename] = vi.mocked(exportFile).mock.calls[0] as [Blob, string]
+    expect(blob).toBeInstanceOf(Blob)
+    expect(filename).toBe('sample.png')
+  })
+
+  it('does not report success when the save dialog is cancelled', async () => {
+    vi.mocked(exportFile).mockResolvedValue(null)
+    await loadMockImage()
+    useUiStore.setState({ lastAction: null })
+
+    fireEvent.click(screen.getByText('Export'))
+    fireEvent.click(screen.getByRole('button', { name: /Download PNG/i }))
+
+    await waitFor(() => expect(exportFile).toHaveBeenCalled())
+    expect(useUiStore.getState().lastAction).toBeNull()
+  })
+
+  it('reports a write failure from exportFile', async () => {
+    vi.mocked(exportFile).mockRejectedValue(new Error('disk full'))
+    await loadMockImage()
+
+    fireEvent.click(screen.getByText('Export'))
+    fireEvent.click(screen.getByRole('button', { name: /Download PNG/i }))
+
+    await waitFor(() =>
+      expect(useUiStore.getState().lastAction).toMatchObject({
+        message: 'Image export failed',
+        type: 'error',
+      })
+    )
   })
 
   // ── Drag over state ──────────────────────────────────────────────

--- a/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
@@ -10,7 +10,7 @@ describe('RegexTester (component)', () => {
     expect(screen.getByPlaceholderText(/enter text to test/i)).toBeInTheDocument()
   })
 
-  it('shows match count when pattern matches', () => {
+  it('shows match count when pattern matches', async () => {
     renderTool(RegexTester)
     fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), {
       target: { value: '\\d+' },
@@ -18,7 +18,7 @@ describe('RegexTester (component)', () => {
     fireEvent.change(screen.getByPlaceholderText(/enter text to test/i), {
       target: { value: 'abc 123 def 456' },
     })
-    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(await screen.findByText('2')).toBeInTheDocument()
   })
 
   it('exposes regex flag toggle pressed state', () => {
@@ -112,7 +112,7 @@ describe('RegexTester (component)', () => {
     expect(screen.getByText(/chars/i)).toBeInTheDocument()
   })
 
-  it('keeps unnamed capture groups when named groups are also present', () => {
+  it('keeps unnamed capture groups when named groups are also present', async () => {
     renderTool(RegexTester)
     fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), {
       target: { value: '([A-Z])(?<digits>\\d+)' },
@@ -121,13 +121,13 @@ describe('RegexTester (component)', () => {
       target: { value: 'A12' },
     })
 
-    expect(screen.getByText('$1')).toBeInTheDocument()
+    expect(await screen.findByText('$1')).toBeInTheDocument()
     expect(screen.getByText('digits')).toBeInTheDocument()
     expect(screen.getByText('A')).toBeInTheDocument()
     expect(screen.getByText('12')).toBeInTheDocument()
   })
 
-  it('warns when only the first 1000 matches are shown', () => {
+  it('warns when only the first 1000 matches are shown', async () => {
     renderTool(RegexTester)
     fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), {
       target: { value: '.' },
@@ -136,7 +136,7 @@ describe('RegexTester (component)', () => {
       target: { value: 'a'.repeat(1205) },
     })
 
-    expect(screen.getByText('1000+')).toBeInTheDocument()
+    expect(await screen.findByText('1000+')).toBeInTheDocument()
     expect(screen.getByText('Showing first 1000 matches')).toBeInTheDocument()
     expect(screen.getByText(/First 1000 matches/)).toBeInTheDocument()
   })

--- a/apps/cockpit/src/tools/__tests__/snippets.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/snippets.test.tsx
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import { useSnippetsStore } from '@/stores/snippets.store'
+import { useUiStore } from '@/stores/ui.store'
+import { exportFile } from '@/lib/file-io'
 import SnippetsManager from '../snippets/SnippetsManager'
+
+vi.mock('@/lib/file-io', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/file-io')>('@/lib/file-io')
+  return { ...actual, exportFile: vi.fn() }
+})
 
 describe('SnippetsManager', () => {
   it('renders search input and new button', () => {
@@ -439,5 +446,57 @@ describe('SnippetsManager — tag autocomplete', () => {
     expect(screen.getByTestId('tag-suggestions')).toBeInTheDocument()
     fireEvent.change(tagInput, { target: { value: '' } })
     expect(screen.queryByTestId('tag-suggestions')).not.toBeInTheDocument()
+  })
+
+  describe('download', () => {
+    beforeEach(() => {
+      vi.mocked(exportFile).mockReset()
+      useSnippetsStore.setState({
+        snippets: [
+          {
+            id: '1',
+            title: 'my snippet',
+            content: 'console.log("hi")',
+            language: 'javascript',
+            tags: [],
+            folder: '',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        ],
+        initialized: true,
+      })
+      useUiStore.setState({ lastAction: null })
+    })
+
+    it('saves through exportFile and reports success', async () => {
+      vi.mocked(exportFile).mockResolvedValue('/tmp/my_snippet.js')
+      renderTool(SnippetsManager)
+      fireEvent.click(screen.getByText('my snippet').closest('button')!)
+      fireEvent.click(screen.getByTitle('Download as file'))
+
+      await waitFor(() => expect(useUiStore.getState().lastAction?.message).toMatch(/Downloaded/))
+      expect(exportFile).toHaveBeenCalledWith('console.log("hi")', 'my_snippet.js')
+    })
+
+    it('reports cancellation without an error state', async () => {
+      vi.mocked(exportFile).mockResolvedValue(null)
+      renderTool(SnippetsManager)
+      fireEvent.click(screen.getByText('my snippet').closest('button')!)
+      fireEvent.click(screen.getByTitle('Download as file'))
+
+      await waitFor(() => expect(exportFile).toHaveBeenCalled())
+      expect(useUiStore.getState().lastAction).toBeNull()
+    })
+
+    it('reports a write failure', async () => {
+      vi.mocked(exportFile).mockRejectedValue(new Error('disk full'))
+      renderTool(SnippetsManager)
+      fireEvent.click(screen.getByText('my snippet').closest('button')!)
+      fireEvent.click(screen.getByTitle('Download as file'))
+
+      await waitFor(() => expect(useUiStore.getState().lastAction?.message).toBe('Download failed'))
+      expect(useUiStore.getState().lastAction?.type).toBe('error')
+    })
   })
 })

--- a/apps/cockpit/src/tools/__tests__/useToolState.test.ts
+++ b/apps/cockpit/src/tools/__tests__/useToolState.test.ts
@@ -204,6 +204,79 @@ describe('useToolState', () => {
     expect(saveToolState).toHaveBeenCalledTimes(1)
   })
 
+  it('edit during a pending load keeps the edit and drops the resolved load', async () => {
+    let resolveDb: (val: any) => void = () => {}
+    vi.mocked(loadToolState).mockReturnValue(
+      new Promise((resolve) => {
+        resolveDb = resolve
+      })
+    )
+
+    const { result } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    // User types while the SQLite read is still in flight
+    act(() => {
+      result.current[1]({ value: 'typed-while-loading' })
+    })
+
+    await act(async () => {
+      resolveDb({ value: 'stale-sqlite-data' })
+    })
+
+    expect(result.current[0]).toEqual({ value: 'typed-while-loading' })
+    expect(cacheStore[TOOL_ID]).toEqual({ value: 'typed-while-loading' })
+  })
+
+  it('unmount during a pending load still persists the edit', async () => {
+    vi.mocked(loadToolState).mockReturnValue(new Promise(() => {})) // never resolves
+
+    const { result, unmount } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    act(() => {
+      result.current[1]({ value: 'edited-before-load' })
+    })
+
+    act(() => {
+      unmount()
+    })
+
+    expect(saveToolState).toHaveBeenCalledWith(TOOL_ID, { value: 'edited-before-load' })
+  })
+
+  it('untouched cold path still restores saved state after the load resolves', async () => {
+    let resolveDb: (val: any) => void = () => {}
+    vi.mocked(loadToolState).mockReturnValue(
+      new Promise((resolve) => {
+        resolveDb = resolve
+      })
+    )
+
+    const { result, unmount } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+
+    await act(async () => {
+      resolveDb({ value: 'restored' })
+    })
+
+    expect(result.current[0]).toEqual({ value: 'restored' })
+    expect(cacheStore[TOOL_ID]).toEqual({ value: 'restored' })
+
+    act(() => {
+      unmount()
+    })
+    expect(saveToolState).toHaveBeenCalledWith(TOOL_ID, { value: 'restored' })
+  })
+
+  it('unmount without any edit or completed load does not write', () => {
+    vi.mocked(loadToolState).mockReturnValue(new Promise(() => {})) // never resolves
+
+    const { unmount } = renderHook(() => useToolState(TOOL_ID, DEFAULT_STATE))
+    act(() => {
+      unmount()
+    })
+
+    expect(saveToolState).not.toHaveBeenCalled()
+  })
+
   it('cancelled load: if component unmounts before SQLite load resolves, state is not updated', async () => {
     let resolveDb: (val: any) => void = () => {}
     vi.mocked(loadToolState).mockReturnValue(

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { useUiStore } from '@/stores/ui.store'
+import { buildExportFilename, exportFile } from '@/lib/file-io'
 import { Button } from '@/components/shared/Button'
 import { TabBar } from '@/components/shared/TabBar'
 import {
@@ -481,30 +482,24 @@ export default function ImageTool() {
 
   // ── Export ─────────────────────────────────────────────────────
 
-  const handleDownload = useCallback(() => {
+  const handleDownload = useCallback(async () => {
     const canvas = outputCanvasRef.current
     if (!canvas) return
     const mimeType =
       state.format === 'jpeg' ? 'image/jpeg' : state.format === 'webp' ? 'image/webp' : 'image/png'
     const ext = state.format
     try {
-      canvas.toBlob(
-        (blob) => {
-          if (!blob) {
-            setLastAction('Image export failed', 'error')
-            return
-          }
-          const url = URL.createObjectURL(blob)
-          const a = document.createElement('a')
-          a.href = url
-          a.download = `${fileName.replace(/\.[^.]+$/, '')}.${ext}`
-          a.click()
-          URL.revokeObjectURL(url)
-          setLastAction(`Saved as ${ext.toUpperCase()} (${formatBytes(blob.size)})`, 'success')
-        },
-        mimeType,
-        state.quality / 100
-      )
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob(resolve, mimeType, state.quality / 100)
+      })
+      if (!blob) {
+        setLastAction('Image export failed', 'error')
+        return
+      }
+      const filename = buildExportFilename(fileName.replace(/\.[^.]+$/, ''), ext)
+      const path = await exportFile(blob, filename)
+      if (path)
+        setLastAction(`Saved as ${ext.toUpperCase()} (${formatBytes(blob.size)})`, 'success')
     } catch {
       setLastAction('Image export failed', 'error')
     }

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/shared/Button'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { useToolAction } from '@/hooks/useToolAction'
-import { saveFileDialog } from '@/lib/file-io'
+import { exportFile, saveFileDialog } from '@/lib/file-io'
 import { useDomSelectionToolbar } from '@/hooks/useDomSelectionToolbar'
 import { useMonacoSelectionToolbar } from '@/hooks/useMonacoSelectionToolbar'
 import { MarkdownPreview } from './MarkdownPreview'
@@ -37,7 +37,8 @@ import remarkGfm from 'remark-gfm'
 import remarkRehype from 'remark-rehype'
 import rehypeStringify from 'rehype-stringify'
 import rehypeHighlight from 'rehype-highlight'
-import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import rehypeSanitize from 'rehype-sanitize'
+import { markdownSanitizeSchema } from '@/lib/markdown'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -403,23 +404,11 @@ const PRINT_STYLES = '@media print{body{margin:0}}' + BASE_EXPORT_STYLES
 
 // ─── Processor ───────────────────────────────────────────────────────
 
-const sanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    a: [...(defaultSchema.attributes?.['a'] ?? []), 'target', 'rel'],
-    code: [...(defaultSchema.attributes?.['code'] ?? []), 'className'],
-    span: [...(defaultSchema.attributes?.['span'] ?? []), 'className'],
-    input: [...(defaultSchema.attributes?.['input'] ?? []), 'type', 'checked', 'disabled'],
-  },
-  tagNames: [...(defaultSchema.tagNames ?? []), 'input'],
-}
-
 const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkRehype, { allowDangerousHtml: false })
-  .use(rehypeSanitize, sanitizeSchema)
+  .use(rehypeSanitize, markdownSanitizeSchema)
   .use(rehypeHighlight, { detect: true })
   .use(rehypeStringify)
 
@@ -755,16 +744,12 @@ export default function MarkdownEditor() {
     async (format: 'md' | 'html') => {
       const content =
         format === 'md' ? state.content : await buildCurrentExportHtml(BASE_EXPORT_STYLES)
-      const blob = new Blob([content], {
-        type: format === 'md' ? 'text/markdown' : 'text/html',
-      })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `document.${format}`
-      a.click()
-      URL.revokeObjectURL(url)
-      setLastAction(`Downloaded as .${format}`, 'success')
+      try {
+        const path = await exportFile(content, `document.${format}`)
+        if (path) setLastAction(`Downloaded as .${format}`, 'success')
+      } catch {
+        setLastAction('Download failed', 'error')
+      }
       setShowExport(false)
     },
     [buildCurrentExportHtml, state.content, setLastAction]

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/shared/Button'
 import { useUiStore } from '@/stores/ui.store'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
+import { exportFile } from '@/lib/file-io'
 import { CaretDownIcon } from '@phosphor-icons/react'
 
 type MermaidEditorState = {
@@ -323,16 +324,14 @@ export default function MermaidEditor() {
     setShowExport(false)
   }, [svgHtml, setLastAction])
 
-  const handleDownloadSvg = useCallback(() => {
+  const handleDownloadSvg = useCallback(async () => {
     if (!svgHtml) return
-    const blob = new Blob([svgHtml], { type: 'image/svg+xml' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'diagram.svg'
-    a.click()
-    URL.revokeObjectURL(url)
-    setLastAction('SVG downloaded', 'success')
+    try {
+      const path = await exportFile(svgHtml, 'diagram.svg')
+      if (path) setLastAction('SVG downloaded', 'success')
+    } catch {
+      setLastAction('Export failed', 'error')
+    }
     setShowExport(false)
   }, [svgHtml, setLastAction])
 
@@ -380,13 +379,8 @@ export default function MermaidEditor() {
   const handleDownloadPng = useCallback(async () => {
     try {
       const blob = await renderPngBlob(exportScale)
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `diagram-${exportScale}x.png`
-      a.click()
-      URL.revokeObjectURL(url)
-      setLastAction(`PNG (${exportScale}×) downloaded`, 'success')
+      const path = await exportFile(blob, `diagram-${exportScale}x.png`)
+      if (path) setLastAction(`PNG (${exportScale}×) downloaded`, 'success')
     } catch {
       setLastAction('Export failed', 'error')
     }

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -5,19 +5,14 @@ import { CopyButton } from '@/components/shared/CopyButton'
 import { TabBar } from '@/components/shared/TabBar'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
+import { REGEX_TIMEOUT_MS, useRegexEvaluation } from '@/hooks/useRegexEvaluation'
+import { MAX_REGEX_MATCHES } from '@/workers/regex.api'
 
 type RegexTesterState = {
   pattern: string
   flags: string
   testString: string
   replacePattern: string
-}
-
-type Match = {
-  full: string
-  index: number
-  length: number
-  groups: Array<{ index: number; name: string | null; value: string }>
 }
 
 // ── Reference data ─────────────────────────────────────────────────
@@ -86,173 +81,7 @@ const MODE_TABS = [
   { id: 'replace', label: 'Replace' },
 ]
 
-const MAX_REGEX_MATCHES = 1000
-
-// ── Matching logic ─────────────────────────────────────────────────
-
-export function extractCaptureGroupNames(pattern: string): Array<string | null> {
-  const names: Array<string | null> = []
-  let inClass = false
-
-  for (let i = 0; i < pattern.length; i++) {
-    const char = pattern[i]
-    if (!char) break
-
-    if (char === '\\') {
-      i++
-      continue
-    }
-
-    if (char === '[') {
-      inClass = true
-      continue
-    }
-
-    if (char === ']' && inClass) {
-      inClass = false
-      continue
-    }
-
-    if (inClass || char !== '(') continue
-
-    const next = pattern[i + 1]
-    if (next !== '?') {
-      names.push(null)
-      continue
-    }
-
-    if (
-      pattern.startsWith('(?:', i) ||
-      pattern.startsWith('(?=', i) ||
-      pattern.startsWith('(?!', i)
-    ) {
-      continue
-    }
-
-    if (pattern.startsWith('(?<=', i) || pattern.startsWith('(?<!', i)) {
-      continue
-    }
-
-    if (pattern.startsWith('(?<', i)) {
-      const end = pattern.indexOf('>', i + 3)
-      if (end !== -1) {
-        names.push(pattern.slice(i + 3, end))
-      }
-    }
-  }
-
-  return names
-}
-
-function findMatches(
-  pattern: string,
-  flags: string,
-  text: string
-): { matches: Match[]; error: string | null; truncated: boolean } {
-  if (!pattern) return { matches: [], error: null, truncated: false }
-  try {
-    const re = new RegExp(pattern, flags)
-    const matches: Match[] = []
-    const captureGroupNames = extractCaptureGroupNames(pattern)
-
-    function buildGroups(m: RegExpExecArray): Match['groups'] {
-      const groups: Match['groups'] = []
-      for (let i = 1; i < m.length; i++) {
-        groups.push({
-          index: i,
-          name: captureGroupNames[i - 1] ?? null,
-          value: m[i] ?? '',
-        })
-      }
-      return groups
-    }
-
-    let truncated = false
-    if (flags.includes('g')) {
-      let m: RegExpExecArray | null
-      while ((m = re.exec(text)) !== null) {
-        if (matches.length >= MAX_REGEX_MATCHES) {
-          truncated = true
-          break
-        }
-        matches.push({ full: m[0], index: m.index, length: m[0].length, groups: buildGroups(m) })
-        if (m[0] === '') re.lastIndex++
-      }
-    } else {
-      const m = re.exec(text)
-      if (m) {
-        matches.push({ full: m[0], index: m.index, length: m[0].length, groups: buildGroups(m) })
-      }
-    }
-
-    return { matches, error: null, truncated }
-  } catch (e) {
-    return { matches: [], error: (e as Error).message, truncated: false }
-  }
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
-const MATCH_COLORS = [
-  { bg: 'var(--color-accent)', text: 'var(--color-bg)' },
-  { bg: 'var(--color-info)', text: 'var(--color-bg)' },
-]
-
-function highlightMatches(
-  text: string,
-  pattern: string,
-  flags: string
-): { html: string; truncated: boolean } {
-  if (!pattern || !text) return { html: '', truncated: false }
-  try {
-    const re = new RegExp(pattern, flags.includes('g') ? flags : flags + 'g')
-    const parts: string[] = []
-    let lastIndex = 0
-    let m: RegExpExecArray | null
-    let colorIdx = 0
-    let truncated = false
-    while ((m = re.exec(text)) !== null) {
-      if (colorIdx >= MAX_REGEX_MATCHES) {
-        truncated = true
-        break
-      }
-      parts.push(escapeHtml(text.slice(lastIndex, m.index)))
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const c = MATCH_COLORS[colorIdx % MATCH_COLORS.length]! // safe: modulo keeps index in bounds
-      parts.push(
-        `<mark style="background:${c.bg};color:${c.text};border-radius:2px;padding:0 2px">${escapeHtml(m[0])}</mark>`
-      )
-      colorIdx++
-      lastIndex = m.index + m[0].length
-      if (m[0] === '') re.lastIndex++
-    }
-    parts.push(escapeHtml(text.slice(lastIndex)))
-    return { html: parts.join(''), truncated }
-  } catch {
-    return { html: escapeHtml(text), truncated: false }
-  }
-}
-
-function computeReplace(
-  text: string,
-  pattern: string,
-  flags: string,
-  replacement: string
-): { result: string; error: string | null } {
-  if (!pattern || !text) return { result: text, error: null }
-  try {
-    const re = new RegExp(pattern, flags)
-    return { result: text.replace(re, replacement), error: null }
-  } catch (e) {
-    return { result: text, error: (e as Error).message }
-  }
-}
+const TIMEOUT_MESSAGE = `Pattern timed out after ${REGEX_TIMEOUT_MS}ms — likely catastrophic backtracking. Edit the pattern or the test string to retry.`
 
 // ── Component ──────────────────────────────────────────────────────
 
@@ -269,27 +98,30 @@ export default function RegexTester() {
   const [showDiff, setShowDiff] = useState(false)
   const patternRef = useRef<HTMLInputElement>(null)
 
-  const result = useMemo(
-    () => findMatches(state.pattern, state.flags, state.testString),
-    [state.pattern, state.flags, state.testString]
-  )
+  // Evaluation runs in a terminable worker — a user pattern must never touch this thread.
+  const evaluation = useRegexEvaluation({
+    pattern: state.pattern,
+    flags: state.flags,
+    text: state.testString,
+    replacement: state.replacePattern,
+  })
 
-  const highlighted = useMemo(
-    () => highlightMatches(state.testString, state.pattern, state.flags),
-    [state.testString, state.pattern, state.flags]
-  )
-
-  const replaceResult = useMemo(
-    () => computeReplace(state.testString, state.pattern, state.flags, state.replacePattern),
-    [state.testString, state.pattern, state.flags, state.replacePattern]
-  )
+  const timedOut = evaluation.status === 'timeout'
+  const evaluated = evaluation.result
+  // Memoised so the `?? []` fallback does not produce a new array identity on every
+  // render and invalidate the copy callback below.
+  const matches = useMemo(() => evaluated?.matches ?? [], [evaluated])
+  const truncated = evaluated?.truncated ?? false
+  const matchError = timedOut ? TIMEOUT_MESSAGE : (evaluated?.matchError ?? null)
+  const replaceValue = evaluated?.replaceResult ?? state.testString
+  const replaceError = timedOut ? TIMEOUT_MESSAGE : (evaluated?.replaceError ?? null)
 
   // Character-level diff between source and substituted text (only computed when needed)
   const charDiff = useMemo(() => {
     if (!showDiff || mode !== 'replace') return null
-    if (replaceResult.error || !state.pattern || !state.testString) return null
-    return diffChars(state.testString, replaceResult.result)
-  }, [showDiff, mode, replaceResult.result, replaceResult.error, state.pattern, state.testString])
+    if (replaceError || !state.pattern || !state.testString) return null
+    return diffChars(state.testString, replaceValue)
+  }, [showDiff, mode, replaceValue, replaceError, state.pattern, state.testString])
 
   const diffStats = useMemo(() => {
     if (!charDiff) return null
@@ -335,11 +167,11 @@ export default function RegexTester() {
 
   const exportMatches = useCallback(
     async (format: 'lines' | 'json') => {
-      if (result.matches.length === 0) return
+      if (matches.length === 0) return
       const text =
         format === 'json'
           ? JSON.stringify(
-              result.matches.map((m) => ({
+              matches.map((m) => ({
                 match: m.full,
                 index: m.index,
                 length: m.length,
@@ -348,22 +180,22 @@ export default function RegexTester() {
               null,
               2
             )
-          : result.matches.map((m) => m.full).join('\n')
+          : matches.map((m) => m.full).join('\n')
       try {
         await navigator.clipboard.writeText(text)
         setLastAction(
-          `Copied ${result.truncated ? `first ${result.matches.length}` : result.matches.length} match${result.matches.length !== 1 ? 'es' : ''} as ${format === 'json' ? 'JSON' : 'lines'}`,
+          `Copied ${truncated ? `first ${matches.length}` : matches.length} match${matches.length !== 1 ? 'es' : ''} as ${format === 'json' ? 'JSON' : 'lines'}`,
           'success'
         )
       } catch {
         setLastAction('Failed to copy', 'error')
       }
     },
-    [result.matches, result.truncated, setLastAction]
+    [matches, truncated, setLastAction]
   )
 
-  const matchCount = result.matches.length
-  const hasGroups = result.matches.some((m) => m.groups.length > 0)
+  const matchCount = matches.length
+  const hasGroups = matches.some((m) => m.groups.length > 0)
 
   return (
     <div className="flex h-full">
@@ -403,15 +235,13 @@ export default function RegexTester() {
           >
             {showRef ? 'Hide' : 'Ref'}
           </button>
-          {result.error && (
-            <span className="text-xs text-[var(--color-error)]">{result.error}</span>
-          )}
-          {!result.error && matchCount > 0 && (
+          {matchError && <span className="text-xs text-[var(--color-error)]">{matchError}</span>}
+          {!matchError && matchCount > 0 && (
             <span className="rounded-full bg-[var(--color-accent-dim)] px-2 py-0.5 text-xs font-bold text-[var(--color-accent)]">
-              {result.truncated ? `${matchCount}+` : matchCount}
+              {truncated ? `${matchCount}+` : matchCount}
             </span>
           )}
-          {!result.error && result.truncated && (
+          {!matchError && truncated && (
             <span className="text-xs text-[var(--color-warning)]">
               Showing first {MAX_REGEX_MATCHES} matches
             </span>
@@ -429,7 +259,7 @@ export default function RegexTester() {
                 placeholder="Replacement pattern ($1, $2, $<name>)..."
                 className="flex-1 border-none bg-transparent font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
               />
-              <CopyButton text={replaceResult.result} label="Copy result" />
+              <CopyButton text={replaceValue} label="Copy result" />
             </div>
           )}
           {mode === 'match' && matchCount > 0 && (
@@ -462,7 +292,7 @@ export default function RegexTester() {
               <span className="text-xs text-[var(--color-text-muted)]">
                 {mode === 'replace' ? 'Replace Preview' : 'Highlighted Matches'}
               </span>
-              {mode === 'replace' && state.pattern && state.testString && !replaceResult.error && (
+              {mode === 'replace' && state.pattern && state.testString && !replaceError && (
                 <div className="flex items-center gap-2">
                   {diffStats && (
                     <span className="font-mono text-[10px] text-[var(--color-text-muted)]">
@@ -484,8 +314,8 @@ export default function RegexTester() {
             </div>
             {mode === 'replace' ? (
               <div className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm">
-                {replaceResult.error ? (
-                  <span className="text-[var(--color-error)]">{replaceResult.error}</span>
+                {replaceError ? (
+                  <span className="text-[var(--color-error)]">{replaceError}</span>
                 ) : !state.pattern || !state.testString ? (
                   <span className="text-[var(--color-text-muted)]">
                     Replace preview will appear here
@@ -512,15 +342,19 @@ export default function RegexTester() {
                     </span>
                   ))
                 ) : (
-                  <span className="text-[var(--color-text)]">{replaceResult.result}</span>
+                  <span className="text-[var(--color-text)]">{replaceValue}</span>
                 )}
+              </div>
+            ) : timedOut ? (
+              <div className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm">
+                <span className="text-[var(--color-error)]">{TIMEOUT_MESSAGE}</span>
               </div>
             ) : (
               <div
                 className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm text-[var(--color-text)]"
                 dangerouslySetInnerHTML={{
                   __html:
-                    highlighted.html ||
+                    evaluated?.highlightHtml ||
                     '<span style="color:var(--color-text-muted)">Matches will be highlighted here</span>',
                 }}
               />
@@ -533,14 +367,12 @@ export default function RegexTester() {
           <div className="max-h-48 shrink-0 overflow-auto border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
             <div className="mb-2 flex items-center gap-2 font-mono text-xs text-[var(--color-text-muted)]">
               <span>
-                {result.truncated ? `First ${matchCount}` : matchCount} match
+                {truncated ? `First ${matchCount}` : matchCount} match
                 {matchCount !== 1 ? 'es' : ''}
-                {hasGroups
-                  ? ` · ${result.matches.reduce((n, m) => n + m.groups.length, 0)} groups`
-                  : ''}
+                {hasGroups ? ` · ${matches.reduce((n, m) => n + m.groups.length, 0)} groups` : ''}
               </span>
             </div>
-            {result.matches.map((m, i) => (
+            {matches.map((m, i) => (
               <div
                 key={i}
                 className="mb-1.5 flex items-start gap-3 rounded p-1 text-xs hover:bg-[var(--color-surface-hover)]"

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -21,6 +21,7 @@ import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Input, Select } from '@/components/shared/Input'
 import { useUiStore } from '@/stores/ui.store'
+import { buildExportFilename, exportFile } from '@/lib/file-io'
 
 // ─── Constants ───────────────────────────────────────────────────────
 
@@ -525,18 +526,16 @@ export default function SnippetsManager() {
     }
   }, [addSnippet, setLastAction])
 
-  const handleDownload = useCallback(() => {
+  const handleDownload = useCallback(async () => {
     if (!selected) return
     const ext = LANG_EXTENSIONS[selected.language] ?? selected.language
-    const filename = (selected.title || 'snippet').replace(/[^a-zA-Z0-9_-]/g, '_') + '.' + ext
-    const blob = new Blob([selected.content], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(url)
-    setLastAction(`Downloaded ${filename}`, 'success')
+    const filename = buildExportFilename(selected.title || 'snippet', ext)
+    try {
+      const path = await exportFile(selected.content, filename)
+      if (path) setLastAction(`Downloaded ${filename}`, 'success')
+    } catch {
+      setLastAction('Download failed', 'error')
+    }
   }, [selected, setLastAction])
 
   // ─── Shortcuts ───────────────────────────────────────────────────

--- a/apps/cockpit/src/workers/__tests__/regex.api.test.ts
+++ b/apps/cockpit/src/workers/__tests__/regex.api.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_REGEX_MATCHES,
+  escapeHtml,
+  evaluateRegex,
+  extractCaptureGroupNames,
+} from '@/workers/regex.api'
+
+function evaluate(pattern: string, flags: string, text: string, replacement = '') {
+  return evaluateRegex({ pattern, flags, text, replacement })
+}
+
+describe('escapeHtml', () => {
+  it('escapes angle brackets, quotes, and ampersands', () => {
+    expect(escapeHtml('<script>alert("xss" & 1)</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot; &amp; 1)&lt;/script&gt;'
+    )
+  })
+})
+
+describe('extractCaptureGroupNames', () => {
+  it('keeps unnamed groups alongside named ones and skips non-capturing constructs', () => {
+    expect(extractCaptureGroupNames('([A-Z])(?:x)(?<digits>\\d+)(?=y)')).toEqual([null, 'digits'])
+  })
+
+  it('ignores parentheses inside character classes and escapes', () => {
+    expect(extractCaptureGroupNames('[(]\\((a)')).toEqual([null])
+  })
+})
+
+describe('evaluateRegex', () => {
+  it('returns an empty evaluation for an empty pattern', () => {
+    const result = evaluate('', 'g', 'anything')
+    expect(result).toEqual({
+      matches: [],
+      matchError: null,
+      truncated: false,
+      highlightHtml: '',
+      replaceResult: 'anything',
+      replaceError: null,
+    })
+  })
+
+  it('collects global matches with capture groups', () => {
+    const result = evaluate('([a-z])(\\d)', 'g', 'a1 b2')
+    expect(result.matches.map((m) => m.full)).toEqual(['a1', 'b2'])
+    expect(result.matches[0]?.index).toBe(0)
+    expect(result.matches[0]?.groups).toEqual([
+      { index: 1, name: null, value: 'a' },
+      { index: 2, name: null, value: '1' },
+    ])
+    expect(result.matchError).toBeNull()
+  })
+
+  it('reports only the first match without the g flag but still highlights all', () => {
+    const result = evaluate('a', '', 'aaa')
+    expect(result.matches).toHaveLength(1)
+    expect(result.highlightHtml.match(/<mark/g)).toHaveLength(3)
+    expect(result.truncated).toBe(false)
+  })
+
+  it('escapes HTML in both matched and unmatched text', () => {
+    const result = evaluate('bold', 'g', '<b>bold</b>')
+    expect(result.highlightHtml).toContain('&lt;b&gt;')
+    expect(result.highlightHtml).toContain('>bold</mark>')
+    expect(result.highlightHtml).not.toContain('<b>')
+  })
+
+  it('truncates at the match cap and flags it', () => {
+    const result = evaluate('.', 'g', 'a'.repeat(MAX_REGEX_MATCHES + 205))
+    expect(result.matches).toHaveLength(MAX_REGEX_MATCHES)
+    expect(result.truncated).toBe(true)
+  })
+
+  it('does not loop forever on a zero-width match', () => {
+    const result = evaluate('x*', 'g', 'ab')
+    expect(result.matches.length).toBeLessThanOrEqual(3)
+  })
+
+  it('applies the replacement with capture group references', () => {
+    const result = evaluate('(\\w+)@(\\w+)', 'g', 'me@here you@there', '$2:$1')
+    expect(result.replaceResult).toBe('here:me there:you')
+    expect(result.replaceError).toBeNull()
+  })
+
+  it('reuses one compiled pattern: scanning does not disturb the replacement', () => {
+    // The global scan advances lastIndex; String.replace must still see the whole input.
+    const result = evaluate('a', 'g', 'aaa', 'b')
+    expect(result.matches).toHaveLength(3)
+    expect(result.replaceResult).toBe('bbb')
+  })
+
+  it('surfaces an invalid pattern as an error on both paths and leaves text intact', () => {
+    const result = evaluate('[invalid', 'g', '<b>text</b>')
+    expect(result.matchError).toBeTruthy()
+    expect(result.replaceError).toBe(result.matchError)
+    expect(result.matches).toEqual([])
+    expect(result.replaceResult).toBe('<b>text</b>')
+    expect(result.highlightHtml).toBe('&lt;b&gt;text&lt;/b&gt;')
+  })
+})

--- a/apps/cockpit/src/workers/regex.api.ts
+++ b/apps/cockpit/src/workers/regex.api.ts
@@ -1,0 +1,203 @@
+/**
+ * Pure regex evaluation shared by the regex worker and its tests.
+ *
+ * Lives in its own module (no `self` reference) so it can be unit tested directly and
+ * reused by the test-environment worker stub. Nothing here may run on the main thread:
+ * a user-supplied pattern can backtrack for an unbounded time and only a terminable
+ * worker can be interrupted.
+ */
+
+export const MAX_REGEX_MATCHES = 1000
+
+export type RegexMatch = {
+  full: string
+  index: number
+  length: number
+  groups: Array<{ index: number; name: string | null; value: string }>
+}
+
+export type RegexEvaluationInput = {
+  pattern: string
+  flags: string
+  text: string
+  replacement: string
+}
+
+export type RegexEvaluation = {
+  matches: RegexMatch[]
+  matchError: string | null
+  truncated: boolean
+  highlightHtml: string
+  replaceResult: string
+  replaceError: string | null
+}
+
+const MATCH_COLORS = [
+  { bg: 'var(--color-accent)', text: 'var(--color-bg)' },
+  { bg: 'var(--color-info)', text: 'var(--color-bg)' },
+]
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function extractCaptureGroupNames(pattern: string): Array<string | null> {
+  const names: Array<string | null> = []
+  let inClass = false
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]
+    if (!char) break
+
+    if (char === '\\') {
+      i++
+      continue
+    }
+
+    if (char === '[') {
+      inClass = true
+      continue
+    }
+
+    if (char === ']' && inClass) {
+      inClass = false
+      continue
+    }
+
+    if (inClass || char !== '(') continue
+
+    const next = pattern[i + 1]
+    if (next !== '?') {
+      names.push(null)
+      continue
+    }
+
+    if (
+      pattern.startsWith('(?:', i) ||
+      pattern.startsWith('(?=', i) ||
+      pattern.startsWith('(?!', i)
+    ) {
+      continue
+    }
+
+    if (pattern.startsWith('(?<=', i) || pattern.startsWith('(?<!', i)) {
+      continue
+    }
+
+    if (pattern.startsWith('(?<', i)) {
+      const end = pattern.indexOf('>', i + 3)
+      if (end !== -1) {
+        names.push(pattern.slice(i + 3, end))
+      }
+    }
+  }
+
+  return names
+}
+
+export function emptyEvaluation(text: string): RegexEvaluation {
+  return {
+    matches: [],
+    matchError: null,
+    truncated: false,
+    highlightHtml: '',
+    replaceResult: text,
+    replaceError: null,
+  }
+}
+
+function buildHighlightHtml(text: string, matches: RegexMatch[]): string {
+  if (!text) return ''
+  const parts: string[] = []
+  let lastIndex = 0
+  matches.forEach((match, i) => {
+    parts.push(escapeHtml(text.slice(lastIndex, match.index)))
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const c = MATCH_COLORS[i % MATCH_COLORS.length]! // safe: modulo keeps index in bounds
+    parts.push(
+      `<mark style="background:${c.bg};color:${c.text};border-radius:2px;padding:0 2px">${escapeHtml(match.full)}</mark>`
+    )
+    lastIndex = match.index + match.full.length
+  })
+  parts.push(escapeHtml(text.slice(lastIndex)))
+  return parts.join('')
+}
+
+/**
+ * Compiles the pattern once and derives matches, highlight markup, and the replacement
+ * from a single scan.
+ *
+ * Previously this was three `useMemo`s, each building its own `RegExp` and running its
+ * own scan on every keystroke. `re` carries the user's flags (needed for `String.replace`
+ * so `$1` / `$<name>` semantics are preserved); `scanner` is the same object when the
+ * `g` flag is set, and only then a second one is built.
+ */
+export function evaluateRegex(input: RegexEvaluationInput): RegexEvaluation {
+  const { pattern, flags, text, replacement } = input
+  if (!pattern) return emptyEvaluation(text)
+
+  let re: RegExp
+  try {
+    re = new RegExp(pattern, flags)
+  } catch (e) {
+    const message = (e as Error).message
+    return {
+      matches: [],
+      matchError: message,
+      truncated: false,
+      highlightHtml: escapeHtml(text),
+      replaceResult: text,
+      replaceError: message,
+    }
+  }
+
+  const isGlobal = flags.includes('g')
+  const scanner = isGlobal ? re : new RegExp(pattern, flags + 'g')
+  const captureGroupNames = extractCaptureGroupNames(pattern)
+
+  const scanned: RegexMatch[] = []
+  let truncated = false
+  if (text) {
+    scanner.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = scanner.exec(text)) !== null) {
+      if (scanned.length >= MAX_REGEX_MATCHES) {
+        truncated = true
+        break
+      }
+      const groups: RegexMatch['groups'] = []
+      for (let i = 1; i < m.length; i++) {
+        groups.push({ index: i, name: captureGroupNames[i - 1] ?? null, value: m[i] ?? '' })
+      }
+      scanned.push({ full: m[0], index: m.index, length: m[0].length, groups })
+      if (m[0] === '') scanner.lastIndex++
+    }
+  }
+
+  // Without `g` only the first match is reported, but every occurrence is still
+  // highlighted — this mirrors the pre-worker behaviour of the tool.
+  const matches = isGlobal ? scanned : scanned.slice(0, 1)
+
+  let replaceResult = text
+  let replaceError: string | null = null
+  if (text) {
+    try {
+      replaceResult = text.replace(re, replacement)
+    } catch (e) {
+      replaceError = (e as Error).message
+    }
+  }
+
+  return {
+    matches,
+    matchError: null,
+    truncated: isGlobal && truncated,
+    highlightHtml: buildHighlightHtml(text, scanned),
+    replaceResult,
+    replaceError,
+  }
+}

--- a/apps/cockpit/src/workers/regex.worker.ts
+++ b/apps/cockpit/src/workers/regex.worker.ts
@@ -1,0 +1,13 @@
+import { handleRpc } from './rpc'
+import { evaluateRegex } from './regex.api'
+import type { RegexEvaluation, RegexEvaluationInput } from './regex.api'
+
+const api = {
+  evaluate(input: RegexEvaluationInput): RegexEvaluation {
+    return evaluateRegex(input)
+  },
+}
+
+export type RegexWorker = typeof api
+
+handleRpc(api)

--- a/apps/cockpit/vitest.config.ts
+++ b/apps/cockpit/vitest.config.ts
@@ -9,20 +9,31 @@ export default defineConfig({
     css: false,
   },
   resolve: {
-    alias: {
-      '@': resolve(__dirname, './src'),
-      '@monaco-editor/react': resolve(__dirname, './src/__mocks__/monaco-editor-react.tsx'),
-      '@tauri-apps/api/webviewWindow': resolve(
-        __dirname,
-        './src/__mocks__/tauri-webview-window.ts'
-      ),
-      '@tauri-apps/plugin-sql': resolve(__dirname, './src/__mocks__/tauri-plugin-sql.ts'),
-      // Add worker mocks
-      '@/workers/typescript.worker?worker': resolve(__dirname, './src/__mocks__/worker.ts'),
-      '@/workers/formatter.worker?worker': resolve(__dirname, './src/__mocks__/worker.ts'),
-      '@/workers/refactoring.worker?worker': resolve(__dirname, './src/__mocks__/worker.ts'),
-      '@/workers/diff.worker?worker': resolve(__dirname, './src/__mocks__/worker.ts'),
-      '@/workers/xml.worker?worker': resolve(__dirname, './src/__mocks__/worker.ts'),
-    },
+    // Order matters: Vite picks the first matching alias, and the bare '@' entry matches
+    // every '@/...' specifier. The worker mocks must therefore be listed before it.
+    alias: [
+      {
+        // Runs the real evaluation instead of no-oping, so regex tester tests are meaningful.
+        find: '@/workers/regex.worker?worker',
+        replacement: resolve(__dirname, './src/__mocks__/regex-worker.ts'),
+      },
+      {
+        find: /^@\/workers\/(typescript|formatter|refactoring|diff|xml)\.worker\?worker$/,
+        replacement: resolve(__dirname, './src/__mocks__/worker.ts'),
+      },
+      { find: '@', replacement: resolve(__dirname, './src') },
+      {
+        find: '@monaco-editor/react',
+        replacement: resolve(__dirname, './src/__mocks__/monaco-editor-react.tsx'),
+      },
+      {
+        find: '@tauri-apps/api/webviewWindow',
+        replacement: resolve(__dirname, './src/__mocks__/tauri-webview-window.ts'),
+      },
+      {
+        find: '@tauri-apps/plugin-sql',
+        replacement: resolve(__dirname, './src/__mocks__/tauri-plugin-sql.ts'),
+      },
+    ],
   },
 })


### PR DESCRIPTION
## Summary

Seven defects found in a source audit of `apps/cockpit` on 2026-07-30 — three P0, four P1. All four gates (tsc, vitest, eslint, clippy) were green before this PR; none of these had a failing test. Each was found by reading code or by direct reproduction.

### P0

- **Regex Tester no longer freezes the app.** A pattern like `(a+)+$` against 30 `a`s and a `!` hung the entire WebView with no way to recover except force-quitting — and because the pattern is persisted, relaunching hung it again. Evaluation now runs in a Web Worker with a 1000 ms budget; on expiry the worker is terminated, a replacement is spawned, and the pane shows an explicit timeout message. A timed-out pattern is not re-evaluated until the user edits an input.
- **`runTransaction` now actually is a transaction.** It issued `BEGIN` / statements / `COMMIT` as separate calls through `tauri-plugin-sql`, which hands out a connection per call from a 10-connection pool — so statements could land on different connections and a failure could leave a half-applied write. Replaced with a Rust `db_execute_batch` command that runs the whole batch on one connection, rolling back on any error. `saveNotesOrder` uses `BEGIN IMMEDIATE`. Rationale recorded as ADR-013.
- **`useToolState` no longer discards edits made during cold start.** If the user typed while the initial read was in flight, the load overwrote their input. Live input now wins.

### P1

- **Notes stop silently destroying content.** `src/lib/markdown.ts` passed `rehypeSanitize` a *replacement* schema and never registered `remark-gfm`, so tables rendered as loose prose, images became empty `<p></p>`, strikethrough lost its styling, and task-list checkboxes vanished — no error, no indication anything was lost. It now extends `defaultSchema` with GFM, and the Markdown Editor imports that same schema instead of keeping its own copy, so the two surfaces can't drift.
- **Exports go through the native save dialog.** Five call sites built a detached `<a download>` and revoked the blob URL in the same tick — unreliable in WKWebView, and inconsistent with the global save shortcut, which already used `saveFileDialog()`. All five now use one shared `exportFile` helper.
- **Bootstrap no longer leaks listeners.** `providers.tsx` pushed cleanups onto an array only after long `await` chains; unmounting first meant the array was drained before the listeners were ever registered. Each cleanup is now registered — or torn down on the spot — the moment its resource is created.
- **A transient init failure is no longer permanent.** All seven store promise-guards cached rejections forever, so one locked database at launch left the app dead until relaunch. They now clear the cached promise on rejection, and the error screen has a Retry button.

Also fixes a pre-existing bug in `vitest.config.ts`: the bare `'@'` alias was listed first and matched every `@/workers/*.worker?worker` specifier, so five worker mocks had never been active. The alias map is now an ordered array with specific entries first.

Follow-ups filed in `documentation/TODO.md` rather than fixed here: the `lint` package script has never been runnable locally (`bun run lint` exits 127), the five newly-active worker mocks want a second look, `getDb()` has the same unguarded-singleton shape the stores just had, and the `useToolState` tests sit outside the documented location.

## Reviewer notes

The regex timeout test drives a wedged-worker stub with fake timers rather than a genuinely catastrophic pattern — the mock worker runs on the test thread, so a real pathological regex would hang the Vitest runner exactly as the bug hung the app. It asserts the timeout machinery (status, single `terminate()`, replacement spawn, no re-post of identical input, resumption on edit), not that a specific pattern trips it.

`useRegexEvaluation` is a dedicated hook rather than an extension of `useWorker`. Adding terminate-and-respawn to `useWorker` would change its contract for six existing consumers — a rejected call would no longer imply a live worker — and that contract is pinned by `useWorker.test.ts`.

Two things checked because they were the obvious ways this could go wrong quietly: switching Notes to `defaultSchema` restricts `code` `className` to `language-*`, which would have stripped the `hljs-*` classes `rehypeHighlight` emits — the schema re-allows it explicitly and this was verified against the real pipeline. And the three new `providers.test.tsx` tests were each confirmed to fail against the pre-fix file, so they pin the actual defects rather than passing vacuously.

One `URL.createObjectURL` remains, in `MermaidEditor.renderPngBlob`: it rasterizes SVG into an `Image` for canvas rather than triggering a download, and revokes in `onload`/`onerror`. `src-tauri/capabilities/default.json` is unchanged — `fs:allow-write-file` was already scoped to `$DOWNLOAD/**` and `$HOME/**`.

## Pre-merge review

An independent review pass found two blocking defects, both now fixed in `6f8e42d`:

- **`batch.rs` could poison its own connection pool.** The first cut hand-wrote `BEGIN`/`COMMIT`/`ROLLBACK` as raw SQL on a pooled connection, so sqlx had no idea a transaction was open — and the `COMMIT`-failure path returned without attempting a rollback. On a full disk or lock timeout, the connection went back to a `max_connections(1)` pool still inside a transaction and every later batch would fail with "cannot start a transaction within a transaction" until relaunch. That is a worse failure than the one this PR set out to fix. Now uses `pool.begin()` / `pool.begin_with("BEGIN IMMEDIATE")`, which rolls back on `Drop` for every early return.
- **The regex timeout could be undone by a late reply.** The timeout set `status: 'timeout'` but never retired the request id, and `terminate()` does not cancel a reply already queued as a task on this thread. A match finishing just under the wire would pass both staleness guards and flip the pane back to `ready` — while the input stayed in `timedOutKeysRef`, wedging it as permanently timed-out the next time the user returned to it. The timeout now bumps the request id; the regression test was confirmed to fail against the pre-fix hook.

Three non-blocking findings are filed in `documentation/TODO.md` rather than fixed here: the re-allowed `className` is broader than the `hljs-*`/`language-*` classes actually need (not exploitable today — no `rehype-raw` pass, so no user string can reach a class attribute), the converted export handlers pass async functions to `onClick` without the `void` prefix the conventions call for, and init-rejection recovery is tested for `settings.store` but not the other six.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bunx vitest run` — 78 files, 650 tests passing (baseline 76/623)
- [x] `bunx eslint src` — zero warnings
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Manual: paste `(a+)+$` into Regex Tester against `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!` and confirm the shell stays interactive and shows the timeout message
- [ ] Manual: reorder notes and confirm the order persists across a relaunch
- [ ] Manual: export from Snippets, Image Tool, Mermaid (SVG + PNG), and Markdown Editor and confirm each opens the native save dialog and writes a valid file
- [ ] Manual: write a note containing a table, an image, `~~strike~~`, and a task list and confirm all four render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
