### PR TITLE
fix(cockpit): resolve four follow-ups found during the P2 batch

### DIFF
--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1340,12 +1340,16 @@ toast), but it silently defeats a retry mechanism the code believes it has.
 
 Completed 2026-07-31:
 
-- Dropped the outer `.catch((err) => { initPromise = null; throw err })` entirely and clear
-  `initPromise = null` directly inside the inner catch instead. Verified the ordering is safe: the
-  inner catch only runs on the async continuation _after_ an `await` (the first is `getSetting`),
-  which is scheduled as a microtask — by the time it runs, the synchronous
-  `initPromise = (async () => {...})()` assignment has already completed, so clearing it there is not
-  immediately clobbered by that assignment.
+- Dropped the outer `.catch((err) => { initPromise = null; throw err })` entirely. The inner catch now
+  sets a `failed` flag, and `initPromise = null` happens in a `.then()` chained onto the IIFE.
+- **Clearing from inside the inner catch is _not_ safe, contrary to a first reading.** It works for a
+  rejected promise (the catch runs on a microtask continuation, after the synchronous
+  `initPromise = (async () => {...})()` assignment has landed), but it silently breaks if `getSetting`
+  throws _synchronously_: that catch then runs during the IIFE's synchronous prologue, before the
+  assignment completes, so the assignment immediately clobbers the clear and the retry never happens.
+  Confirmed empirically, then guarded by a dedicated regression test — reverting the clear back into
+  the catch fails that test and only that test. A `.then()` callback is always a later microtask, so
+  the assignment is guaranteed to have landed.
 - **Deliberate decision — not in the TODO's own acceptance criteria:** did _not_ make the inner catch
   rethrow. `useMcpStore.init()` has exactly one call site — `providers.tsx`'s bootstrap sequence,
   which `await`s it — and MCP is an optional, disabled-by-default feature. Making init() reject would
@@ -1358,8 +1362,8 @@ Completed 2026-07-31:
   throw just to reach the now-deleted outer catch, and asserted the broken behavior). The new test
   calls `init()`, fails it via a rejected `getSetting`, asserts `initialized: true` /
   `status.lastError` are set, then calls `init()` again and asserts `getSetting` was called a second
-  time — proving the retry actually happens.
-- `bunx vitest run src/stores/__tests__/mcp.store.test.ts` — 11/11 passing.
+  time — proving the retry actually happens. A second test covers the synchronous-throw path above.
+- `bunx vitest run src/stores/__tests__/mcp.store.test.ts` — 12/12 passing.
 
 ### [x] Add error handling to SnippetsManager's handleDuplicate and handleToggleFavorite
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1400,7 +1400,7 @@ Completed 2026-07-31:
   `useUiStore`'s `lastAction` instead of throwing.
 - `bunx vitest run src/tools/__tests__/snippets.test.tsx` — 27/27 passing (24 existing + 3 new).
 
-### [ ] Reconcile markdown rehype plugin order between src/lib/markdown.ts and MarkdownEditor.tsx
+### [x] Reconcile markdown rehype plugin order between src/lib/markdown.ts and MarkdownEditor.tsx
 
 Area: markdown rendering / sanitize-vs-highlight ordering
 
@@ -1427,6 +1427,41 @@ Acceptance criteria:
 Judged priority: P2 — no known exploit today since `markdownSanitizeSchema` still runs either way, but
 divergent behavior between two markdown surfaces is exactly the kind of drift that becomes a bug once
 either pipeline changes independently.
