### PR TITLE
docs(cockpit): drop PATH prefixes now that bash_env.sh is fixed

### DIFF
--- a/apps/cockpit/CLAUDE.md
+++ b/apps/cockpit/CLAUDE.md
@@ -36,13 +36,12 @@ chore(release): bump version to 0.1.37 [skip ci]
 
 Format: `type(scope): short description` — imperative mood, no period, under 72 chars. Scope is almost always `cockpit`.
 
-### Commits need HUSKY_PATH
+### Commits
 
-The pre-commit hook calls `bunx`. Bun lives in `/opt/homebrew/bin`, which isn't on the minimal shell PATH. Always prefix:
-
-```bash
-HUSKY_PATH=/opt/homebrew/bin PATH="/opt/homebrew/bin:$PATH" git commit -m "..."
-```
+Plain `git commit -m "..."` works. The pre-commit hook calls `bunx`, which resolves normally now that
+`~/.claude/bash_env.sh` extends PATH instead of overwriting it (see PATH note below). The older
+`HUSKY_PATH=/opt/homebrew/bin PATH="/opt/homebrew/bin:$PATH" git commit` form is still harmless if
+you see it in old notes, just unnecessary.
 
 ### PRs
 
@@ -91,44 +90,58 @@ Full canonical docs live in [`documentation/`](./documentation/):
 
 - **Package manager:** Bun only. Never use npm or yarn.
 - **Run commands from:** `apps/cockpit/` — never the monorepo root.
-- **PATH prefix required:** Bun and other Homebrew tools are in `/opt/homebrew/bin`, which is not on the default shell PATH. Every command below needs the prefix.
+- **PATH prefixes are no longer needed.** They used to be, and older notes still show them. See the PATH note below.
 
 ## Commands
 
-All commands must be run from `apps/cockpit/` with the PATH prefix. Running from the monorepo root will silently use the wrong config or fail to find binaries.
+All commands must be run from `apps/cockpit/`. Running from the monorepo root will silently use the
+wrong config or fail to find binaries.
 
 ```bash
 # Typecheck — must be zero errors before committing
-PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit
+npx tsc --noEmit
 
-# Tests — use bunx, NOT bun run test (bun can't resolve the vitest binary directly)
-PATH="/opt/homebrew/bin:$PATH" bunx vitest run        # run once
-PATH="/opt/homebrew/bin:$PATH" bunx vitest            # watch mode
+# Tests
+bunx vitest run        # run once
+bunx vitest            # watch mode
 
 # Lint — ESLint across src/
-PATH="/opt/homebrew/bin:$PATH" bun run lint
+bun run lint
 
 # Dev server — starts Vite + Tauri hot-reload
-PATH="/opt/homebrew/bin:$PATH" bun run tauri dev
+bun run tauri dev
 
-# Production build
-PATH="/opt/homebrew/bin:$PATH" bun run tauri build
+# Production build — emits .app and .dmg under src-tauri/target/release/bundle/
+bun run tauri build
 
 # Install / restore dependencies
-PATH="/opt/homebrew/bin:$PATH" bun install
+bun install
 
 # Clean build artifacts and node_modules
-PATH="/opt/homebrew/bin:$PATH" bun run clean
+bun run clean
 ```
+
+### The PATH prefix, and why you'll see it in old notes
+
+`~/.claude/bash_env.sh` is sourced by every non-interactive bash the agent harness spawns. It used to
+do a hard `export PATH=...`, which ran _after_ the environment was assembled and therefore discarded
+both the `node_modules/.bin` entry `bun run` prepends and any inline `PATH="..." cmd` prefix. That is
+why `bun run lint`, `bun run build`, and `bun run tauri build` all failed with "command not found",
+and why every documented command carried a `PATH="/opt/homebrew/bin:$PATH"` prefix as a workaround.
+
+Fixed 2026-07-30: that file now appends only missing directories instead of assigning, so caller
+precedence is preserved, and it includes `$HOME/.cargo/bin` so `cargo` resolves too. Prefixed
+commands still work identically — the prefix is now redundant, not wrong.
 
 ### Common mistakes
 
-| Wrong                      | Right                                | Why                                                             |
-| -------------------------- | ------------------------------------ | --------------------------------------------------------------- |
-| Run from monorepo root     | Run from `apps/cockpit/`             | Wrong tsconfig, wrong vitest config, wrong node_modules         |
-| `bun run test`             | `bunx vitest run`                    | bun resolves scripts but can't find the `vitest` binary in PATH |
-| `npm run ...` / `yarn ...` | `bun run ...`                        | npm/yarn are not the package manager here                       |
-| No PATH prefix             | `PATH="/opt/homebrew/bin:$PATH" ...` | Homebrew tools not on default shell PATH                        |
+| Wrong                      | Right                    | Why                                                     |
+| -------------------------- | ------------------------ | ------------------------------------------------------- |
+| Run from monorepo root     | Run from `apps/cockpit/` | Wrong tsconfig, wrong vitest config, wrong node_modules |
+| `npm run ...` / `yarn ...` | `bun run ...`            | npm/yarn are not the package manager here               |
+
+`bun run test` and `bun run test:watch` also work now; older notes say they don't, which was the
+PATH bug above rather than anything about the scripts.
 
 ## Architecture
 
@@ -440,8 +453,8 @@ return () => observer.disconnect()
 ## Running the Test Suite
 
 ```bash
-bunx vitest run       # run once (bun run test fails — shell can't resolve vitest binary)
-bunx vitest           # watch mode
+bunx vitest run       # run once (or `bun run test`)
+bunx vitest           # watch mode (or `bun run test:watch`)
 ```
 
 Tests live in `src/**/__tests__/*.test.tsx` for tool tests and `src/**/*.test.ts` for unit tests.

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -10,13 +10,17 @@ evidence, an expected outcome, acceptance criteria, and a verification path.
 
 Verified locally from `apps/cockpit` on 2026-07-30:
 
-| Gate        | Command                                           | Result                       |
-| ----------- | ------------------------------------------------- | ---------------------------- |
-| TypeScript  | `PATH="/opt/homebrew/bin:$PATH" npx tsc --noEmit` | Passing                      |
-| Tests       | `PATH="/opt/homebrew/bin:$PATH" bunx vitest run`  | Passing: 78 files, 650 tests |
-| ESLint      | `PATH="/opt/homebrew/bin:$PATH" bunx eslint src`  | Passing with zero warnings   |
-| Rust check  | `cargo check` from `src-tauri`                    | Passing                      |
-| Rust clippy | `cargo clippy -- -D warnings` from `src-tauri`    | Passing                      |
+| Gate        | Command                                        | Result                          |
+| ----------- | ---------------------------------------------- | ------------------------------- |
+| TypeScript  | `npx tsc --noEmit`                             | Passing                         |
+| Tests       | `bunx vitest run`                              | Passing: 78 files, 650 tests    |
+| ESLint      | `bun run lint`                                 | Passing with zero warnings      |
+| Rust check  | `cargo check` from `src-tauri`                 | Passing                         |
+| Rust clippy | `cargo clippy -- -D warnings` from `src-tauri` | Passing                         |
+| Release     | `bun run tauri build`                          | Passing: builds `.app` + `.dmg` |
+
+Commands no longer need a `PATH="/opt/homebrew/bin:$PATH"` prefix; older entries in this file still
+show one. See the PATH section in `CLAUDE.md` for what changed.
 
 Known context:
 
@@ -48,8 +52,9 @@ Newly filed from that audit:
 | Tool capabilities duplicated across 3 id sets | P2       | Registry drift risk                      | Open   |
 | `settings.store` hand-rolls persisted object  | P2       | Silent setting loss on future fields     | Open   |
 
-Two further defects surfaced while fixing the P0 items, both filed in P2 below: the `lint` package
-script has never been runnable locally, and five worker mocks had never been wired up.
+Two further defects surfaced while fixing the P0 items, both filed in P2 below: `bun run lint` was
+not runnable locally (root-caused to the agent harness overwriting PATH, now fixed), and five worker
+mocks had never been wired up.
 
 ## How To Use This Backlog
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -778,26 +778,30 @@ Completed 2026-07-30:
 
 ## P2 - Quality Ratchets and Maintainability
 
-### [ ] Repair the `lint` package script
+### [x] Repair the `lint` package script
 
 Area: quality gates / tooling
 
-Problem: `"lint": "eslint src --ext ..."` in `package.json` invokes a bare `eslint`, which does not
-resolve under the minimal shell PATH. `bun run lint` exits 127 with `eslint: command not found`. The
-documented lint gate has therefore not been runnable locally, and any local "lint passing" claim made
-via that script was vacuous. `bunx eslint src --ext .ts,.tsx,.js,.jsx` works and currently reports
-zero warnings, so this is a script defect, not lint debt.
+Problem: `bun run lint` exited 127 with `eslint: command not found`, so the documented lint gate was
+not runnable locally and any local "lint passing" claim made via that script was vacuous. The same
+applied to `bun run build` (`vite: command not found`) and `bun run tauri build`
+(`tauri: command not found`) — every package script that calls a local binary by bare name.
 