+
+Completed 2026-07-31:
+
+- **Overriding the TODO's stated preference, deliberately:** the acceptance criteria above suggested
+  "sanitize-then-highlight is the safer default." That is backwards. Unified on
+  **highlight → sanitize** instead — the order already used by `src/lib/markdown.ts` — so the
+  sanitizer is the last thing to touch the tree before output, which is the standard rehype posture.
+  `markdownSanitizeSchema` already explicitly allows the `hljs-`/`language-` classes highlighting
+  emits and has a passing test (`keeps syntax highlighting classes on fenced code`) pinning that, so
+  nothing is lost by sanitizing last.
+- Extracted one shared `markdownProcessor` (a `unified()` instance) into `src/lib/markdown.ts`, built
+  with `remarkParse → remarkGfm → remarkRehype → rehypeHighlight({ detect: true }) → rehypeSanitize →
+rehypeStringify`. `processMarkdown()` now just calls `markdownProcessor.process()`, unchanged from
+  the outside for `NotesDrawer`. `MarkdownEditor.tsx` deleted its local, differently-ordered `unified()`
+  chain and imports `markdownProcessor` directly; its own `renderMarkdownContent()` wrapper (HTML-escaped
+  error reporting) is preserved and now just delegates processing to the shared processor. The two
+  surfaces can no longer drift apart because there is only one processor.
+- Dropped `remarkRehype`'s explicit `{ allowDangerousHtml: false }` option from the editor's old chain
+  — it was already the library default and thus a no-op; the shared processor doesn't pass it either.
+- **Visible rendering change for Notes, not a no-op:** the unified pipeline uses `detect: true`
+  (matching the editor's prior behavior), so unlabelled code fences in Notes are now
+  syntax-highlighted where they previously rendered as plain text. This is an intentional improvement
+  and brings Notes in line with the editor, but it is a real behavior change worth calling out.
+- `renderMarkdownContent` was exported from `MarkdownEditor.tsx` (previously module-private) so tests
+  can exercise it directly rather than only indirectly through component rendering.
+- New tests in `src/lib/__tests__/markdown.test.ts`: one confirms unlabelled fences now get
+  highlighted (the visible Notes change above), and one renders a fenced code block containing an
+  XSS-shaped payload (`<script>`, an `onerror`-bearing `<img>`, and a `javascript:` link, all inside
+  the fence) through both `processMarkdown()` and `renderMarkdownContent()` and asserts byte-identical,
+  safe output — plus a follow-up assertion that a real (non-fenced) `javascript:` link is still
+  stripped by the sanitizer.
+- All existing tests in `markdown.test.ts` (GFM tables/images/strikethrough/task-lists,
+  `javascript:`/`data:` href stripping) and in `markdown-editor.test.tsx` remain green, unmodified.
+- `bunx vitest run src/lib/__tests__/markdown.test.ts src/tools/__tests__/markdown-editor.test.tsx` —
+  45/45 passing (14 + 31, up from 12 + 31 baseline — 2 new tests).
 
 ### [ ] Add an `initialized` field to api.store for consistency with other stores
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1312,7 +1312,7 @@ cd apps/cockpit
 PATH="/opt/homebrew/bin:$PATH" bun run lint
 ```
 
-### [ ] Fix mcp.store init() error handling that never actually retries
+### [x] Fix mcp.store init() error handling that never actually retries
 
 Area: state management / error recovery
 
@@ -1337,6 +1337,29 @@ Acceptance criteria:
 
 Judged priority: P2 — not user-visible today (MCP init failures are rare and already surfaced via
 toast), but it silently defeats a retry mechanism the code believes it has.
+
+Completed 2026-07-31:
+
+- Dropped the outer `.catch((err) => { initPromise = null; throw err })` entirely and clear
+  `initPromise = null` directly inside the inner catch instead. Verified the ordering is safe: the
+  inner catch only runs on the async continuation _after_ an `await` (the first is `getSetting`),
+  which is scheduled as a microtask — by the time it runs, the synchronous
+  `initPromise = (async () => {...})()` assignment has already completed, so clearing it there is not
+  immediately clobbered by that assignment.
+- **Deliberate decision — not in the TODO's own acceptance criteria:** did _not_ make the inner catch
+  rethrow. `useMcpStore.init()` has exactly one call site — `providers.tsx`'s bootstrap sequence,
+  which `await`s it — and MCP is an optional, disabled-by-default feature. Making init() reject would
+  turn a degraded MCP server into a full app-startup failure screen, which is strictly worse than the
+  bug being fixed. `init()` still resolves on failure, still sets `initialized: true` (so the UI shows
+  a degraded MCP rather than a permanent spinner), and now also clears `initPromise` so a later call
+  genuinely retries. The `addToast` call is additionally wrapped in its own `try`/`catch` so even an
+  unexpected toast failure can't turn this into an unhandled rejection.
+- Rewrote `src/stores/__tests__/mcp.store.test.ts`'s rejection test (previously forced `addToast` to
+  throw just to reach the now-deleted outer catch, and asserted the broken behavior). The new test
+  calls `init()`, fails it via a rejected `getSetting`, asserts `initialized: true` /
+  `status.lastError` are set, then calls `init()` again and asserts `getSetting` was called a second
+  time — proving the retry actually happens.
+- `bunx vitest run src/stores/__tests__/mcp.store.test.ts` — 11/11 passing.
 
 ### [ ] Add error handling to SnippetsManager's handleDuplicate and handleToggleFavorite
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1463,7 +1463,7 @@ rehypeStringify`. `processMarkdown()` now just calls `markdownProcessor.process(
 - `bunx vitest run src/lib/__tests__/markdown.test.ts src/tools/__tests__/markdown-editor.test.tsx` —
   45/45 passing (14 + 31, up from 12 + 31 baseline — 2 new tests).
 
-### [ ] Add an `initialized` field to api.store for consistency with other stores
+### [x] Add an `initialized` field to api.store for consistency with other stores
 
 Area: state management / store consistency
 
@@ -1483,6 +1483,20 @@ Acceptance criteria:
   not required to land in the same change).
 
 Judged priority: P2 — cosmetic/consistency; no observed bug from its absence today.
+
+Completed 2026-07-31:
+
+- Added `initialized: boolean` to `ApiStore` in `src/stores/api.store.ts`, defaulting to `false`.
+- Set to `true` only inside the `set()` call on the success path of `init()`'s `Promise.all` load —
+  matching `settings.store`'s pattern, **not** `mcp.store`'s. Unlike mcp.store's deliberately
+  degraded-mode design (see the mcp.store item above), a failed api.store `init()` leaves `initialized`
+  at its default `false` since the `catch` never calls `set()`.
+- Did not go hunting for UI call sites inferring readiness from array emptiness, per the TODO's own
+  "optional" carve-out — none were found during recon either.
+- Extended `src/stores/__tests__/api.store.test.ts`'s existing `expectInitRejectionRecovers` rejection
+  test to assert `initialized` stays `false` after the failed `init()` call and flips to `true` after
+  the retried, successful one.
+- `bunx vitest run src/stores/__tests__/api.store.test.ts` — 5/5 passing.
 
 ### [ ] Add a no-regression audit for cockpit non-negotiables
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1361,7 +1361,7 @@ Completed 2026-07-31:
   time — proving the retry actually happens.
 - `bunx vitest run src/stores/__tests__/mcp.store.test.ts` — 11/11 passing.
 
-### [ ] Add error handling to SnippetsManager's handleDuplicate and handleToggleFavorite
+### [x] Add error handling to SnippetsManager's handleDuplicate and handleToggleFavorite
 
 Area: snippets tool / error handling consistency
 
@@ -1383,6 +1383,22 @@ Acceptance criteria:
   thrown as an unhandled rejection.
 
 Judged priority: P2 — inconsistent error handling within one file, not a reliability blocker.
+
+Completed 2026-07-31:
+
+- `handleDuplicate` and `handleToggleFavorite` in `src/tools/snippets/SnippetsManager.tsx` now wrap
+  their bodies in `try`/`catch`, surfacing failures via `setLastAction('...', 'error')` — the same
+  idiom already used by `handleExport`/`handleDownload` in this file.
+- **Extended beyond the letter of the TODO, per explicit instruction:** `handleDeleteClick`'s
+  `.catch(() => {})` around `handleDelete()` swallowed delete failures with zero user feedback — same
+  class of defect as the two handlers named in the TODO. Changed it to
+  `.catch(() => setLastAction('Delete failed', 'error'))`.
+- Added a new `describe('SnippetsManager — mutation error handling')` block in
+  `src/tools/__tests__/snippets.test.tsx` that overrides `add`/`update`/`remove` on the live
+  `useSnippetsStore` with rejecting mocks (captured and restored via `afterEach` since the store is a
+  shared module instance across the test file) and asserts each failure surfaces through
+  `useUiStore`'s `lastAction` instead of throwing.
+- `bunx vitest run src/tools/__tests__/snippets.test.tsx` — 27/27 passing (24 existing + 3 new).
 
 ### [ ] Reconcile markdown rehype plugin order between src/lib/markdown.ts and MarkdownEditor.tsx
 

--- a/apps/cockpit/src/lib/__tests__/markdown.test.ts
+++ b/apps/cockpit/src/lib/__tests__/markdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import rehypeSanitize from 'rehype-sanitize'
 import { processMarkdown, markdownSanitizeSchema } from '@/lib/markdown'
+import { renderMarkdownContent } from '@/tools/markdown-editor/MarkdownEditor'
 
 // `hast` types aren't a direct dependency here (only pulled in transitively by
 // rehype/remark packages), so define the minimal shape this test needs rather than
@@ -64,6 +65,41 @@ describe('processMarkdown', () => {
   it('keeps https: hrefs', async () => {
     const html = await processMarkdown('[click](https://example.com)')
     expect(html).toContain('href="https://example.com"')
+  })
+
+  it('detects the language of an unlabelled fenced code block', async () => {
+    // Unified pipeline decision: highlight runs with `detect: true`, matching the
+    // editor's prior behavior. This is a visible change for Notes — unlabelled
+    // fences are now syntax-highlighted where they previously were not.
+    const html = await processMarkdown('```\nconst a = 1\n```\n')
+    expect(html).toContain('hljs')
+  })
+})
+
+describe('markdown pipeline reconciliation', () => {
+  // src/lib/markdown.ts (NotesDrawer) and MarkdownEditor.tsx now share the exact
+  // same `markdownProcessor` instance, so both entry points must render an
+  // XSS-shaped payload inside a fenced code block identically and safely: the
+  // `<script>` text is highlighted/escaped as inert text content, never as a
+  // live tag, and no `onerror`/`javascript:` attribute survives sanitization.
+  const xssPayload =
+    '```html\n<script>alert(1)</script>\n<img src=x onerror="alert(2)">\n[click](javascript:alert(3))\n```\n'
+
+  it('renders identical, safe output through processMarkdown and MarkdownEditor', async () => {
+    const fromNotes = await processMarkdown(xssPayload)
+    const fromEditor = await renderMarkdownContent(xssPayload)
+
+    // The two entry points must never diverge again.
+    expect(fromEditor).toBe(fromNotes)
+    // Inside a fenced code block the payload is rendered as inert, highlighted
+    // text — not as a live <script> element or an onerror-bearing <img> — so
+    // there is no unescaped script tag in the output.
+    expect(fromNotes).not.toContain('<script>alert')
+    expect(fromNotes).toContain('&#x3C;') // hljs-escaped angle bracket, inert text
+
+    // A real (non-fenced) dangerous href is still stripped by the sanitizer.
+    const withRealLink = await processMarkdown('[click](javascript:alert(1))')
+    expect(withRealLink).not.toContain('javascript:')
   })
 })
 

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -43,15 +43,24 @@ export const markdownSanitizeSchema = {
   tagNames: [...(defaultSchema.tagNames ?? []), 'input'],
 }
 
-export async function processMarkdown(content: string): Promise<string> {
-  const file = await unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    .use(remarkRehype)
-    .use(rehypeHighlight)
-    .use(rehypeSanitize, markdownSanitizeSchema)
-    .use(rehypeStringify)
-    .process(content)
+/**
+ * Single shared markdown pipeline used by every rendering surface (Notes drawer,
+ * Markdown Editor). Plugin order is deliberate: `rehypeHighlight` runs *before*
+ * `rehypeSanitize` so the sanitizer is the last thing to touch the tree — nothing
+ * should reach output after it. `markdownSanitizeSchema` above explicitly allows
+ * the `hljs-`/`language-` classes highlighting emits, so nothing is lost by
+ * sanitizing last. `detect: true` lets unlabelled code fences get a best-guess
+ * language instead of rendering as plain, unhighlighted text.
+ */
+export const markdownProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(rehypeHighlight, { detect: true })
+  .use(rehypeSanitize, markdownSanitizeSchema)
+  .use(rehypeStringify)
 
+export async function processMarkdown(content: string): Promise<string> {
+  const file = await markdownProcessor.process(content)
   return String(file)
 }

--- a/apps/cockpit/src/stores/__tests__/api.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/api.store.test.ts
@@ -82,6 +82,7 @@ describe('API store persistence', () => {
     vi.mocked(deleteApiRequest).mockResolvedValue()
     vi.mocked(addHistoryEntry).mockResolvedValue()
     useApiStore.setState({
+      initialized: false,
       environments: [],
       collections: [],
       requests: [],
@@ -297,12 +298,15 @@ describe('API store initialization', () => {
       },
       rejectMessage: 'db locked',
       assertAfterFailure: () => {
-        // ApiStore has no `initialized` flag; a rejected Promise.all means `set()`
-        // was never called, so state is untouched from its module-fresh defaults.
+        // A rejected Promise.all means `set()` was never called, so state is
+        // untouched from its module-fresh defaults — unlike mcp.store, api.store's
+        // init() does not set `initialized: true` on failure, only on success.
         expect(freshStore.getState().environments).toEqual([])
+        expect(freshStore.getState().initialized).toBe(false)
       },
       assertAfterSuccess: () => {
         expect(freshStore.getState().environments).toEqual([persistedEnvironment])
+        expect(freshStore.getState().initialized).toBe(true)
       },
       getCallCount: () => vi.mocked(loadApiEnvironments).mock.calls.length,
     })

--- a/apps/cockpit/src/stores/__tests__/mcp.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/mcp.store.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { expectInitRejectionRecovers } from './init-rejection-helper'
 
 const mocks = vi.hoisted(() => ({
   getSetting: vi.fn(),
@@ -226,47 +225,37 @@ describe('useMcpStore', () => {
     })
   })
 
-  // Unlike the other six stores with this pattern, init()'s business logic wraps
-  // getSetting/persistSettings/invoke in its own internal try/catch that swallows
-  // failures (see the "keeps initialization non-blocking..." test above) and never
-  // rethrows — the outer `.catch(() => { initPromise = null; throw err })` guard is
-  // therefore only reachable if something throws *inside* that internal catch block
-  // itself, which is not covered by a plain getSetting/invoke rejection. The only
-  // reachable path is the addToast() call at the end of the catch branch: if it
-  // throws, that throw is not caught by the same try/catch and propagates to the
-  // outer guard. Using that (rather than faking a false pass) to genuinely exercise
-  // the rejection-clearing code — see the assertion below that `initialized` is
-  // already `true` after the "rejected" call, which does not match the other six
-  // stores and is a real behavioral asymmetry, not a test artifact.
-  it('init() clears the cached promise on rejection so a later call retries', async () => {
+  // Unlike the other six stores with this pattern, mcp.store's init() must never
+  // reject: it is the only store awaited directly in providers.tsx's bootstrap
+  // sequence, and MCP is an optional, disabled-by-default feature — a rejection
+  // there would turn a degraded MCP server into a full app-startup failure. So
+  // init()'s internal try/catch swallows failures, sets `initialized: true` (so
+  // the UI shows a degraded MCP rather than a permanent spinner), and resolves
+  // successfully. The bug this test guards against: that inner catch used to
+  // never clear the cached `initPromise`, so a later init() call returned the
+  // same already-resolved promise instead of genuinely retrying. We prove the
+  // fix by calling init() twice and asserting getSetting was invoked both times.
+  it('init() clears the cached promise on failure so a later call retries', async () => {
     const { useMcpStore: freshStore } = await import('@/stores/mcp.store')
 
-    await expectInitRejectionRecovers({
-      runInit: () => freshStore.getState().init(),
-      arrangeFailure: () => {
-        mocks.getSetting.mockRejectedValueOnce(new Error('db locked'))
-        mocks.addToast.mockImplementationOnce(() => {
-          throw new Error('notify failed')
-        })
-      },
-      arrangeSuccess: () => {
-        mocks.getSetting.mockResolvedValueOnce(null)
-      },
-      rejectMessage: 'notify failed',
-      assertAfterFailure: () => {
-        const state = freshStore.getState()
-        // set() already ran (with initialized: true) before addToast threw, so
-        // — unlike settings/notes/history/snippets/prompt-templates/api — a
-        // rejected mcp.store init() leaves `initialized` true, not false.
-        expect(state.initialized).toBe(true)
-        expect(state.status.lastError).toBe('db locked')
-      },
-      assertAfterSuccess: () => {
-        const state = freshStore.getState()
-        expect(state.initialized).toBe(true)
-        expect(state.status.lastError).toBeNull()
-      },
-      getCallCount: () => mocks.getSetting.mock.calls.length,
-    })
+    mocks.getSetting.mockRejectedValueOnce(new Error('db locked'))
+    await expect(freshStore.getState().init()).resolves.toBeUndefined()
+
+    const failedState = freshStore.getState()
+    expect(failedState.initialized).toBe(true)
+    expect(failedState.status.lastError).toBe('db locked')
+    expect(mocks.addToast).toHaveBeenCalledWith(
+      'Failed to initialize MCP server: db locked',
+      'error'
+    )
+    expect(mocks.getSetting).toHaveBeenCalledTimes(1)
+
+    mocks.getSetting.mockResolvedValueOnce(null)
+    await freshStore.getState().init()
+
+    expect(mocks.getSetting).toHaveBeenCalledTimes(2)
+    const successState = freshStore.getState()
+    expect(successState.initialized).toBe(true)
+    expect(successState.status.lastError).toBeNull()
   })
 })

--- a/apps/cockpit/src/stores/__tests__/mcp.store.test.ts
+++ b/apps/cockpit/src/stores/__tests__/mcp.store.test.ts
@@ -258,4 +258,29 @@ describe('useMcpStore', () => {
     expect(successState.initialized).toBe(true)
     expect(successState.status.lastError).toBeNull()
   })
+
+  // Regression guard for the subtler half of the same bug: a *synchronous* throw
+  // from getSetting() runs init()'s catch block during the IIFE's synchronous
+  // prologue, before `initPromise = ...` has finished assigning. Clearing
+  // `initPromise` from inside that catch is therefore immediately clobbered by the
+  // assignment and the retry silently never happens — the async-rejection test
+  // above passes either way and does not catch it. The clear lives in a `.then()`
+  // precisely so this case works too.
+  it('init() retries after a synchronous throw, not just a rejected promise', async () => {
+    const { useMcpStore: freshStore } = await import('@/stores/mcp.store')
+
+    mocks.getSetting.mockImplementationOnce(() => {
+      throw new Error('sync boom')
+    })
+    await expect(freshStore.getState().init()).resolves.toBeUndefined()
+
+    expect(freshStore.getState().status.lastError).toBe('sync boom')
+    expect(mocks.getSetting).toHaveBeenCalledTimes(1)
+
+    mocks.getSetting.mockResolvedValueOnce(null)
+    await freshStore.getState().init()
+
+    expect(mocks.getSetting).toHaveBeenCalledTimes(2)
+    expect(freshStore.getState().status.lastError).toBeNull()
+  })
 })

--- a/apps/cockpit/src/stores/api.store.ts
+++ b/apps/cockpit/src/stores/api.store.ts
@@ -20,6 +20,7 @@ const API_CLIENT_HISTORY_TOOL = 'api-client'
 const API_CLIENT_HISTORY_LIMIT = 30
 
 type ApiStore = {
+  initialized: boolean
   environments: ApiEnvironment[]
   collections: ApiCollection[]
   requests: ApiRequest[]
@@ -50,6 +51,7 @@ type ApiStore = {
 let initPromise: Promise<void> | null = null
 
 export const useApiStore = create<ApiStore>((set) => ({
+  initialized: false,
   environments: [],
   collections: [],
   requests: [],
@@ -66,6 +68,7 @@ export const useApiStore = create<ApiStore>((set) => ({
           loadHistory(API_CLIENT_HISTORY_TOOL, API_CLIENT_HISTORY_LIMIT),
         ])
         set({
+          initialized: true,
           environments: envs,
           collections: cols,
           requests: reqs,

--- a/apps/cockpit/src/stores/mcp.store.ts
+++ b/apps/cockpit/src/stores/mcp.store.ts
@@ -153,15 +153,27 @@ export const useMcpStore = create<McpStore>()((set, get) => ({
             initialized: true,
             status: { ...emptyStatus(settings), lastError: msg },
           })
-          useUiStore.getState().addToast('Failed to initialize MCP server: ' + msg, 'error')
+          // Clear the cached promise so a transient error doesn't latch the
+          // app in a broken state for the rest of the process lifetime — a
+          // later init() call retries. This assignment happens on the async
+          // continuation after the `await` calls above, which runs strictly
+          // after `initPromise = (async () => {...})()` has already
+          // completed synchronously below, so it is not immediately
+          // clobbered by that assignment.
+          initPromise = null
+          // MCP is an optional, disabled-by-default feature. init() must
+          // never reject: providers.tsx awaits it during bootstrap, and a
+          // rejection there sends the whole app to the startup error
+          // screen — strictly worse than a degraded MCP server. Guard the
+          // toast call too, so even an unexpected addToast failure can't
+          // turn this into an unhandled rejection.
+          try {
+            useUiStore.getState().addToast('Failed to initialize MCP server: ' + msg, 'error')
+          } catch {
+            // Swallow — see comment above.
+          }
         }
-      })().catch((err: unknown) => {
-        // Clear the cached promise on failure so a transient error doesn't
-        // latch the app in a broken state for the rest of the process
-        // lifetime — a later init() call retries.
-        initPromise = null
-        throw err
-      })
+      })()
     }
     return initPromise
   },

--- a/apps/cockpit/src/stores/mcp.store.ts
+++ b/apps/cockpit/src/stores/mcp.store.ts
@@ -134,6 +134,7 @@ export const useMcpStore = create<McpStore>()((set, get) => ({
 
   init: async () => {
     if (!initPromise) {
+      let failed = false
       initPromise = (async () => {
         let settings = normalizeSettings(null)
         try {
@@ -153,14 +154,7 @@ export const useMcpStore = create<McpStore>()((set, get) => ({
             initialized: true,
             status: { ...emptyStatus(settings), lastError: msg },
           })
-          // Clear the cached promise so a transient error doesn't latch the
-          // app in a broken state for the rest of the process lifetime — a
-          // later init() call retries. This assignment happens on the async
-          // continuation after the `await` calls above, which runs strictly
-          // after `initPromise = (async () => {...})()` has already
-          // completed synchronously below, so it is not immediately
-          // clobbered by that assignment.
-          initPromise = null
+          failed = true
           // MCP is an optional, disabled-by-default feature. init() must
           // never reject: providers.tsx awaits it during bootstrap, and a
           // rejection there sends the whole app to the startup error
@@ -173,7 +167,17 @@ export const useMcpStore = create<McpStore>()((set, get) => ({
             // Swallow — see comment above.
           }
         }
-      })()
+      })().then(() => {
+        // Clear the cached promise on failure so a transient error doesn't latch
+        // the app in a broken state for the rest of the process lifetime — a later
+        // init() call retries. This must happen in a `.then()` rather than inside
+        // the catch above: a *synchronous* throw from getSetting() runs that catch
+        // during the IIFE's synchronous prologue, i.e. before the
+        // `initPromise = ...` assignment completes, so clearing there would be
+        // immediately clobbered and the retry would never happen. A `.then()`
+        // callback is always a later microtask, so the assignment has landed.
+        if (failed) initPromise = null
+      })
     }
     return initPromise
   },

--- a/apps/cockpit/src/tools/__tests__/snippets.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/snippets.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderTool } from './test-utils'
 import { useSnippetsStore } from '@/stores/snippets.store'
@@ -498,5 +498,69 @@ describe('SnippetsManager — tag autocomplete', () => {
       await waitFor(() => expect(useUiStore.getState().lastAction?.message).toBe('Download failed'))
       expect(useUiStore.getState().lastAction?.type).toBe('error')
     })
+  })
+})
+
+describe('SnippetsManager — mutation error handling', () => {
+  // Capture the real store actions once, before any test overrides them, so
+  // each rejection test can restore the store to a working state afterward.
+  const realAdd = useSnippetsStore.getState().add
+  const realUpdate = useSnippetsStore.getState().update
+  const realRemove = useSnippetsStore.getState().remove
+
+  beforeEach(() => {
+    useUiStore.setState({ lastAction: null })
+    useSnippetsStore.setState({
+      snippets: [
+        {
+          id: '1',
+          title: 'Snippet A',
+          content: 'console.log("hi")',
+          language: 'javascript',
+          tags: [],
+          folder: '',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ],
+      initialized: true,
+    })
+  })
+
+  afterEach(() => {
+    useSnippetsStore.setState({ add: realAdd, update: realUpdate, remove: realRemove })
+  })
+
+  it('surfaces a failure when duplicating a snippet fails', async () => {
+    useSnippetsStore.setState({ add: vi.fn().mockRejectedValue(new Error('db locked')) })
+    renderTool(SnippetsManager)
+    fireEvent.click(screen.getByText('Snippet A').closest('button')!)
+    fireEvent.click(screen.getByText('[F6: DUP]'))
+
+    await waitFor(() => expect(useUiStore.getState().lastAction?.message).toBe('Duplicate failed'))
+    expect(useUiStore.getState().lastAction?.type).toBe('error')
+  })
+
+  it('surfaces a failure when toggling favorite fails', async () => {
+    useSnippetsStore.setState({ update: vi.fn().mockRejectedValue(new Error('db locked')) })
+    renderTool(SnippetsManager)
+    fireEvent.click(screen.getByText('Snippet A').closest('button')!)
+    fireEvent.click(screen.getByTitle('Add to favorites'))
+
+    await waitFor(() =>
+      expect(useUiStore.getState().lastAction?.message).toBe('Failed to update favorite')
+    )
+    expect(useUiStore.getState().lastAction?.type).toBe('error')
+  })
+
+  it('surfaces a failure when deleting a snippet fails', async () => {
+    useSnippetsStore.setState({ remove: vi.fn().mockRejectedValue(new Error('db locked')) })
+    renderTool(SnippetsManager)
+    fireEvent.click(screen.getByText('Snippet A').closest('button')!)
+    fireEvent.click(screen.getByText('[F8: DEL]'))
+    fireEvent.click(screen.getByText('[CONFIRM?]'))
+
+    await waitFor(() => expect(useUiStore.getState().lastAction?.message).toBe('Delete failed'))
+    expect(useUiStore.getState().lastAction?.type).toBe('error')
   })
 })

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -30,15 +30,10 @@ import {
   TextItalicIcon,
 } from '@phosphor-icons/react'
 
-// Markdown pipeline imports
-import { unified } from 'unified'
-import remarkParse from 'remark-parse'
-import remarkGfm from 'remark-gfm'
-import remarkRehype from 'remark-rehype'
-import rehypeStringify from 'rehype-stringify'
-import rehypeHighlight from 'rehype-highlight'
-import rehypeSanitize from 'rehype-sanitize'
-import { markdownSanitizeSchema } from '@/lib/markdown'
+// Shared markdown pipeline — see src/lib/markdown.ts for plugin order rationale.
+// Both this tool and the Notes drawer render through the same processor so they
+// cannot drift apart again.
+import { markdownProcessor } from '@/lib/markdown'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -402,16 +397,6 @@ const BASE_EXPORT_STYLES =
 
 const PRINT_STYLES = '@media print{body{margin:0}}' + BASE_EXPORT_STYLES
 
-// ─── Processor ───────────────────────────────────────────────────────
-
-const processor = unified()
-  .use(remarkParse)
-  .use(remarkGfm)
-  .use(remarkRehype, { allowDangerousHtml: false })
-  .use(rehypeSanitize, markdownSanitizeSchema)
-  .use(rehypeHighlight, { detect: true })
-  .use(rehypeStringify)
-
 // ─── Helpers ─────────────────────────────────────────────────────────
 
 function extractToc(html: string): TocEntry[] {
@@ -440,10 +425,13 @@ export function prefixMarkdownLines(text: string, prefix: string): string {
     .join('\n')
 }
 
-async function renderMarkdownContent(content: string): Promise<string> {
+// Exported for tests only — proves this entry point and processMarkdown()
+// (used by NotesDrawer) render identically since both call the same
+// `markdownProcessor` from src/lib/markdown.ts.
+export async function renderMarkdownContent(content: string): Promise<string> {
   if (!content.trim()) return ''
   try {
-    const result = await processor.process(content)
+    const result = await markdownProcessor.process(content)
     return String(result)
   } catch (e) {
     const msg = (e as Error).message

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -415,15 +415,19 @@ export default function SnippetsManager() {
 
   const handleDuplicate = useCallback(async () => {
     if (!selected) return
-    const snippet = await addSnippet(
-      selected.title + ' (copy)',
-      selected.content,
-      selected.language,
-      visibleTags(selected.tags),
-      selected.folder
-    )
-    setSelectedId(snippet.id)
-    setLastAction('Snippet duplicated', 'success')
+    try {
+      const snippet = await addSnippet(
+        selected.title + ' (copy)',
+        selected.content,
+        selected.language,
+        visibleTags(selected.tags),
+        selected.folder
+      )
+      setSelectedId(snippet.id)
+      setLastAction('Snippet duplicated', 'success')
+    } catch {
+      setLastAction('Duplicate failed', 'error')
+    }
   }, [selected, addSnippet, setLastAction])
 
   const handleDelete = useCallback(async () => {
@@ -438,22 +442,26 @@ export default function SnippetsManager() {
     if (confirmDeleteId === selectedId) {
       if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
       setConfirmDeleteId(null)
-      handleDelete().catch(() => {})
+      handleDelete().catch(() => setLastAction('Delete failed', 'error'))
     } else {
       setConfirmDeleteId(selectedId)
       if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
       confirmTimeoutRef.current = setTimeout(() => setConfirmDeleteId(null), 2500)
     }
-  }, [selectedId, confirmDeleteId, handleDelete])
+  }, [selectedId, confirmDeleteId, handleDelete, setLastAction])
 
   const handleToggleFavorite = useCallback(async () => {
     if (!selected) return
-    if (isFavorite(selected.tags)) {
-      await updateSnippet(selected.id, { tags: selected.tags.filter((t) => t !== FAVORITE_TAG) })
-    } else {
-      await updateSnippet(selected.id, { tags: [...selected.tags, FAVORITE_TAG] })
+    try {
+      if (isFavorite(selected.tags)) {
+        await updateSnippet(selected.id, { tags: selected.tags.filter((t) => t !== FAVORITE_TAG) })
+      } else {
+        await updateSnippet(selected.id, { tags: [...selected.tags, FAVORITE_TAG] })
+      }
+    } catch {
+      setLastAction('Failed to update favorite', 'error')
     }
-  }, [selected, updateSnippet])
+  }, [selected, updateSnippet, setLastAction])
 
   const handleAddTag = useCallback(async () => {
     if (!selected || !tagInput.trim()) return


### PR DESCRIPTION
## Summary

Fixes the four incidental issues discovered while working through the P2 backlog in PR #78. All four were filed in `documentation/TODO.md` at the time and are now marked complete with their reasoning recorded.

- **MCP server no longer gets stuck after a failed startup.** `mcp.store.init()` had a retry mechanism that never actually retried — the cached promise was never cleared, so every later attempt returned the original failed result. A transient failure (database locked, port busy) meant MCP stayed broken until the app was restarted.
- **Snippet actions now report failures.** Duplicating a snippet, toggling its favourite star, or deleting it could fail silently — the action just appeared not to happen. All three now surface an error message the same way export and download already did.
- **Markdown renders identically everywhere.** The Notes drawer and the Markdown Editor were running two separately-maintained rendering pipelines that had drifted apart. They now share one. Visible change: unlabelled code fences in Notes are syntax-highlighted now, matching the editor's behaviour.
- **`api.store` exposes an `initialized` flag**, consistent with the other stores.

## Notes for the reviewer

Two decisions deviate from what the TODO entries proposed, both recorded in `TODO.md`:

1. **MCP init still does not reject on failure.** The TODO suggested making it rethrow. It is the one store awaited directly in the bootstrap sequence, so rejecting would send the whole app to the startup error screen over an optional, disabled-by-default feature — worse than the bug. It resolves, flags the degraded state, and now genuinely retries next time.
2. **Sanitization runs last, not first.** The TODO called sanitize-then-highlight "the safer default"; that is backwards. Nothing should touch the tree after the sanitizer. The schema already permits the `hljs-`/`language-` classes highlighting emits, so nothing is lost.

The obvious way to fix the MCP retry — clearing the cached promise inside the `catch` — is subtly wrong: it works for a rejected promise but not for a synchronous throw, where the assignment clobbers the clear. The final commit moves the clear into a `.then()` and adds a regression test for that path specifically.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `bun run lint` — clean at `--max-warnings 0`
- [x] `bunx vitest run` — 81 files / 693 tests passing (baseline 687)
- [x] MCP retry verified by sabotage: moving the clear back into the `catch` fails the new synchronous-throw test and only that test
- [x] Nine XSS-shaped payloads (raw `<script>`, `onerror`, `javascript:`/`data:` hrefs, `<iframe>`, `<svg onload>`, inline `style`) checked through both markdown entry points — all stripped, output byte-identical between the two

🤖 Generated with [Claude Code](https://claude.com/claude-code)