-Expected outcome: The documented command actually runs the linter.
+Expected outcome: The documented commands actually run.
 
-Acceptance criteria:
+Completed 2026-07-30:
 
-- The script uses `bunx eslint` (or otherwise resolves the local binary) and exits 0.
-- Confirm whether CI invokes this script; if so, establish why CI has been reporting green and
-  whether the gate has been passing for the right reason.
-- Update `AGENTS.md` and `CLAUDE.md` command tables to match the working invocation.
-- Fold into the ESLint ratchet item below, since `--max-warnings` is meaningless until the script
-  runs.
+- Root cause was not in this repo. The agent harness sets `BASH_ENV=~/.claude/bash_env.sh`, which
+  bash sources for every non-interactive shell, and that file did a hard `export PATH=...`. Because
+  it runs _after_ the environment is assembled, it discarded both the `node_modules/.bin` entry that
+  `bun run` prepends for exactly this purpose and any inline `PATH="..." cmd` prefix from the caller.
+  So the scripts were correct and the shell was lying to them.
+- `bash_env.sh` now appends only the directories that are missing instead of assigning, which
+  preserves caller precedence. It also adds `$HOME/.cargo/bin`, so `cargo` no longer needs a prefix.
+- Verified after the change with no PATH prefix at all: `bun run lint` exits 0, `bun run build`
+  succeeds, and `bun run tauri build` produces both the `.app` and the `.dmg`. Previously-prefixed
+  invocations still work unchanged — 78 files / 650 tests pass either way.
+- No `package.json` script was modified; none was broken.
 
 ### [ ] Re-examine the five worker mocks that were never active
 


### PR DESCRIPTION
## Summary

Documentation-only. These two commits were on `fix/cockpit-p0-reliability` but landed after PR #76 was merged at `6f8e42d`, so they never reached `main`. Cherry-picked onto a fresh branch off `origin/main`.

No source, test, config, or workflow file is touched — `apps/cockpit/CLAUDE.md` and `apps/cockpit/documentation/TODO.md` only. The app is byte-for-byte unchanged from v0.1.54.

## What changed

The `PATH="/opt/homebrew/bin:$PATH"` prefix that every documented command carried is gone, because the thing it worked around is fixed.

**Root cause, for the record:** it was never a defect in this repo. The agent harness sets `BASH_ENV=~/.claude/bash_env.sh`, which bash sources for every non-interactive shell, and that file did a hard `export PATH=...`. Because `BASH_ENV` runs *after* the environment is assembled, the assignment discarded both the `node_modules/.bin` entry `bun run` prepends so package scripts can call local binaries by bare name, and any inline `PATH="..." cmd` prefix from the caller. That is why `bun run lint` exited 127 with `eslint: command not found`, `bun run build` with `vite: command not found`, and `bun run tauri build` with `tauri: command not found` — the scripts were correct and the shell was lying to them. The prefix convention was fighting the same file that caused the problem.

`bash_env.sh` now appends only missing directories instead of assigning, preserving caller precedence, and adds `$HOME/.cargo/bin`. That file lives outside this repository, so it is not part of this diff.

- `CLAUDE.md` — command table unprefixed; a PATH section explaining what changed and why old notes still show the prefix; `Commits need HUSKY_PATH` retitled, since plain `git commit` now works. Also corrects a claim that `bun run test` cannot work — there is a `test` script and it passes.
- `TODO.md` — snapshot gate table unprefixed, plus a `Release` row; the P2 item "Repair the `lint` package script" closed as fixed-elsewhere, with the root cause recorded and an explicit note that no `package.json` script was modified because none was broken.

Verified after the change with no prefix anywhere: `bun run lint` exits 0, `bunx vitest run` passes 78 files / 650 tests, `bun run build` succeeds, `bun run tauri build` emits both the `.app` and the `.dmg`, and `git commit` works without `HUSKY_PATH`. Previously-prefixed invocations still behave identically — the prefix is redundant now, not wrong.

## Merge note

Merging with `[skip ci]`. `tauri.yml` triggers on any push to `main` under `apps/cockpit/**` — markdown included — and `bump-version.mjs` bumps the patch unconditionally, so a plain merge would cut a 0.1.55 release with no app change in it. Worth considering a `paths-ignore` for docs on that workflow as a follow-up, rather than relying on remembering this each time.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bunx vitest run` — 78 files, 650 tests passing
- [x] `bun run lint` — zero warnings
- [x] `git diff origin/main...HEAD --stat` — two `.md` files, nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)
