### PR TITLE
fix(cockpit): fix markdown preview selection loss and add file open/save

### DIFF
--- a/apps/cockpit/.gitignore
+++ b/apps/cockpit/.gitignore
@@ -31,3 +31,6 @@ dist-ssr
 # Vite config emit
 /vite.config.js
 /vite.config.d.ts
+
+# Playwright MCP scratch output (browser harness — see documentation/BROWSER_HARNESS.md)
+.playwright-mcp/

--- a/apps/cockpit/.playwright-mcp/page-2026-08-12T14-54-36-658Z.yml
+++ b/apps/cockpit/.playwright-mcp/page-2026-08-12T14-54-36-658Z.yml
@@ -1,0 +1,3 @@
+- generic [ref=e3]:
+  - generic [ref=e4]: "Failed to initialize: TypeError: Cannot read properties of undefined (reading 'metadata')"
+  - button "Retry" [ref=e5]

--- a/apps/cockpit/.playwright-mcp/page-2026-08-12T14-54-36-658Z.yml
+++ b/apps/cockpit/.playwright-mcp/page-2026-08-12T14-54-36-658Z.yml
@@ -1,3 +1,0 @@
-- generic [ref=e3]:
-  - generic [ref=e4]: "Failed to initialize: TypeError: Cannot read properties of undefined (reading 'metadata')"
-  - button "Retry" [ref=e5]

--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -1,0 +1,118 @@
+# Browser Harness
+
+How to run the cockpit UI in a plain Chromium page for DOM-level debugging, and the diagnostic
+recipes that come with it.
+
+Vitest runs against jsdom/node and cannot reproduce anything involving real layout, real text
+selection, or the browser's own commit behaviour. The Tauri app can, but it is a black box —
+no DevTools protocol, no scripted input. This harness closes that gap: the same web bundle,
+served by `bun run dev`, driven from Chromium.
+
+## When to reach for it
+
+- Text selection, caret, or clipboard behaviour
+- Scroll/resize/layout bugs, measured rather than reasoned about
+- "It re-renders but I can't see why" — DOM mutation forensics
+- Anything you were about to explain with a theory instead of evidence
+
+Not for: file I/O, SQLite persistence, window/menu behaviour, or shortcuts that go through Rust.
+Those need the real app.
+
+## Setup
+
+The web bundle refuses to boot outside Tauri — the Tauri JS API reads `window.__TAURI_INTERNALS__`
+eagerly and throws `Cannot read properties of undefined (reading 'metadata')` before the shell
+mounts. [`scripts/tauri-browser-stub.js`](../scripts/tauri-browser-stub.js) provides the minimum
+stub to get past that.
+
+```bash
+bun run dev   # from apps/cockpit — serves on http://localhost:5173
+```
+
+```js
+import { installTauriStub } from './scripts/tauri-browser-stub.js'
+
+await page.addInitScript(installTauriStub) // must precede any page script
+await page.goto('http://localhost:5173')
+```
+
+Every SQL read returns empty, so stores start blank and nothing persists across a reload. Seed
+state through the UI.
+
+## Gotchas found the hard way
+
+- **Monaco needs time to settle.** Switching a tool into Split mode reflows the pane for a while
+  after the DOM looks ready. Measuring immediately produced a false "still broken" reading;
+  ~1800ms of settle time made Split, Preview, and back-to-Split all behave identically.
+- **Use `page.mouse` drags, not `dblclick`, to select prose.** A double-click landing on container
+  padding selects `"\n"` and looks like a failure. Drag across a paragraph's bounding box instead.
+- **Toolbar buttons collide by name.** `getByRole('button', { name: 'Templates' })` matched three
+  elements; pass `{ exact: true }`.
+
+## Recipe: who is rewriting my DOM?
+
+This pair is what identified the React 19 `dangerouslySetInnerHTML` bug (see below). Run both in the
+page, then reproduce the interaction.
+
+Trap `innerHTML` writes and capture the stack:
+
+```js
+const proto = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML')
+Object.defineProperty(Element.prototype, 'innerHTML', {
+  ...proto,
+  set(value) {
+    if (this.matches?.('.prose')) {
+      console.log('innerHTML write', {
+        len: value.length,
+        same: value === this.innerHTML, // `true` = a pointless rewrite
+        stack: new Error().stack,
+      })
+    }
+    proto.set.call(this, value)
+  },
+})
+```
+
+Watch the subtree and correlate with selection loss:
+
+```js
+new MutationObserver((records) => {
+  for (const r of records) {
+    console.log(r.type, [...r.removedNodes].map((n) => n.nodeName).join('/'))
+  }
+}).observe(document.querySelector('.prose'), { childList: true, subtree: true })
+
+document.addEventListener('selectionchange', () => {
+  const s = window.getSelection()
+  console.log(s.isCollapsed ? 'COLLAPSED' : 'range', s.toString().slice(0, 40))
+})
+```
+
+A `same: true` write immediately followed by `COLLAPSED` means something is re-setting identical
+markup and taking the selection with it.
+
+## The React 19 identity rule
+
+React 19's `updateProperties` compares `dangerouslySetInnerHTML` by **object identity**, not by the
+`__html` string inside it — React 18 compared the string. An inline `{ __html: html }` literal is a
+fresh object every render, so React re-sets `innerHTML` every render, rebuilding the whole subtree
+even when the markup is byte-identical. That destroys any text selection inside it.
+
+Always memoise the payload:
+
+```tsx
+const htmlProp = useMemo(() => ({ __html: html }), [html])
+return <div dangerouslySetInnerHTML={htmlProp} />
+```
+
+All five call sites in the app follow this pattern: `MarkdownPreview`, `NotesDrawer`,
+`MermaidEditor`, `RegexTester`, `DiffViewer`. Keep it that way when adding a sixth.
+
+The identity rule can be asserted in Vitest even though the selection bug itself cannot — re-render
+with the same `html` and check the DOM node is the same object:
+
+```tsx
+const paragraph = container.querySelector('p')
+rerender(<MarkdownPreview html={html} /* ...changed sibling prop... */ />)
+expect(container.querySelector('p')).toBe(paragraph)
+```

--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -26,14 +26,14 @@ mounts. [`scripts/tauri-browser-stub.js`](../scripts/tauri-browser-stub.js) prov
 stub to get past that.
 
 ```bash
-bun run dev   # from apps/cockpit — serves on http://localhost:5173
+bun run dev   # from apps/cockpit — serves on http://localhost:1420
 ```
 
 ```js
 import { installTauriStub } from './scripts/tauri-browser-stub.js'
 
 await page.addInitScript(installTauriStub) // must precede any page script
-await page.goto('http://localhost:5173')
+await page.goto('http://localhost:1420')
 ```
 
 Every SQL read returns empty, so stores start blank and nothing persists across a reload. Seed
@@ -44,8 +44,14 @@ state through the UI.
 - **Monaco needs time to settle.** Switching a tool into Split mode reflows the pane for a while
   after the DOM looks ready. Measuring immediately produced a false "still broken" reading;
   ~1800ms of settle time made Split, Preview, and back-to-Split all behave identically.
-- **Use `page.mouse` drags, not `dblclick`, to select prose.** A double-click landing on container
-  padding selects `"\n"` and looks like a failure. Drag across a paragraph's bounding box instead.
+- **Aim drags near the top of a paragraph's box, not its vertical centre.** `prose` line-height and
+  margins make a one-line `<p>` report a box roughly twice the height of its text, so `y + height/2`
+  lands in empty space below the line and selects nothing — which reads exactly like "the selection
+  bug is back". `y + 12` works. Cross-check with `page.mouse.dblclick`, which is less sensitive to
+  this (though a double-click on container padding selects `"\n"` and looks like its own failure).
+- **Confirm the DOM can hold a selection at all** before believing a negative result: set a `Range`
+  programmatically and re-read it after a delay. If that holds but your synthetic input doesn't, the
+  bug is in your coordinates, not in the app.
 - **Toolbar buttons collide by name.** `getByRole('button', { name: 'Templates' })` matched three
   elements; pass `{ exact: true }`.
 

--- a/apps/cockpit/documentation/README.md
+++ b/apps/cockpit/documentation/README.md
@@ -14,14 +14,15 @@ Welcome to the devdrivr cockpit documentation. This directory contains all the d
 8. [PERFORMANCE.md](PERFORMANCE.md) - Performance optimization guidelines
 9. [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) - Visual design language, theming, and CSS tokens
 10. [TESTING.md](TESTING.md) - Testing documentation and best practices
-11. [../CONTRIBUTING.md](../CONTRIBUTING.md) - Contribution guidelines for the project (lives at `apps/cockpit/CONTRIBUTING.md`)
-12. [QUICK_START.md](QUICK_START.md) - Quick start guide for new users
-13. [USER_GUIDE.md](USER_GUIDE.md) - Comprehensive user guide
-14. [MCP_SERVER.md](MCP_SERVER.md) - Local MCP server setup and agent usage
-15. [STYLE_GUIDE.md](STYLE_GUIDE.md) - Documentation style guidelines
-16. [TODO.md](TODO.md) - Active quality/reliability backlog (current source of truth for in-progress work)
-17. [COCKPIT_STATE_AND_ROADMAP.md](COCKPIT_STATE_AND_ROADMAP.md) - Historical state review and roadmap (2026-06-12; see TODO.md for current status)
-18. [infrastructure/](infrastructure/) - Core infrastructure documentation
+11. [BROWSER_HARNESS.md](BROWSER_HARNESS.md) - Running the UI in Chromium for DOM-level debugging
+12. [../CONTRIBUTING.md](../CONTRIBUTING.md) - Contribution guidelines for the project (lives at `apps/cockpit/CONTRIBUTING.md`)
+13. [QUICK_START.md](QUICK_START.md) - Quick start guide for new users
+14. [USER_GUIDE.md](USER_GUIDE.md) - Comprehensive user guide
+15. [MCP_SERVER.md](MCP_SERVER.md) - Local MCP server setup and agent usage
+16. [STYLE_GUIDE.md](STYLE_GUIDE.md) - Documentation style guidelines
+17. [TODO.md](TODO.md) - Active quality/reliability backlog (current source of truth for in-progress work)
+18. [COCKPIT_STATE_AND_ROADMAP.md](COCKPIT_STATE_AND_ROADMAP.md) - Historical state review and roadmap (2026-06-12; see TODO.md for current status)
+19. [infrastructure/](infrastructure/) - Core infrastructure documentation
 
 ## Overview
 

--- a/apps/cockpit/scripts/tauri-browser-stub.js
+++ b/apps/cockpit/scripts/tauri-browser-stub.js
@@ -1,0 +1,49 @@
+/**
+ * Minimal `window.__TAURI_INTERNALS__` stub so the cockpit web bundle boots in a
+ * plain Chromium page (Playwright, DevTools MCP, `vite dev` in a normal browser).
+ *
+ * Without it the app throws `Cannot read properties of undefined (reading
+ * 'metadata')` during startup: the Tauri JS API reads `__TAURI_INTERNALS__`
+ * eagerly, and the SQL plugin calls fail before the shell ever mounts.
+ *
+ * Scope: enough to *render* the UI for DOM-level debugging (selection, layout,
+ * re-render behaviour). Persistence is faked — every SQL read returns empty, so
+ * stores start blank and nothing survives a reload. Not a substitute for
+ * running the real app when testing anything that touches disk or the DB.
+ *
+ * Usage with Playwright (must run before any page script):
+ *
+ *   import { installTauriStub } from './scripts/tauri-browser-stub.js'
+ *   await page.addInitScript(installTauriStub)
+ *   await page.goto('http://localhost:5173')
+ *
+ * Usage from the Playwright MCP `browser_run_code_unsafe` tool: paste the body
+ * of `installTauriStub` into an `addInitScript` call — it is deliberately
+ * self-contained and dependency-free so it survives copy/paste.
+ *
+ * See documentation/BROWSER_HARNESS.md for the full workflow.
+ */
+export function installTauriStub() {
+  const invoke = async (cmd) => {
+    if (cmd === 'plugin:sql|load') return 'sqlite:cockpit.db'
+    if (cmd === 'plugin:sql|select') return []
+    if (cmd === 'plugin:sql|execute') return [0, 0]
+    if (cmd === 'plugin:event|listen') return 1
+    return null
+  }
+
+  window.__TAURI_INTERNALS__ = {
+    invoke,
+    transformCallback: (cb) => {
+      const id = Math.floor(Math.random() * 1e9)
+      window['_' + id] = cb
+      return id
+    },
+    metadata: {
+      currentWindow: { label: 'main' },
+      currentWebview: { windowLabel: 'main', label: 'main' },
+    },
+  }
+
+  window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} }
+}

--- a/apps/cockpit/src/components/shared/__tests__/SelectionContextToolbar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SelectionContextToolbar.test.tsx
@@ -76,6 +76,19 @@ function MonacoSelectionHarness({ onSelect }: { onSelect: (text: string) => void
 
 beforeEach(() => {
   window.getSelection()?.removeAllRanges()
+  // jsdom has no rAF — run the callback synchronously so scroll/resize
+  // repositioning in useDomSelectionToolbar can be asserted without a real frame.
+  Object.defineProperty(globalThis, 'requestAnimationFrame', {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    },
+  })
+  Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+    configurable: true,
+    value: () => {},
+  })
 })
 
 describe('SelectionContextToolbar', () => {
@@ -136,5 +149,38 @@ describe('SelectionContextToolbar', () => {
     await waitFor(() =>
       expect(screen.queryByRole('toolbar', { name: 'Selection actions' })).not.toBeInTheDocument()
     )
+  })
+
+  it('keeps the live DOM selection across scroll/resize but drops it on explicit dismiss', async () => {
+    const onSelect = vi.fn()
+    render(<SelectionHarness onSelect={onSelect} />)
+
+    const textNode = screen.getByTestId('selectable-text').firstChild
+    expect(textNode).not.toBeNull()
+
+    const range = document.createRange()
+    range.selectNodeContents(textNode!)
+    range.getBoundingClientRect = () => new window.DOMRect(100, 100, 140, 18)
+
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    fireEvent.mouseUp(document)
+
+    await screen.findByRole('toolbar', { name: 'Selection actions' })
+    expect(window.getSelection()?.rangeCount).toBe(1)
+
+    act(() => {
+      fireEvent.scroll(window, { target: { scrollY: 100 } })
+    })
+    expect(window.getSelection()?.rangeCount).toBe(1)
+
+    act(() => {
+      fireEvent.resize(window)
+    })
+    expect(window.getSelection()?.rangeCount).toBe(1)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(window.getSelection()?.rangeCount).toBe(0))
   })
 })

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -91,10 +91,15 @@ function MarkdownRenderer({ content }: { content: string }) {
     }
   }, [content])
 
+  // Stable identity — React 19 compares `dangerouslySetInnerHTML` by object
+  // identity, not by the `__html` string, so an inline literal re-writes
+  // innerHTML on every render and wipes any text selection inside the note.
+  const htmlProp = useMemo(() => ({ __html: html }), [html])
+
   return (
     <div
       className="prose prose-xs max-w-none overflow-hidden text-xs text-[var(--color-text)]"
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={htmlProp}
     />
   )
 }

--- a/apps/cockpit/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/apps/cockpit/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -223,6 +223,7 @@ describe('useGlobalShortcuts', () => {
     mocks.openFileDialog.mockResolvedValue({
       content: '{"valid":true}',
       filename: 'example.json',
+      path: '/tmp/example.json',
     })
     renderShortcuts()
 
@@ -234,6 +235,7 @@ describe('useGlobalShortcuts', () => {
       type: 'open-file',
       content: '{"valid":true}',
       filename: 'example.json',
+      path: '/tmp/example.json',
     })
     expect(mocks.addToast).toHaveBeenCalledWith('Opened example.json', 'success')
   })

--- a/apps/cockpit/src/hooks/useDomSelectionToolbar.ts
+++ b/apps/cockpit/src/hooks/useDomSelectionToolbar.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
 import type { SelectionToolbarState } from '@/components/shared/SelectionContextToolbar'
 
 export function useDomSelectionToolbar(
@@ -6,6 +6,7 @@ export function useDomSelectionToolbar(
   enabled: boolean
 ) {
   const [selection, setSelection] = useState<SelectionToolbarState | null>(null)
+  const rafRef = useRef<number | null>(null)
 
   const clearSelection = useCallback(() => {
     window.getSelection()?.removeAllRanges()
@@ -46,6 +47,17 @@ export function useDomSelectionToolbar(
     setSelection({ text, rect })
   }, [containerRef, enabled])
 
+  // Scroll/resize must only reposition the toolbar from the live selection —
+  // never destroy the user's actual DOM selection (removeAllRanges). Throttled
+  // via requestAnimationFrame since scroll/resize can fire at high frequency.
+  const repositionSelection = useCallback(() => {
+    if (rafRef.current !== null) return
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null
+      updateSelection()
+    })
+  }, [updateSelection])
+
   useEffect(() => {
     if (!enabled) {
       setSelection(null)
@@ -55,17 +67,21 @@ export function useDomSelectionToolbar(
     document.addEventListener('selectionchange', updateSelection)
     document.addEventListener('mouseup', updateSelection)
     document.addEventListener('keyup', updateSelection)
-    window.addEventListener('scroll', clearSelection, true)
-    window.addEventListener('resize', clearSelection)
+    window.addEventListener('scroll', repositionSelection, true)
+    window.addEventListener('resize', repositionSelection)
 
     return () => {
       document.removeEventListener('selectionchange', updateSelection)
       document.removeEventListener('mouseup', updateSelection)
       document.removeEventListener('keyup', updateSelection)
-      window.removeEventListener('scroll', clearSelection, true)
-      window.removeEventListener('resize', clearSelection)
+      window.removeEventListener('scroll', repositionSelection, true)
+      window.removeEventListener('resize', repositionSelection)
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
     }
-  }, [clearSelection, enabled, updateSelection])
+  }, [enabled, repositionSelection, updateSelection])
 
   return { selection, clearSelection }
 }

--- a/apps/cockpit/src/hooks/useGlobalShortcuts.ts
+++ b/apps/cockpit/src/hooks/useGlobalShortcuts.ts
@@ -94,6 +94,7 @@ export function useGlobalShortcuts(): void {
           type: 'open-file',
           content: result.content,
           filename: result.filename,
+          path: result.path,
         })
         addToast(`Opened ${result.filename}`, 'success')
       }

--- a/apps/cockpit/src/lib/__tests__/file-io.test.ts
+++ b/apps/cockpit/src/lib/__tests__/file-io.test.ts
@@ -10,6 +10,7 @@ import {
   readSupportedTextFile,
   sanitizeExportBasename,
   saveFileDialog,
+  saveFileToPath,
 } from '@/lib/file-io'
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
@@ -45,6 +46,7 @@ describe('file I/O', () => {
     await expect(openFileDialog()).resolves.toEqual({
       content: '{"ok":true}',
       filename: 'example.json',
+      path: '/tmp/example.json',
     })
   })
 
@@ -89,6 +91,21 @@ describe('file I/O', () => {
     vi.mocked(writeTextFile).mockRejectedValue(new Error('disk full'))
 
     await expect(saveFileDialog('content')).rejects.toThrow('disk full')
+  })
+
+  describe('saveFileToPath', () => {
+    it('writes content directly to the given path without a dialog', async () => {
+      await saveFileToPath('/tmp/existing.md', '# hello')
+
+      expect(save).not.toHaveBeenCalled()
+      expect(writeTextFile).toHaveBeenCalledWith('/tmp/existing.md', '# hello')
+    })
+
+    it('propagates write errors to callers for user feedback', async () => {
+      vi.mocked(writeTextFile).mockRejectedValue(new Error('disk full'))
+
+      await expect(saveFileToPath('/tmp/existing.md', 'content')).rejects.toThrow('disk full')
+    })
   })
 
   describe('sanitizeExportBasename / buildExportFilename', () => {

--- a/apps/cockpit/src/lib/__tests__/inner-html-identity.test.ts
+++ b/apps/cockpit/src/lib/__tests__/inner-html-identity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// React 19 compares `dangerouslySetInnerHTML` by object identity, not by the
+// `__html` string inside it (React 18 compared the string). An inline object
+// literal is therefore a new value every render, so React re-sets innerHTML on
+// every render — rebuilding the subtree and destroying any text selection the
+// user has made inside it. Every call site must pass a memoised object.
+//
+// See documentation/BROWSER_HARNESS.md § The React 19 identity rule.
+
+const SRC_ROOT = fileURLToPath(new URL('../..', import.meta.url))
+
+function sourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue
+      files.push(...sourceFiles(full))
+    } else if (entry.name.endsWith('.tsx')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe('dangerouslySetInnerHTML', () => {
+  it('is never passed an inline object literal', () => {
+    const offenders = sourceFiles(SRC_ROOT).filter((file) =>
+      readFileSync(file, 'utf8').includes('dangerouslySetInnerHTML={{')
+    )
+
+    expect(offenders.map((f) => f.slice(SRC_ROOT.length))).toEqual([])
+  })
+})

--- a/apps/cockpit/src/lib/__tests__/markdown.test.ts
+++ b/apps/cockpit/src/lib/__tests__/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import rehypeSanitize from 'rehype-sanitize'
-import { processMarkdown, markdownSanitizeSchema } from '@/lib/markdown'
+import { processMarkdown, markdownSanitizeSchema, markdownEditorProcessor } from '@/lib/markdown'
 import { renderMarkdownContent } from '@/tools/markdown-editor/MarkdownEditor'
 
 // `hast` types aren't a direct dependency here (only pulled in transitively by
@@ -189,5 +189,31 @@ describe('markdownSanitizeSchema', () => {
     expect(el?.type).toBe('element')
     expect(el?.type === 'element' && el.properties.type).toBe('checkbox')
     expect(el?.type === 'element' && el.properties.checked).toBe(true)
+  })
+})
+
+describe('markdownEditorProcessor', () => {
+  const TASKS = '- [ ] one\n- [x] two\n'
+
+  // Browsers do not dispatch click events from disabled form controls, so a
+  // `disabled` checkbox is unclickable in the real app — but `fireEvent.click`
+  // in jsdom fires on one regardless. These assertions pin the rendered
+  // attribute itself, which is the only thing that actually decides whether the
+  // preview's task-toggle feature works.
+  it('renders task-list checkboxes enabled so the preview can toggle them', async () => {
+    const html = String(await markdownEditorProcessor.process(TASKS))
+    expect(html).toContain('<input type="checkbox">')
+    expect(html).toContain('<input type="checkbox" checked>')
+    expect(html).not.toContain('disabled')
+  })
+
+  it('leaves the shared pipeline rendering disabled checkboxes', async () => {
+    const html = await processMarkdown(TASKS)
+    expect(html).toContain('disabled')
+  })
+
+  it('still restricts inputs to checkboxes', async () => {
+    const html = String(await markdownEditorProcessor.process(TASKS))
+    expect(html).not.toContain('type="text"')
   })
 })

--- a/apps/cockpit/src/lib/file-io.ts
+++ b/apps/cockpit/src/lib/file-io.ts
@@ -31,7 +31,11 @@ export async function readSupportedTextFile(filePath: string): Promise<string> {
   return content
 }
 
-export async function openFileDialog(): Promise<{ content: string; filename: string } | null> {
+export async function openFileDialog(): Promise<{
+  content: string
+  filename: string
+  path: string
+} | null> {
   const path = await open({
     multiple: false,
     filters: [
@@ -63,7 +67,12 @@ export async function openFileDialog(): Promise<{ content: string; filename: str
   const filePath = typeof path === 'string' ? path : path[0]
   if (!filePath) return null
   const content = await readSupportedTextFile(filePath)
-  return { content, filename: filenameFromPath(filePath) }
+  return { content, filename: filenameFromPath(filePath), path: filePath }
+}
+
+/** Writes content directly to a known absolute path — no dialog shown. */
+export async function saveFileToPath(path: string, content: string): Promise<void> {
+  await writeTextFile(path, content)
 }
 
 export async function saveFileDialog(

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -64,3 +64,38 @@ export async function processMarkdown(content: string): Promise<string> {
   const file = await markdownProcessor.process(content)
   return String(file)
 }
+
+/**
+ * Editor-only variant of `markdownSanitizeSchema` that drops the
+ * `['disabled', true]` allowlist entry for GFM task-list checkboxes, so the
+ * `disabled` attribute remark-gfm always emits gets stripped by the
+ * sanitizer instead of surviving. This deliberately does NOT touch
+ * `markdownSanitizeSchema`/`markdownProcessor` — the Notes drawer (and any
+ * other future surface) keeps rendering dead, disabled checkboxes via the
+ * shared pipeline above. Only the Markdown Editor preview, which needs
+ * clickable checkboxes that write back to the source, uses this variant.
+ */
+export const markdownEditorSanitizeSchema = {
+  ...markdownSanitizeSchema,
+  attributes: {
+    ...markdownSanitizeSchema.attributes,
+    input: [
+      ['type', 'checkbox'] as [string, ...Array<string | boolean>],
+      ...(defaultSchema.attributes?.['input'] ?? []),
+      'checked',
+    ],
+  },
+}
+
+export const markdownEditorProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(rehypeHighlight, { detect: true })
+  .use(rehypeSanitize, markdownEditorSanitizeSchema)
+  .use(rehypeStringify)
+
+export async function processMarkdownForEditor(content: string): Promise<string> {
+  const file = await markdownEditorProcessor.process(content)
+  return String(file)
+}

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -66,24 +66,38 @@ export async function processMarkdown(content: string): Promise<string> {
 }
 
 /**
- * Editor-only variant of `markdownSanitizeSchema` that drops the
- * `['disabled', true]` allowlist entry for GFM task-list checkboxes, so the
- * `disabled` attribute remark-gfm always emits gets stripped by the
- * sanitizer instead of surviving. This deliberately does NOT touch
- * `markdownSanitizeSchema`/`markdownProcessor` — the Notes drawer (and any
- * other future surface) keeps rendering dead, disabled checkboxes via the
- * shared pipeline above. Only the Markdown Editor preview, which needs
- * clickable checkboxes that write back to the source, uses this variant.
+ * Editor-only variant of `markdownSanitizeSchema` that renders GFM task-list
+ * checkboxes *enabled*, so the Markdown Editor preview can toggle them. This
+ * deliberately does NOT touch `markdownSanitizeSchema`/`markdownProcessor` —
+ * the Notes drawer (and any other future surface) keeps rendering dead,
+ * disabled checkboxes via the shared pipeline above.
+ *
+ * Dropping `disabled` takes two changes, and *both* are required — omitting the
+ * attribute entry alone is a no-op:
+ *
+ *  1. `attributes.input` must not allow `disabled` at all. That means listing
+ *     the permitted attributes explicitly rather than spreading
+ *     `defaultSchema.attributes.input`, which itself contains
+ *     `['disabled', true]`.
+ *  2. `required.input` must drop `disabled`. hast-util-sanitize's `required`
+ *     map *adds back* any listed attribute that is missing after filtering, and
+ *     `defaultSchema.required` is `{ input: { disabled: true, type: 'checkbox' } }`
+ *     — so the sanitizer re-attaches `disabled` even once the allowlist is
+ *     clean.
+ *
+ * This matters beyond cosmetics: browsers do not dispatch click events from
+ * disabled form controls, so a `disabled` checkbox is unclickable in the real
+ * app even though `fireEvent.click` in jsdom happily fires on one.
  */
 export const markdownEditorSanitizeSchema = {
   ...markdownSanitizeSchema,
   attributes: {
     ...markdownSanitizeSchema.attributes,
-    input: [
-      ['type', 'checkbox'] as [string, ...Array<string | boolean>],
-      ...(defaultSchema.attributes?.['input'] ?? []),
-      'checked',
-    ],
+    input: [['type', 'checkbox'] as [string, ...Array<string | boolean>], 'checked'],
+  },
+  required: {
+    ...defaultSchema.required,
+    input: { type: 'checkbox' },
   },
 }
 
@@ -94,8 +108,3 @@ export const markdownEditorProcessor = unified()
   .use(rehypeHighlight, { detect: true })
   .use(rehypeSanitize, markdownEditorSanitizeSchema)
   .use(rehypeStringify)
-
-export async function processMarkdownForEditor(content: string): Promise<string> {
-  const file = await markdownEditorProcessor.process(content)
-  return String(file)
-}

--- a/apps/cockpit/src/lib/tool-actions.ts
+++ b/apps/cockpit/src/lib/tool-actions.ts
@@ -9,7 +9,7 @@ export type ToolAction =
   | { type: 'execute' }
   | { type: 'copy-output' }
   | { type: 'switch-tab'; tab: number }
-  | { type: 'open-file'; content: string; filename: string }
+  | { type: 'open-file'; content: string; filename: string; path?: string }
   | { type: 'save-file' }
   | { type: 'send-to'; content: string }
 

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -20,6 +20,7 @@ import {
   renumberOrderedListAround,
   renumberAroundIndex,
 } from '@/tools/markdown-editor/list-editing'
+import { toggleTaskAtIndex, countTasks } from '@/tools/markdown-editor/task-list'
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -676,5 +677,121 @@ describe('list-editing: renumberAroundIndex', () => {
   it('is a no-op when neither neighbour is an ordered item at the given indent', () => {
     const lines = ['- a', '  1. b', '- c']
     expect(renumberAroundIndex(lines, 1, '')).toEqual(lines)
+  })
+})
+
+describe('task-list: toggleTaskAtIndex', () => {
+  it('toggles unchecked to checked', () => {
+    expect(toggleTaskAtIndex('- [ ] one', 0)).toBe('- [x] one')
+  })
+
+  it('toggles checked to unchecked', () => {
+    expect(toggleTaskAtIndex('- [x] one', 0)).toBe('- [ ] one')
+  })
+
+  it('handles uppercase X as checked', () => {
+    expect(toggleTaskAtIndex('- [X] one', 0)).toBe('- [ ] one')
+  })
+
+  it('toggles nested/indented tasks', () => {
+    const content = '- [ ] parent\n  - [ ] child'
+    expect(toggleTaskAtIndex(content, 1)).toBe('- [ ] parent\n  - [x] child')
+  })
+
+  it('toggles by source-order index across multiple tasks', () => {
+    const content = '- [ ] one\n- [ ] two\n- [x] three'
+    expect(toggleTaskAtIndex(content, 1)).toBe('- [ ] one\n- [x] two\n- [x] three')
+    expect(toggleTaskAtIndex(content, 2)).toBe('- [ ] one\n- [ ] two\n- [ ] three')
+  })
+
+  it('ignores task-like text inside fenced code blocks', () => {
+    const content = '- [ ] real task\n```\n- [ ] fake task\n```\n- [ ] another real task'
+    // Index 1 should hit "another real task", not the one inside the fence.
+    expect(toggleTaskAtIndex(content, 1)).toBe(
+      '- [ ] real task\n```\n- [ ] fake task\n```\n- [x] another real task'
+    )
+  })
+
+  it('does not touch a checkbox-shaped string inside inline code', () => {
+    const content = '- `[ ]` not a task\n- [ ] real task'
+    expect(toggleTaskAtIndex(content, 0)).toBe('- `[ ]` not a task\n- [x] real task')
+  })
+
+  it('leaves content unchanged for an out-of-range index', () => {
+    const content = '- [ ] one'
+    expect(toggleTaskAtIndex(content, 5)).toBe(content)
+    expect(toggleTaskAtIndex(content, -1)).toBe(content)
+  })
+})
+
+describe('task-list: countTasks', () => {
+  it('counts task items and excludes fenced code blocks', () => {
+    const content = '- [ ] one\n```\n- [ ] fake\n```\n- [x] two'
+    expect(countTasks(content)).toBe(2)
+  })
+
+  it('returns 0 when there are no task items', () => {
+    expect(countTasks('- bullet\n1. ordered\n> quote')).toBe(0)
+  })
+})
+
+describe('MarkdownPreview task checkbox interaction', () => {
+  it('renders checkboxes enabled (not disabled) so they are clickable', () => {
+    render(
+      <MarkdownPreview
+        html={'<ul><li><input type="checkbox"> task</li></ul>'}
+        showToc={false}
+        toc={[]}
+      />
+    )
+    expect(screen.getByRole('checkbox')).not.toBeDisabled()
+  })
+
+  it('calls onToggleTask with the source-order index when a checkbox is clicked', () => {
+    const onToggleTask = vi.fn()
+    render(
+      <MarkdownPreview
+        html={
+          '<ul><li><input type="checkbox"> one</li>' +
+          '<li><input type="checkbox" checked> two</li></ul>'
+        }
+        showToc={false}
+        toc={[]}
+        onToggleTask={onToggleTask}
+      />
+    )
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[1]!)
+    expect(onToggleTask).toHaveBeenCalledWith(1)
+  })
+
+  it('toggles via Enter for keyboard accessibility', () => {
+    const onToggleTask = vi.fn()
+    render(
+      <MarkdownPreview
+        html={'<ul><li><input type="checkbox"> task</li></ul>'}
+        showToc={false}
+        toc={[]}
+        onToggleTask={onToggleTask}
+      />
+    )
+    fireEvent.keyDown(screen.getByRole('checkbox'), { key: 'Enter' })
+    expect(onToggleTask).toHaveBeenCalledWith(0)
+  })
+})
+
+describe('MarkdownEditor task checkbox end-to-end', () => {
+  it('clicking a checkbox in the preview toggles it in the source content', async () => {
+    renderTool(MarkdownEditor)
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: '- [ ] one\n- [ ] two' },
+    })
+
+    await waitFor(() => expect(screen.getAllByRole('checkbox')).toHaveLength(2))
+    fireEvent.click(screen.getAllByRole('checkbox')[1]!)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('monaco-editor')).toHaveValue('- [ ] one\n- [x] two')
+    )
   })
 })

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -21,6 +21,7 @@ import {
   renumberAroundIndex,
 } from '@/tools/markdown-editor/list-editing'
 import { toggleTaskAtIndex, countTasks } from '@/tools/markdown-editor/task-list'
+import { isUrl, tsvToMarkdownTable } from '@/tools/markdown-editor/paste-helpers'
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -732,6 +733,52 @@ describe('task-list: countTasks', () => {
 
   it('returns 0 when there are no task items', () => {
     expect(countTasks('- bullet\n1. ordered\n> quote')).toBe(0)
+  })
+})
+
+describe('paste-helpers: isUrl', () => {
+  it('accepts bare http/https URLs', () => {
+    expect(isUrl('https://example.com')).toBe(true)
+    expect(isUrl('http://example.com/path?query=1')).toBe(true)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(isUrl('  https://example.com  ')).toBe(true)
+  })
+
+  it('rejects non-URL text and unsupported protocols', () => {
+    expect(isUrl('not a url')).toBe(false)
+    expect(isUrl('ftp://example.com')).toBe(false)
+    expect(isUrl('https://example.com has trailing text')).toBe(false)
+    expect(isUrl('')).toBe(false)
+  })
+})
+
+describe('paste-helpers: tsvToMarkdownTable', () => {
+  it('converts a 2x2 TSV grid into a GFM table with a header', () => {
+    expect(tsvToMarkdownTable('Name\tAge\nAlice\t30\nBob\t25')).toBe(
+      '| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |'
+    )
+  })
+
+  it('escapes pipe characters in cell content', () => {
+    expect(tsvToMarkdownTable('A|B\tC\n1\t2|3')).toBe('| A\\|B | C |\n| --- | --- |\n| 1 | 2\\|3 |')
+  })
+
+  it('returns null for a single row (no data)', () => {
+    expect(tsvToMarkdownTable('Name\tAge')).toBeNull()
+  })
+
+  it('returns null for single-column data', () => {
+    expect(tsvToMarkdownTable('Name\nAlice\nBob')).toBeNull()
+  })
+
+  it('returns null for ragged rows with inconsistent column counts', () => {
+    expect(tsvToMarkdownTable('Name\tAge\nAlice\t30\tExtra')).toBeNull()
+  })
+
+  it('returns null for a lone URL / plain single-line text', () => {
+    expect(tsvToMarkdownTable('https://example.com')).toBeNull()
   })
 })
 

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -10,7 +10,7 @@ import { ImageModal } from '@/tools/markdown-editor/modals/ImageModal'
 import { useSettingsStore } from '@/stores/settings.store'
 import { DEFAULT_SETTINGS } from '@/types/models'
 import { dispatchToolAction } from '@/lib/tool-actions'
-import { saveFileDialog } from '@/lib/file-io'
+import { openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -23,6 +23,9 @@ vi.mock('mermaid', () => ({
 
 vi.mock('@/lib/file-io', () => ({
   saveFileDialog: vi.fn(),
+  saveFileToPath: vi.fn(),
+  openFileDialog: vi.fn(),
+  filenameFromPath: (path: string) => path.split(/[\\/]/).pop() || path,
 }))
 
 function deferred<T>() {
@@ -78,6 +81,89 @@ describe('MarkdownEditor', () => {
     await waitFor(() =>
       expect(saveFileDialog).toHaveBeenCalledWith('# Opened document', 'opened.md')
     )
+  })
+
+  it('File dropdown renders Open, Save, and Save As entries', () => {
+    renderTool(MarkdownEditor)
+    fireEvent.click(screen.getByText('File'))
+    expect(screen.getByText('Open…')).toBeInTheDocument()
+    expect(screen.getByText('Save')).toBeInTheDocument()
+    expect(screen.getByText('Save As…')).toBeInTheDocument()
+  })
+
+  it('File > Open… populates content, fileName, and filePath', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue({
+      content: '# From disk',
+      filename: 'notes.md',
+      path: '/tmp/notes.md',
+    })
+    renderTool(MarkdownEditor)
+
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Open…'))
+
+    await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
+    expect(screen.getByTestId('file-name')).toHaveTextContent('notes.md')
+  })
+
+  it('File > Save writes directly to a known filePath without opening the save dialog', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue({
+      content: '# From disk',
+      filename: 'notes.md',
+      path: '/tmp/notes.md',
+    })
+    vi.mocked(saveFileToPath).mockResolvedValue(undefined)
+    renderTool(MarkdownEditor)
+
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Open…'))
+    await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
+
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(saveFileToPath).toHaveBeenCalledWith('/tmp/notes.md', '# From disk'))
+    expect(saveFileDialog).not.toHaveBeenCalled()
+  })
+
+  it('File > Save falls back to the Save As dialog when no filePath is known', async () => {
+    vi.mocked(saveFileDialog).mockResolvedValue('/tmp/document.md')
+    renderTool(MarkdownEditor)
+
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: '# Untitled' },
+    })
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(saveFileDialog).toHaveBeenCalledWith('# Untitled', 'document.md'))
+    expect(saveFileToPath).not.toHaveBeenCalled()
+  })
+
+  it('shows a dirty indicator after editing and clears it after saving', async () => {
+    vi.mocked(openFileDialog).mockResolvedValue({
+      content: '# From disk',
+      filename: 'notes.md',
+      path: '/tmp/notes.md',
+    })
+    vi.mocked(saveFileToPath).mockResolvedValue(undefined)
+    renderTool(MarkdownEditor)
+
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Open…'))
+    await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
+    expect(screen.getByTestId('file-name')).toHaveTextContent('notes.md')
+    expect(screen.getByTestId('file-name').textContent).not.toContain('•')
+
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: '# Edited' },
+    })
+    await waitFor(() => expect(screen.getByTestId('file-name').textContent).toContain('•'))
+
+    fireEvent.click(screen.getByText('File'))
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(screen.getByTestId('file-name').textContent).not.toContain('•'))
   })
 
   it('shows word count stats', () => {

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -11,6 +11,15 @@ import { useSettingsStore } from '@/stores/settings.store'
 import { DEFAULT_SETTINGS } from '@/types/models'
 import { dispatchToolAction } from '@/lib/tool-actions'
 import { openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
+import {
+  parseListMarker,
+  isMarkerContentEmpty,
+  nextLineMarker,
+  indentLine,
+  outdentLine,
+  renumberOrderedListAround,
+  renumberAroundIndex,
+} from '@/tools/markdown-editor/list-editing'
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -508,5 +517,164 @@ describe('MarkdownEditor modal integration', () => {
     renderTool(MarkdownEditor)
     fireEvent.click(screen.getByTitle('Table'))
     await waitFor(() => expect(screen.getByText('Insert Table')).toBeInTheDocument())
+  })
+})
+
+describe('list-editing: parseListMarker', () => {
+  it('parses a bullet item', () => {
+    expect(parseListMarker('- item')).toEqual({
+      kind: 'bullet',
+      indent: '',
+      bulletChar: '-',
+      content: 'item',
+    })
+  })
+
+  it('parses * and + bullets', () => {
+    expect(parseListMarker('* item')?.bulletChar).toBe('*')
+    expect(parseListMarker('+ item')?.bulletChar).toBe('+')
+  })
+
+  it('parses indented bullets', () => {
+    expect(parseListMarker('    - item')).toMatchObject({ indent: '    ', content: 'item' })
+  })
+
+  it('parses an unchecked task item', () => {
+    expect(parseListMarker('- [ ] task')).toEqual({
+      kind: 'task',
+      indent: '',
+      bulletChar: '-',
+      checked: false,
+      content: 'task',
+    })
+  })
+
+  it('parses a checked task item, including uppercase X', () => {
+    expect(parseListMarker('- [x] task')).toMatchObject({ kind: 'task', checked: true })
+    expect(parseListMarker('- [X] task')).toMatchObject({ kind: 'task', checked: true })
+  })
+
+  it('parses an ordered item with . or ) delimiter', () => {
+    expect(parseListMarker('1. item')).toEqual({
+      kind: 'ordered',
+      indent: '',
+      number: 1,
+      delimiter: '.',
+      content: 'item',
+    })
+    expect(parseListMarker('2) item')).toMatchObject({ number: 2, delimiter: ')' })
+  })
+
+  it('parses a blockquote, including nested >>', () => {
+    expect(parseListMarker('> quote')).toEqual({
+      kind: 'quote',
+      indent: '',
+      quotePrefix: '>',
+      content: 'quote',
+    })
+    expect(parseListMarker('>> nested')).toMatchObject({ quotePrefix: '>>' })
+  })
+
+  it('parses empty markers (no content)', () => {
+    expect(parseListMarker('- ')).toMatchObject({ kind: 'bullet', content: '' })
+    expect(parseListMarker('1. ')).toMatchObject({ kind: 'ordered', content: '' })
+    expect(parseListMarker('> ')).toMatchObject({ kind: 'quote', content: '' })
+    expect(parseListMarker('- [ ] ')).toMatchObject({ kind: 'task', content: '' })
+  })
+
+  it('returns null for non-list lines', () => {
+    expect(parseListMarker('plain paragraph text')).toBeNull()
+    expect(parseListMarker('')).toBeNull()
+    expect(parseListMarker('# Heading')).toBeNull()
+  })
+})
+
+describe('list-editing: isMarkerContentEmpty', () => {
+  it('is true for a bare marker and false when content is present', () => {
+    expect(isMarkerContentEmpty(parseListMarker('- ')!)).toBe(true)
+    expect(isMarkerContentEmpty(parseListMarker('-   ')!)).toBe(true)
+    expect(isMarkerContentEmpty(parseListMarker('- x')!)).toBe(false)
+  })
+})
+
+describe('list-editing: nextLineMarker', () => {
+  it('repeats the bullet character', () => {
+    expect(nextLineMarker(parseListMarker('- item')!)).toBe('- ')
+    expect(nextLineMarker(parseListMarker('  * item')!)).toBe('  * ')
+  })
+
+  it('always continues a task item unchecked, even from a checked one', () => {
+    expect(nextLineMarker(parseListMarker('- [x] done')!)).toBe('- [ ] ')
+    expect(nextLineMarker(parseListMarker('- [ ] todo')!)).toBe('- [ ] ')
+  })
+
+  it('advances the ordered number by one', () => {
+    expect(nextLineMarker(parseListMarker('1. item')!)).toBe('2. ')
+    expect(nextLineMarker(parseListMarker('9) item')!)).toBe('10) ')
+  })
+
+  it('repeats the quote prefix', () => {
+    expect(nextLineMarker(parseListMarker('> quote')!)).toBe('> ')
+    expect(nextLineMarker(parseListMarker('>> nested')!)).toBe('>> ')
+  })
+})
+
+describe('list-editing: indentLine / outdentLine', () => {
+  it('indents with spaces when insertSpaces is true', () => {
+    expect(indentLine('- item', true, 2)).toBe('  - item')
+  })
+
+  it('indents with a tab when insertSpaces is false', () => {
+    expect(indentLine('- item', false, 4)).toBe('\t- item')
+  })
+
+  it('outdents a leading tab regardless of insertSpaces', () => {
+    expect(outdentLine('\t- item', true, 2)).toBe('- item')
+    expect(outdentLine('\t- item', false, 2)).toBe('- item')
+  })
+
+  it('outdents up to tabSize leading spaces', () => {
+    expect(outdentLine('    - item', true, 2)).toBe('  - item')
+    expect(outdentLine('  - item', true, 2)).toBe('- item')
+  })
+
+  it('is a no-op when there is no leading whitespace to remove', () => {
+    expect(outdentLine('- item', true, 2)).toBe('- item')
+  })
+})
+
+describe('list-editing: renumberOrderedListAround', () => {
+  it('renumbers a contiguous run after a new item is spliced in', () => {
+    const lines = ['1. a', '2. ', '2. b', '3. c']
+    expect(renumberOrderedListAround(lines, 1, '')).toEqual(['1. a', '2. ', '3. b', '4. c'])
+  })
+
+  it('is a no-op when the anchor line is not an ordered item at the given indent', () => {
+    const lines = ['- a', '1. b']
+    expect(renumberOrderedListAround(lines, 0, '')).toEqual(lines)
+  })
+
+  it('only renumbers the run at the matching indent, not nested sub-lists', () => {
+    const lines = ['1. a', '  1. nested', '  2. nested2', '2. b']
+    expect(renumberOrderedListAround(lines, 1, '  ')).toEqual(lines)
+  })
+
+  it('preserves the run start number rather than resetting to 1', () => {
+    const lines = ['5. a', '6. ', '6. b']
+    expect(renumberOrderedListAround(lines, 1, '')).toEqual(['5. a', '6. ', '7. b'])
+  })
+})
+
+describe('list-editing: renumberAroundIndex', () => {
+  it('renumbers the run on each side of a line that was just re-indented away', () => {
+    // Simulates line 1 having just been indented (moved out of the "" run,
+    // which leaves the run below it internally mis-numbered).
+    const lines = ['1. a', '  1. removed', '5. b', '5. c']
+    expect(renumberAroundIndex(lines, 1, '')).toEqual(['1. a', '  1. removed', '5. b', '6. c'])
+  })
+
+  it('is a no-op when neither neighbour is an ordered item at the given indent', () => {
+    const lines = ['- a', '  1. b', '- c']
+    expect(renumberAroundIndex(lines, 1, '')).toEqual(lines)
   })
 })

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -319,6 +319,22 @@ describe('MarkdownEditor', () => {
     expect(container.innerHTML).not.toContain('old diagram')
   })
 
+  // Regression: React 19 compares `dangerouslySetInnerHTML` by object identity,
+  // so an inline `{ __html }` literal made it rewrite innerHTML on every render
+  // and tear down the subtree — destroying any text selection the user had made
+  // in the preview. The rendered nodes must survive re-renders that don't change
+  // the markup.
+  it('preserves preview DOM nodes across re-renders when the html is unchanged', () => {
+    const html = '<p>selectable paragraph</p>'
+    const { container, rerender } = render(<MarkdownPreview html={html} showToc={false} toc={[]} />)
+    const paragraph = container.querySelector('p')
+    expect(paragraph).not.toBeNull()
+
+    rerender(<MarkdownPreview html={html} showToc={false} toc={[]} onToggleTask={() => {}} />)
+
+    expect(container.querySelector('p')).toBe(paragraph)
+  })
+
   it('uses the light Mermaid theme in preview when the app theme is light', async () => {
     useSettingsStore.setState({ ...DEFAULT_SETTINGS, theme: 'github-light' })
     mermaidMock.render.mockResolvedValue({ svg: '<svg><text>diagram</text></svg>' })

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -39,6 +39,41 @@ const LANGUAGES = [
   { id: 'xml', label: 'XML' },
 ]
 
+const DIFF_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: [
+    'div',
+    'span',
+    'code',
+    'pre',
+    'del',
+    'ins',
+    'br',
+    'hr',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'th',
+    'td',
+    'svg',
+    'path',
+    'label',
+    'input',
+    'a',
+  ],
+  ALLOWED_ATTR: [
+    'class',
+    'style',
+    'data-diffline',
+    'data-diffpath',
+    'type',
+    'checked',
+    'disabled',
+    'title',
+  ],
+  FORCE_BODY: true,
+}
+
 type DiffStats = { additions: number; deletions: number }
 
 function parseDiffStats(patch: string): DiffStats {
@@ -83,6 +118,16 @@ export default function DiffViewer() {
   }, [state])
 
   const stats = useMemo(() => (rawPatch ? parseDiffStats(rawPatch) : null), [rawPatch])
+
+  // Stable object identity is load-bearing: React 19 compares
+  // `dangerouslySetInnerHTML` by object identity, not by the `__html` string, so
+  // an inline literal re-writes innerHTML on every render — rebuilding the whole
+  // subtree and destroying any text selection the user has made in the diff.
+  // Memoising also keeps the (non-trivial) sanitize pass off the render path.
+  const sanitizedDiffProp = useMemo(
+    () => ({ __html: sanitize(diffHtml, DIFF_SANITIZE_CONFIG) }),
+    [diffHtml]
+  )
 
   const computeDiff = useCallback(async () => {
     if (!worker) return
@@ -267,42 +312,7 @@ export default function DiffViewer() {
             ['--d2h-info-bg-color' as string]: 'var(--color-surface)',
             ['--d2h-info-border-color' as string]: 'var(--color-border)',
           }}
-          dangerouslySetInnerHTML={{
-            __html: sanitize(diffHtml, {
-              ALLOWED_TAGS: [
-                'div',
-                'span',
-                'code',
-                'pre',
-                'del',
-                'ins',
-                'br',
-                'hr',
-                'table',
-                'thead',
-                'tbody',
-                'tr',
-                'th',
-                'td',
-                'svg',
-                'path',
-                'label',
-                'input',
-                'a',
-              ],
-              ALLOWED_ATTR: [
-                'class',
-                'style',
-                'data-diffline',
-                'data-diffpath',
-                'type',
-                'checked',
-                'disabled',
-                'title',
-              ],
-              FORCE_BODY: true,
-            }),
-          }}
+          dangerouslySetInnerHTML={sanitizedDiffProp}
         />
       ) : (
         <div className="flex min-h-0 flex-1 gap-px overflow-hidden bg-[var(--color-border)]">

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -19,6 +19,8 @@ import { useMonacoSelectionToolbar } from '@/hooks/useMonacoSelectionToolbar'
 import { MarkdownPreview } from './MarkdownPreview'
 import { useScrollSync } from './hooks/useScrollSync'
 import { useImageDrop } from './hooks/useImageDrop'
+import { useMarkdownListEditing } from './hooks/useMarkdownListEditing'
+import { useMarkdownSmartPaste } from './hooks/useMarkdownSmartPaste'
 import { LinkModal } from './modals/LinkModal'
 import { CodeBlockModal } from './modals/CodeBlockModal'
 import { ImageModal } from './modals/ImageModal'
@@ -491,6 +493,8 @@ export default function MarkdownEditor() {
 
   useScrollSync(editorRef, previewRef, state.scrollSync && state.mode === 'split')
   const { isDraggingImage } = useImageDrop(editorRef, editorContainerRef)
+  useMarkdownListEditing(mountedEditor)
+  useMarkdownSmartPaste(mountedEditor)
   const editorSelectionToolbar = useMonacoSelectionToolbar(mountedEditor, showEditor, state.content)
   const previewSelectionToolbar = useDomSelectionToolbar(previewRef, showPreview)
 

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -37,9 +37,13 @@ import {
 } from '@phosphor-icons/react'
 
 // Shared markdown pipeline — see src/lib/markdown.ts for plugin order rationale.
-// Both this tool and the Notes drawer render through the same processor so they
-// cannot drift apart again.
-import { markdownProcessor } from '@/lib/markdown'
+// This tool renders through `markdownEditorProcessor`, which is identical to the
+// Notes drawer's `markdownProcessor` except that GFM task-list checkboxes are left
+// enabled (not `disabled`) so the preview can toggle them — see the sanitize schema
+// comment in src/lib/markdown.ts for why that variant exists instead of loosening
+// the shared schema for every surface.
+import { markdownEditorProcessor } from '@/lib/markdown'
+import { toggleTaskAtIndex } from './task-list'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -439,7 +443,7 @@ export function prefixMarkdownLines(text: string, prefix: string): string {
 export async function renderMarkdownContent(content: string): Promise<string> {
   if (!content.trim()) return ''
   try {
-    const result = await markdownProcessor.process(content)
+    const result = await markdownEditorProcessor.process(content)
     return String(result)
   } catch (e) {
     const msg = (e as Error).message
@@ -859,6 +863,13 @@ export default function MarkdownEditor() {
     setShowExport(false)
   }, [buildCurrentExportHtml, setLastAction])
 
+  const handleToggleTask = useCallback(
+    (index: number) => {
+      updateState({ content: toggleTaskAtIndex(state.content, index) })
+    },
+    [state.content, updateState]
+  )
+
   const handleTemplateSelect = useCallback(
     (content: string) => {
       updateState({ content })
@@ -1143,7 +1154,13 @@ export default function MarkdownEditor() {
         {/* Preview */}
         {showPreview && (
           <div className={showEditor ? 'w-1/2' : 'w-full'}>
-            <MarkdownPreview ref={previewRef} html={html} showToc={state.showToc} toc={toc} />
+            <MarkdownPreview
+              ref={previewRef}
+              html={html}
+              showToc={state.showToc}
+              toc={toc}
+              onToggleTask={handleToggleTask}
+            />
           </div>
         )}
       </div>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -7,7 +7,13 @@ import { Button } from '@/components/shared/Button'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { useToolAction } from '@/hooks/useToolAction'
-import { exportFile, saveFileDialog } from '@/lib/file-io'
+import {
+  exportFile,
+  filenameFromPath,
+  openFileDialog,
+  saveFileDialog,
+  saveFileToPath,
+} from '@/lib/file-io'
 import { useDomSelectionToolbar } from '@/hooks/useDomSelectionToolbar'
 import { useMonacoSelectionToolbar } from '@/hooks/useMonacoSelectionToolbar'
 import { MarkdownPreview } from './MarkdownPreview'
@@ -40,6 +46,8 @@ import { markdownProcessor } from '@/lib/markdown'
 type MarkdownEditorState = {
   content: string
   fileName: string | null
+  filePath: string | null
+  savedContent: string
   mode: string
   showToc: boolean
   scrollSync: boolean
@@ -450,6 +458,8 @@ export default function MarkdownEditor() {
   const [state, updateState] = useToolState<MarkdownEditorState>('markdown-editor', {
     content: '',
     fileName: null,
+    filePath: null,
+    savedContent: '',
     mode: 'split',
     showToc: false,
     scrollSync: true,
@@ -464,9 +474,11 @@ export default function MarkdownEditor() {
   const editorContainerRef = useRef<HTMLDivElement>(null)
   const [showTemplates, setShowTemplates] = useState(false)
   const [showExport, setShowExport] = useState(false)
+  const [showFileMenu, setShowFileMenu] = useState(false)
   const [activeModal, setActiveModal] = useState<'link' | 'image' | 'code' | 'table' | null>(null)
   const templatesRef = useRef<HTMLDivElement>(null)
   const exportRef = useRef<HTMLDivElement>(null)
+  const fileMenuRef = useRef<HTMLDivElement>(null)
 
   // ─── Hooks ────────────────────────────────────────────────────────
 
@@ -546,6 +558,17 @@ export default function MarkdownEditor() {
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
   }, [showExport])
+
+  useEffect(() => {
+    if (!showFileMenu) return
+    const handler = (e: MouseEvent) => {
+      if (fileMenuRef.current && !fileMenuRef.current.contains(e.target as Node)) {
+        setShowFileMenu(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [showFileMenu])
 
   // ─── Formatting insertion ────────────────────────────────────────
 
@@ -743,17 +766,66 @@ export default function MarkdownEditor() {
     [buildCurrentExportHtml, state.content, setLastAction]
   )
 
+  // ─── Open / Save ──────────────────────────────────────────────────
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const result = await openFileDialog()
+      if (result) {
+        updateState({
+          content: result.content,
+          fileName: result.filename,
+          filePath: result.path,
+          savedContent: result.content,
+        })
+        setLastAction(`Opened ${result.filename}`, 'success')
+      }
+    } catch (err) {
+      setLastAction(err instanceof Error ? err.message : String(err), 'error')
+    }
+  }, [updateState, setLastAction])
+
+  const handleSaveAs = useCallback(async () => {
+    try {
+      const path = await saveFileDialog(state.content, state.fileName ?? 'document.md')
+      if (path) {
+        const fileName = filenameFromPath(path)
+        updateState({ filePath: path, fileName, savedContent: state.content })
+        setLastAction(`Saved ${fileName}`, 'success')
+      } else {
+        setLastAction('Save cancelled', 'info')
+      }
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.content, state.fileName, updateState, setLastAction])
+
+  // Shared by the File > Save menu item and the ⌘S shortcut so they cannot drift.
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, state.content)
+      updateState({ savedContent: state.content })
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.content, state.fileName, updateState, setLastAction, handleSaveAs])
+
   useToolAction((action) => {
     if (action.type === 'open-file') {
-      updateState({ content: action.content, fileName: action.filename })
+      updateState({
+        content: action.content,
+        fileName: action.filename,
+        filePath: action.path ?? null,
+        savedContent: action.content,
+      })
     }
     if (action.type === 'save-file') {
-      void saveFileDialog(state.content, state.fileName ?? 'document.md').then(
-        (path) =>
-          setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-        (err: unknown) =>
-          setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-      )
+      void handleSave()
     }
   })
 
@@ -807,6 +879,19 @@ export default function MarkdownEditor() {
           noBorder
         />
         <div className="ml-auto flex items-center gap-3 py-2">
+          {state.fileName && (
+            <span
+              data-testid="file-name"
+              className="text-[10px] text-[var(--color-text-muted)]"
+              title={state.filePath ?? state.fileName}
+            >
+              {state.fileName}
+              {state.content !== state.savedContent && (
+                <span className="text-[var(--color-accent)]"> •</span>
+              )}
+            </span>
+          )}
+
           {stats && (
             <span
               className="text-[10px] text-[var(--color-text-muted)]"
@@ -849,6 +934,53 @@ export default function MarkdownEditor() {
               TOC
             </Button>
           )}
+
+          {/* File dropdown — Open / Save / Save As */}
+          <div ref={fileMenuRef} className="relative">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowFileMenu(!showFileMenu)}
+              className={
+                showFileMenu ? 'bg-[var(--color-surface-hover)] !text-[var(--color-accent)]' : ''
+              }
+              aria-expanded={showFileMenu}
+              aria-haspopup="menu"
+            >
+              File
+            </Button>
+            {showFileMenu && (
+              <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg">
+                <button
+                  onClick={() => {
+                    void handleOpen()
+                    setShowFileMenu(false)
+                  }}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                >
+                  Open…
+                </button>
+                <button
+                  onClick={() => {
+                    void handleSave()
+                    setShowFileMenu(false)
+                  }}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => {
+                    void handleSaveAs()
+                    setShowFileMenu(false)
+                  }}
+                  className="block w-full px-3 py-1.5 text-left text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+                >
+                  Save As…
+                </button>
+              </div>
+            )}
+          </div>
 
           {/* Templates dropdown */}
           <div ref={templatesRef} className="relative">

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+import { useCallback, useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { nextHeadingId } from './heading-ids'
@@ -121,6 +121,18 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       [toggleFromEventTarget]
     )
 
+    // ─── Rendered HTML payload ────────────────────────────────────
+    // Memoised deliberately. React 19's `updateProperties` compares
+    // `dangerouslySetInnerHTML` by *object identity*, not by the `__html` string
+    // inside it (React 18 compared the string). An inline `{ __html: html }`
+    // literal is a new object on every render, so React re-set innerHTML on each
+    // one — tearing down and rebuilding the whole subtree even when the markup
+    // was byte-identical. That destroyed any text selection the user had made in
+    // the preview: selecting text updates the selection-toolbar state, which
+    // re-renders this component, which wiped the very selection being tracked.
+    // Keeping the object stable makes React skip the write entirely.
+    const htmlProp = useMemo(() => ({ __html: html }), [html])
+
     // Expose the inner div via forwarded ref for scroll sync
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     useImperativeHandle(ref, () => innerRef.current!, []) // safe: called after mount, ref is populated
@@ -207,7 +219,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           onKeyDown={handlePreviewKeyDown}
         >
           {html ? (
-            <div className={PREVIEW_STYLES} dangerouslySetInnerHTML={{ __html: html }} />
+            <div className={PREVIEW_STYLES} dangerouslySetInnerHTML={htmlProp} />
           ) : (
             <div className="text-sm text-[var(--color-text-muted)]">
               Start typing markdown in the editor...

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+import { useCallback, useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { nextHeadingId } from './heading-ids'
@@ -13,6 +13,8 @@ type MarkdownPreviewProps = {
   html: string
   showToc: boolean
   toc: TocEntry[]
+  /** Called with the source-order index of a GFM task-list checkbox that was toggled. */
+  onToggleTask?: (index: number) => void
 }
 
 // ─── Preview Styles (extracted + polished) ──────────────────────────
@@ -84,10 +86,40 @@ const PREVIEW_STYLES = [
 // ─── Component ──────────────────────────────────────────────────────
 
 export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
-  function MarkdownPreview({ html, showToc, toc }, ref) {
+  function MarkdownPreview({ html, showToc, toc, onToggleTask }, ref) {
     const innerRef = useRef<HTMLDivElement>(null)
     const mermaidRenderSeqRef = useRef(0)
     const theme = useSettingsStore((s) => s.theme)
+
+    // ─── Task checkbox interaction (click + Enter; Space reaches here via the
+    // native click a focused checkbox fires) ──────────────────────────────
+    const toggleFromEventTarget = useCallback(
+      (target: EventTarget | null) => {
+        if (!onToggleTask || !innerRef.current) return false
+        if (!(target instanceof window.HTMLInputElement) || target.type !== 'checkbox') return false
+        const checkboxes = innerRef.current.querySelectorAll('input[type="checkbox"]')
+        const index = Array.prototype.indexOf.call(checkboxes, target)
+        if (index === -1) return false
+        onToggleTask(index)
+        return true
+      },
+      [onToggleTask]
+    )
+
+    const handlePreviewClick = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (toggleFromEventTarget(e.target)) e.preventDefault()
+      },
+      [toggleFromEventTarget]
+    )
+
+    const handlePreviewKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key !== 'Enter') return
+        if (toggleFromEventTarget(e.target)) e.preventDefault()
+      },
+      [toggleFromEventTarget]
+    )
 
     // Expose the inner div via forwarded ref for scroll sync
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -171,6 +203,8 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           ref={innerRef}
           className="flex-1 overflow-auto p-6"
           data-selection-surface="markdown-preview"
+          onClick={handlePreviewClick}
+          onKeyDown={handlePreviewKeyDown}
         >
           {html ? (
             <div className={PREVIEW_STYLES} dangerouslySetInnerHTML={{ __html: html }} />

--- a/apps/cockpit/src/tools/markdown-editor/hooks/useMarkdownListEditing.ts
+++ b/apps/cockpit/src/tools/markdown-editor/hooks/useMarkdownListEditing.ts
@@ -1,0 +1,216 @@
+import { useEffect } from 'react'
+import {
+  indentLine,
+  isMarkerContentEmpty,
+  nextLineMarker,
+  outdentLine,
+  parseListMarker,
+  renumberAroundIndex,
+  renumberOrderedListAround,
+} from '../list-editing'
+
+// Structural (not imported) monaco-editor types — same pattern as
+// useMonacoSelectionToolbar/useImageDrop, so this hook doesn't need to pull
+// in the full `monaco-editor` type surface.
+
+type Disposable = { dispose: () => void }
+
+interface KeyboardEventLike {
+  keyCode: number
+  shiftKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  altKey: boolean
+  preventDefault: () => void
+  stopPropagation: () => void
+}
+
+interface MonacoPosition {
+  lineNumber: number
+  column: number
+}
+
+interface MonacoRange {
+  startLineNumber: number
+  startColumn: number
+  endLineNumber: number
+  endColumn: number
+}
+
+interface MonacoSelectionLike {
+  isEmpty: () => boolean
+  getPosition: () => MonacoPosition
+}
+
+interface MonacoModelLike {
+  getLineContent: (lineNumber: number) => string
+  getLineCount: () => number
+  getLinesContent: () => string[]
+  getLineMaxColumn: (lineNumber: number) => number
+  getOptions: () => { tabSize: number; insertSpaces: boolean }
+}
+
+interface MonacoEditOperationLike {
+  range: MonacoRange
+  text: string
+  forceMoveMarkers?: boolean
+}
+
+interface MonacoListEditingEditor {
+  getModel: () => MonacoModelLike | null
+  getSelection: () => MonacoSelectionLike | null
+  executeEdits: (source: string, edits: MonacoEditOperationLike[]) => void
+  setPosition: (position: MonacoPosition) => void
+  onKeyDown: (listener: (e: KeyboardEventLike) => void) => Disposable
+}
+
+// monaco.KeyCode.Enter / monaco.KeyCode.Tab — hardcoded to avoid pulling in
+// the monaco-editor runtime just for two enum values.
+const KEY_CODE_ENTER = 3
+const KEY_CODE_TAB = 2
+
+function handleEnter(editor: MonacoListEditingEditor): boolean {
+  const selection = editor.getSelection()
+  const model = editor.getModel()
+  if (!selection || !model || !selection.isEmpty()) return false
+
+  const position = selection.getPosition()
+  const lineContent = model.getLineContent(position.lineNumber)
+  if (position.column !== lineContent.length + 1) return false // not at end of line
+
+  const marker = parseListMarker(lineContent)
+  if (!marker) return false
+
+  if (isMarkerContentEmpty(marker)) {
+    editor.executeEdits('markdown-list-exit', [
+      {
+        range: {
+          startLineNumber: position.lineNumber,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: lineContent.length + 1,
+        },
+        text: '',
+        forceMoveMarkers: true,
+      },
+    ])
+    editor.setPosition({ lineNumber: position.lineNumber, column: 1 })
+    return true
+  }
+
+  const lines = model.getLinesContent()
+  const idx = position.lineNumber - 1
+  const continuation = nextLineMarker(marker)
+  const newLines = [...lines]
+  newLines.splice(idx + 1, 0, continuation)
+
+  const finalLines =
+    marker.kind === 'ordered'
+      ? renumberOrderedListAround(newLines, idx + 1, marker.indent)
+      : newLines
+
+  const tail = finalLines.slice(idx + 1).join('\n')
+  const endLineNumber = model.getLineCount()
+  const endColumn = model.getLineMaxColumn(endLineNumber)
+
+  editor.executeEdits('markdown-list-enter', [
+    {
+      range: {
+        startLineNumber: position.lineNumber,
+        startColumn: lineContent.length + 1,
+        endLineNumber,
+        endColumn,
+      },
+      text: '\n' + tail,
+      forceMoveMarkers: true,
+    },
+  ])
+
+  const insertedLine = finalLines[idx + 1] ?? continuation
+  editor.setPosition({ lineNumber: position.lineNumber + 1, column: insertedLine.length + 1 })
+  return true
+}
+
+function handleTab(editor: MonacoListEditingEditor, shiftKey: boolean): boolean {
+  const selection = editor.getSelection()
+  const model = editor.getModel()
+  if (!selection || !model || !selection.isEmpty()) return false
+
+  const position = selection.getPosition()
+  const lineContent = model.getLineContent(position.lineNumber)
+  const marker = parseListMarker(lineContent)
+  if (!marker) return false
+
+  const { tabSize, insertSpaces } = model.getOptions()
+  const newLineContent = shiftKey
+    ? outdentLine(lineContent, insertSpaces, tabSize)
+    : indentLine(lineContent, insertSpaces, tabSize)
+
+  const lines = model.getLinesContent()
+  const idx = position.lineNumber - 1
+  let finalLines = [...lines]
+  finalLines[idx] = newLineContent
+
+  if (marker.kind === 'ordered') {
+    finalLines = renumberAroundIndex(finalLines, idx, marker.indent)
+    const newMarker = parseListMarker(newLineContent)
+    if (newMarker && newMarker.kind === 'ordered') {
+      finalLines = renumberOrderedListAround(finalLines, idx, newMarker.indent)
+    }
+  }
+
+  const edits: MonacoEditOperationLike[] = []
+  for (let i = 0; i < finalLines.length; i++) {
+    const original = lines[i] ?? ''
+    const updated = finalLines[i] ?? ''
+    if (updated !== original) {
+      edits.push({
+        range: {
+          startLineNumber: i + 1,
+          startColumn: 1,
+          endLineNumber: i + 1,
+          endColumn: original.length + 1,
+        },
+        text: updated,
+        forceMoveMarkers: true,
+      })
+    }
+  }
+
+  if (edits.length > 0) editor.executeEdits('markdown-list-tab', edits)
+
+  const delta = (finalLines[idx] ?? '').length - lineContent.length
+  editor.setPosition({
+    lineNumber: position.lineNumber,
+    column: Math.max(1, position.column + delta),
+  })
+  return true
+}
+
+/**
+ * Registers smart Enter/Tab keybindings for markdown lists (bullets, ordered
+ * lists, task items, blockquotes) on the given editor instance. All logic
+ * lives in ./list-editing.ts so it can be unit tested without Monaco; this
+ * hook is just the wiring + editor mutation layer.
+ */
+export function useMarkdownListEditing(editor: MonacoListEditingEditor | null): void {
+  useEffect(() => {
+    if (!editor) return
+
+    const disposable = editor.onKeyDown((e) => {
+      if (e.keyCode === KEY_CODE_ENTER && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (handleEnter(editor)) {
+          e.preventDefault()
+          e.stopPropagation()
+        }
+      } else if (e.keyCode === KEY_CODE_TAB && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (handleTab(editor, e.shiftKey)) {
+          e.preventDefault()
+          e.stopPropagation()
+        }
+      }
+    })
+
+    return () => disposable.dispose()
+  }, [editor])
+}

--- a/apps/cockpit/src/tools/markdown-editor/hooks/useMarkdownSmartPaste.ts
+++ b/apps/cockpit/src/tools/markdown-editor/hooks/useMarkdownSmartPaste.ts
@@ -1,0 +1,87 @@
+import { useEffect } from 'react'
+import { isUrl, tsvToMarkdownTable } from '../paste-helpers'
+
+// Structural (not imported) monaco-editor types — same pattern as
+// useMonacoSelectionToolbar/useMarkdownListEditing.
+
+interface MonacoRange {
+  startLineNumber: number
+  startColumn: number
+  endLineNumber: number
+  endColumn: number
+}
+
+interface MonacoSelectionLike extends MonacoRange {
+  isEmpty: () => boolean
+}
+
+interface MonacoModelLike {
+  getValueInRange: (range: MonacoRange) => string
+}
+
+interface MonacoEditOperationLike {
+  range: MonacoRange
+  text: string
+  forceMoveMarkers?: boolean
+}
+
+interface MonacoSmartPasteEditor {
+  getModel: () => MonacoModelLike | null
+  getSelection: () => MonacoSelectionLike | null
+  getDomNode: () => HTMLElement | null
+  executeEdits: (source: string, edits: MonacoEditOperationLike[]) => void
+  focus: () => void
+}
+
+/**
+ * Intercepts paste on the editor's DOM node (capture phase — Monaco's own
+ * `onDidPaste` fires too late to alter content) to implement two smart-paste
+ * behaviours:
+ *  - Pasting a URL over a non-empty selection turns it into `[selection](url)`.
+ *  - Pasting multi-row/multi-column TSV data turns it into a GFM table.
+ * Anything else (plain text, code, a URL with no selection, single-column or
+ * single-row data) falls through to Monaco's default paste handling.
+ */
+export function useMarkdownSmartPaste(editor: MonacoSmartPasteEditor | null): void {
+  useEffect(() => {
+    if (!editor) return
+    const domNode = editor.getDomNode()
+    if (!domNode) return
+
+    const handler = (e: ClipboardEvent) => {
+      const text = e.clipboardData?.getData('text/plain')
+      if (!text) return
+
+      const model = editor.getModel()
+      const selection = editor.getSelection()
+      if (!model || !selection) return
+
+      const hasSelection = !selection.isEmpty()
+
+      if (hasSelection && isUrl(text)) {
+        const selectedText = model.getValueInRange(selection)
+        e.preventDefault()
+        e.stopPropagation()
+        editor.executeEdits('smart-paste-link', [
+          { range: selection, text: `[${selectedText}](${text.trim()})`, forceMoveMarkers: true },
+        ])
+        editor.focus()
+        return
+      }
+
+      const table = tsvToMarkdownTable(text)
+      if (table) {
+        e.preventDefault()
+        e.stopPropagation()
+        editor.executeEdits('smart-paste-table', [
+          { range: selection, text: table, forceMoveMarkers: true },
+        ])
+        editor.focus()
+      }
+      // else: let Monaco handle the paste as usual
+    }
+
+    domNode.addEventListener('paste', handler, true)
+    return () => domNode.removeEventListener('paste', handler, true)
+  }, [editor])
+}

--- a/apps/cockpit/src/tools/markdown-editor/list-editing.ts
+++ b/apps/cockpit/src/tools/markdown-editor/list-editing.ts
@@ -1,0 +1,187 @@
+// Pure, Monaco-free markdown list-editing helpers. Kept separate from the
+// useMarkdownListEditing hook so the parsing/renumbering logic is unit
+// testable without a real editor instance.
+
+export type ListMarkerKind = 'bullet' | 'task' | 'ordered' | 'quote'
+
+export interface ListMarker {
+  kind: ListMarkerKind
+  /** Leading whitespace before the marker character(s). */
+  indent: string
+  /** '-' | '*' | '+' — only set for bullet/task markers. */
+  bulletChar?: string
+  /** Only set for task markers. */
+  checked?: boolean
+  /** Only set for ordered markers. */
+  number?: number
+  /** '.' | ')' — only set for ordered markers. */
+  delimiter?: string
+  /** '>' repeated N times — only set for quote markers. */
+  quotePrefix?: string
+  /** Text after the marker (and its trailing space), possibly empty. */
+  content: string
+}
+
+const TASK_RE = /^(\s*)([-*+])\s\[([ xX])\](?:\s(.*))?$/
+const BULLET_RE = /^(\s*)([-*+])(?:\s(.*))?$/
+const ORDERED_RE = /^(\s*)(\d+)([.)])(?:\s(.*))?$/
+const QUOTE_RE = /^(\s*)(>+)(?:\s(.*))?$/
+
+/** Parse a single line into a list marker, or null if it isn't a list/quote line. */
+export function parseListMarker(line: string): ListMarker | null {
+  let m = TASK_RE.exec(line)
+  if (m) {
+    return {
+      kind: 'task',
+      indent: m[1] ?? '',
+      bulletChar: m[2] ?? '-',
+      checked: (m[3] ?? ' ').toLowerCase() === 'x',
+      content: m[4] ?? '',
+    }
+  }
+
+  m = BULLET_RE.exec(line)
+  if (m) {
+    return {
+      kind: 'bullet',
+      indent: m[1] ?? '',
+      bulletChar: m[2] ?? '-',
+      content: m[3] ?? '',
+    }
+  }
+
+  m = ORDERED_RE.exec(line)
+  if (m) {
+    return {
+      kind: 'ordered',
+      indent: m[1] ?? '',
+      number: parseInt(m[2] ?? '1', 10),
+      delimiter: m[3] ?? '.',
+      content: m[4] ?? '',
+    }
+  }
+
+  m = QUOTE_RE.exec(line)
+  if (m) {
+    return {
+      kind: 'quote',
+      indent: m[1] ?? '',
+      quotePrefix: m[2] ?? '>',
+      content: m[3] ?? '',
+    }
+  }
+
+  return null
+}
+
+/** True when the marker has no text after it (just the bare marker itself). */
+export function isMarkerContentEmpty(marker: ListMarker): boolean {
+  return marker.content.trim().length === 0
+}
+
+/**
+ * The marker text (including indent and trailing space) to prefix a new,
+ * empty continuation line with when Enter is pressed at the end of `marker`'s
+ * line. Task items always continue as unchecked, ordered items advance by one.
+ */
+export function nextLineMarker(marker: ListMarker): string {
+  switch (marker.kind) {
+    case 'bullet':
+      return `${marker.indent}${marker.bulletChar ?? '-'} `
+    case 'task':
+      return `${marker.indent}${marker.bulletChar ?? '-'} [ ] `
+    case 'ordered':
+      return `${marker.indent}${(marker.number ?? 1) + 1}${marker.delimiter ?? '.'} `
+    case 'quote':
+      return `${marker.indent}${marker.quotePrefix ?? '>'} `
+    default:
+      return marker.indent
+  }
+}
+
+/** One tab-stop worth of indentation, matching the editor's indent settings. */
+export function indentUnit(insertSpaces: boolean, tabSize: number): string {
+  return insertSpaces ? ' '.repeat(tabSize) : '\t'
+}
+
+/** Indent a line by one indent unit. */
+export function indentLine(line: string, insertSpaces: boolean, tabSize: number): string {
+  return indentUnit(insertSpaces, tabSize) + line
+}
+
+/** Outdent a line by up to one indent unit (a leading tab, or up to `tabSize` spaces). */
+export function outdentLine(line: string, insertSpaces: boolean, tabSize: number): string {
+  // A leading tab is always exactly one indent unit, regardless of `insertSpaces` —
+  // remove it outright rather than counting it as `tabSize` spaces.
+  if (line.startsWith('\t')) return line.slice(1)
+  const unit = indentUnit(insertSpaces, tabSize)
+  if (line.startsWith(unit)) return line.slice(unit.length)
+  const leadingSpaces = /^ */.exec(line)?.[0].length ?? 0
+  const remove = Math.min(leadingSpaces, tabSize)
+  return line.slice(remove)
+}
+
+/**
+ * Renumber the contiguous run of ordered-list items at `indent` that contains
+ * `lines[lineIndex]`, starting from that run's original first number. No-op
+ * if `lines[lineIndex]` isn't itself an ordered item at `indent`.
+ */
+export function renumberOrderedListAround(
+  lines: string[],
+  lineIndex: number,
+  indent: string
+): string[] {
+  const anchor = lines[lineIndex]
+  if (anchor === undefined) return lines
+  const anchorMarker = parseListMarker(anchor)
+  if (!anchorMarker || anchorMarker.kind !== 'ordered' || anchorMarker.indent !== indent) {
+    return lines
+  }
+
+  let start = lineIndex
+  while (start > 0) {
+    const m = parseListMarker(lines[start - 1] ?? '')
+    if (!m || m.kind !== 'ordered' || m.indent !== indent) break
+    start--
+  }
+
+  let end = lineIndex
+  while (end < lines.length - 1) {
+    const m = parseListMarker(lines[end + 1] ?? '')
+    if (!m || m.kind !== 'ordered' || m.indent !== indent) break
+    end++
+  }
+
+  const startMarker = parseListMarker(lines[start] ?? '')
+  if (!startMarker || startMarker.kind !== 'ordered') return lines
+
+  const result = [...lines]
+  let num = startMarker.number ?? 1
+  for (let i = start; i <= end; i++) {
+    const m = parseListMarker(result[i] ?? '')
+    if (!m || m.kind !== 'ordered') continue
+    result[i] = `${m.indent}${num}${m.delimiter ?? '.'} ${m.content}`
+    num++
+  }
+  return result
+}
+
+/**
+ * Renumber whichever contiguous ordered-list run(s) at `indent` are adjacent
+ * to `lineIndex` (the line at `lineIndex` itself is assumed to no longer be
+ * part of that run, e.g. because it was just indented/outdented away from it).
+ */
+export function renumberAroundIndex(lines: string[], lineIndex: number, indent: string): string[] {
+  let result = lines
+  const above = lineIndex - 1
+  const aboveMarker = above >= 0 ? parseListMarker(lines[above] ?? '') : null
+  if (aboveMarker && aboveMarker.kind === 'ordered' && aboveMarker.indent === indent) {
+    result = renumberOrderedListAround(result, above, indent)
+  }
+  const below = lineIndex + 1
+  const belowMarker = below < lines.length ? parseListMarker(lines[below] ?? '') : null
+  if (belowMarker && belowMarker.kind === 'ordered' && belowMarker.indent === indent) {
+    result = renumberOrderedListAround(result, below, indent)
+  }
+  return result
+}

--- a/apps/cockpit/src/tools/markdown-editor/paste-helpers.ts
+++ b/apps/cockpit/src/tools/markdown-editor/paste-helpers.ts
@@ -1,0 +1,43 @@
+// Pure helpers backing the Markdown Editor's smart-paste behaviour: turning a
+// pasted URL + selection into a link, and pasted TSV data into a GFM table.
+// Kept dependency-free and Monaco-free so they're unit testable in isolation.
+
+const URL_RE = /^(https?:\/\/)\S+$/i
+
+/** True when `text` (trimmed) is a single bare http(s) URL with no surrounding content. */
+export function isUrl(text: string): boolean {
+  return URL_RE.test(text.trim())
+}
+
+/** Escape `|` so it can't break out of a markdown table cell. */
+function escapeCell(cell: string): string {
+  return cell.replace(/\|/g, '\\|').trim()
+}
+
+/**
+ * Convert tab-separated clipboard data (e.g. copied from a spreadsheet) into
+ * a GFM table using the first row as the header. Returns null when `text`
+ * isn't TSV-shaped: fewer than 2 rows, fewer than 2 columns, or a ragged
+ * (inconsistent column count) grid.
+ */
+export function tsvToMarkdownTable(text: string): string | null {
+  const rows = text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((line) => line.length > 0)
+  if (rows.length < 2) return null
+
+  const cells = rows.map((row) => row.split('\t'))
+  const columnCount = cells[0]?.length ?? 0
+  if (columnCount < 2) return null
+  if (cells.some((row) => row.length !== columnCount)) return null
+
+  const header = cells[0] ?? []
+  const body = cells.slice(1)
+
+  const headerRow = `| ${header.map(escapeCell).join(' | ')} |`
+  const separatorRow = `| ${header.map(() => '---').join(' | ')} |`
+  const bodyRows = body.map((row) => `| ${row.map(escapeCell).join(' | ')} |`)
+
+  return [headerRow, separatorRow, ...bodyRows].join('\n')
+}

--- a/apps/cockpit/src/tools/markdown-editor/task-list.ts
+++ b/apps/cockpit/src/tools/markdown-editor/task-list.ts
@@ -1,0 +1,78 @@
+// Pure helper for toggling a GFM task-list checkbox in markdown source by
+// index. Kept separate from the preview component so the counting/toggling
+// logic (which has to skip fenced code blocks) is unit testable on its own.
+
+const TASK_LINE_RE = /^(\s*)(?:[-*+]|\d+[.)])\s\[([ xX])\](?:\s.*)?$/
+const FENCE_RE = /^\s*(```+|~~~+)/
+
+/**
+ * Toggle the Nth (0-indexed, source order) GFM task-list checkbox in
+ * `content` between `[ ]` and `[x]`. Checkboxes inside fenced code blocks
+ * are not counted (and can't be toggled) — only real task-list items are.
+ * Returns `content` unchanged if `index` is out of range.
+ */
+export function toggleTaskAtIndex(content: string, index: number): string {
+  if (index < 0) return content
+
+  const lines = content.split('\n')
+  let count = -1
+  let inFence = false
+  let fenceMarker = ''
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+
+    const fenceMatch = FENCE_RE.exec(line)
+    if (fenceMatch) {
+      const marker = (fenceMatch[1] ?? '```').slice(0, 3)
+      if (!inFence) {
+        inFence = true
+        fenceMarker = marker
+      } else if (marker[0] === fenceMarker[0]) {
+        inFence = false
+        fenceMarker = ''
+      }
+      continue
+    }
+    if (inFence) continue
+
+    const taskMatch = TASK_LINE_RE.exec(line)
+    if (!taskMatch) continue
+
+    count++
+    if (count !== index) continue
+
+    const checked = (taskMatch[2] ?? ' ').toLowerCase() === 'x'
+    lines[i] = line.replace(/\[([ xX])\]/, checked ? '[ ]' : '[x]')
+    break
+  }
+
+  return lines.join('\n')
+}
+
+/** Count the number of GFM task-list checkboxes in `content` (fences excluded). */
+export function countTasks(content: string): number {
+  const lines = content.split('\n')
+  let count = 0
+  let inFence = false
+  let fenceMarker = ''
+
+  for (const line of lines) {
+    const fenceMatch = FENCE_RE.exec(line)
+    if (fenceMatch) {
+      const marker = (fenceMatch[1] ?? '```').slice(0, 3)
+      if (!inFence) {
+        inFence = true
+        fenceMarker = marker
+      } else if (marker[0] === fenceMarker[0]) {
+        inFence = false
+        fenceMarker = ''
+      }
+      continue
+    }
+    if (inFence) continue
+    if (TASK_LINE_RE.test(line)) count++
+  }
+
+  return count
+}

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
@@ -138,6 +138,10 @@ export default function MermaidEditor() {
 
   const setLastAction = useUiStore((s) => s.setLastAction)
   const [svgHtml, setSvgHtml] = useState('')
+  // Stable identity — React 19 compares `dangerouslySetInnerHTML` by object
+  // identity, not by the `__html` string, so an inline literal re-writes
+  // innerHTML on every render. Here that also resets the rendered SVG mid-pan.
+  const svgProp = useMemo(() => ({ __html: svgHtml }), [svgHtml])
   const [error, setError] = useState<string | null>(null)
   const [isRendering, setIsRendering] = useState(false)
   const [showTemplates, setShowTemplates] = useState(false)
@@ -661,10 +665,7 @@ export default function MermaidEditor() {
               }}
             >
               {svgHtml ? (
-                <div
-                  data-testid="mermaid-preview-content"
-                  dangerouslySetInnerHTML={{ __html: svgHtml }}
-                />
+                <div data-testid="mermaid-preview-content" dangerouslySetInnerHTML={svgProp} />
               ) : (
                 <div className="select-none text-center text-sm text-[var(--color-text-muted)]">
                   {isRendering ? (

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -116,6 +116,18 @@ export default function RegexTester() {
   const replaceValue = evaluated?.replaceResult ?? state.testString
   const replaceError = timedOut ? TIMEOUT_MESSAGE : (evaluated?.replaceError ?? null)
 
+  // Stable identity — React 19 compares `dangerouslySetInnerHTML` by object
+  // identity, not by the `__html` string, so an inline literal re-writes
+  // innerHTML on every render and wipes any selection in the highlight pane.
+  const highlightProp = useMemo(
+    () => ({
+      __html:
+        evaluated?.highlightHtml ||
+        '<span style="color:var(--color-text-muted)">Matches will be highlighted here</span>',
+    }),
+    [evaluated]
+  )
+
   // Character-level diff between source and substituted text (only computed when needed)
   const charDiff = useMemo(() => {
     if (!showDiff || mode !== 'replace') return null
@@ -352,11 +364,7 @@ export default function RegexTester() {
             ) : (
               <div
                 className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm text-[var(--color-text)]"
-                dangerouslySetInnerHTML={{
-                  __html:
-                    evaluated?.highlightHtml ||
-                    '<span style="color:var(--color-text-muted)">Matches will be highlighted here</span>',
-                }}
+                dangerouslySetInnerHTML={highlightProp}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- **Fixed text selection being destroyed in the Markdown Editor preview** (the original report). Two independent causes, both fixed:
  1. Scrolling (including the automatic scroll sync between edit/preview panes) called `removeAllRanges()` on the real browser selection instead of just repositioning the floating selection toolbar. Scroll/resize now only reposition the toolbar (rAF-throttled); the selection is left alone until you explicitly dismiss it or trigger an action.
  2. The actual root cause of the symptom that survived fix 1: React 19 compares `dangerouslySetInnerHTML` by **object identity**, not by the `__html` string inside it (React 18 compared the string). The inline `{ __html: html }` literal was a new object every render, so React re-set `innerHTML` on every render — tearing down and rebuilding the entire preview subtree even when the markup was byte-identical. Selecting text updates the toolbar state → re-render → subtree rebuilt → selection gone. Memoising the payload makes React skip the write.
- **Swept the same bug across the app.** The four other `dangerouslySetInnerHTML` call sites had identical inline literals and are now memoised too: `NotesDrawer`, `MermaidEditor` (also reset the rendered SVG mid-pan), `RegexTester`, `DiffViewer`. DiffViewer's DOMPurify config is hoisted to a module constant so the memo has stable deps, which additionally keeps the sanitize pass off the render path. A source-scanning guard test fails the build if a sixth inline literal ever appears.
- **Checked in the debugging harness** that found the root cause: `scripts/tauri-browser-stub.js` stubs `window.__TAURI_INTERNALS__` so the web bundle boots in plain Chromium, and `apps/cockpit/documentation/BROWSER_HARNESS.md` documents the workflow, the DOM-forensics recipes (trapping `innerHTML` writes, correlating MutationObserver records with `selectionchange`), and the React 19 identity rule. Static reading did not find this bug; a reproduction did.
- Added a **File** menu to the Markdown Editor (Open…, Save, Save As…), wired up alongside the existing ⌘O / ⌘S shortcuts.
- Opening a file now remembers its location, so **Save** (⌘S or File > Save) writes straight back to that file instead of always prompting a "Save As" dialog. If no file has been opened yet, Save falls back to the Save As dialog as before.
- The header now shows the current file name with a small dirty indicator (•) when there are unsaved changes.
- Added smart Enter/Tab list editing: Enter continues bullet/ordered (with renumbering)/task (always fresh unchecked)/quote markers at end-of-line, and clears an empty marker to exit the list instead of adding another blank one; Enter elsewhere behaves like default Monaco. Tab/Shift-Tab indent/outdent list lines (respecting `tabSize`/`insertSpaces`, renumbering ordered items) when there's no multi-line selection, and fall back to default Monaco behavior outside lists. Pure logic lives in `list-editing.ts`; wiring is in the `useMarkdownListEditing` hook.
- Made GFM task-list checkboxes clickable in the preview. remark-gfm always renders them `disabled`, which makes them inert in the DOM, so a DOM-only listener can't toggle them without changing what's rendered. Rather than loosen the shared `markdownSanitizeSchema`/`markdownProcessor` (which the Notes drawer also renders through and must keep showing dead checkboxes), the editor now renders through a new `markdownEditorProcessor`/`markdownEditorSanitizeSchema` variant that's identical except it doesn't re-add `disabled`. Clicking (or pressing Enter on a focused) checkbox N toggles the Nth GFM task item in source order — skipping checkboxes inside fenced code — via `toggleTaskAtIndex`, writing back through the normal `updateState({ content })` path so undo/redo, the dirty indicator, and debounced re-render all keep working.
- Added smart paste: pasting a URL over a non-empty selection replaces the selection with `[selected text](url)`; a URL with no selection still pastes as plain text. Pasting tab-separated data (≥2 columns, ≥2 rows) converts it into a GFM table, escaping `|` in cells. Everything else pastes unchanged. Intercepted on the Monaco DOM node in the capture phase, since `onDidPaste` fires too late to alter the inserted content. Pure helpers (`isUrl`, `tsvToMarkdownTable`) live in `paste-helpers.ts`; wiring is in `useMarkdownSmartPaste`. No new dependencies — deliberately no HTML-to-markdown conversion, per scope.

## Test plan
- [x] `bunx tsc --noEmit` — zero errors
- [x] `bunx vitest run` — all 751 tests passing across 82 files (was 701; +50 from this PR, zero regressions)
- [x] `bun run lint` — zero errors
- [x] Local Tauri release build — exit 0, produced `devdrivr.app` + `devdrivr_0.1.57_aarch64.dmg`
- [x] Verified in Chromium against the built app's behaviour: drag-select and double-click select now hold in Preview *and* Split mode
- [x] New test: preview DOM nodes are preserved across a re-render when the html is unchanged (fails without the memo fix, with `Object.is` inequality on the paragraph node)
- [x] New test: source-wide guard — no `.tsx` file passes an inline object literal to `dangerouslySetInnerHTML` (verified it fails when a violation is introduced)
- [x] New test: scrolling/resizing while a preview selection is active does not clear the browser selection; explicit dismiss still does
- [x] New tests: File menu renders; Open… populates content/filename/path; Save writes directly to a known path without a dialog; Save falls back to the dialog when no path is known; dirty indicator appears on edit and clears on save
- [x] New tests: `list-editing.ts` (marker parsing, empty-marker detection, next-line marker generation, indent/outdent, ordered-list renumbering around an anchor and around a moved line)
- [x] New tests: `task-list.ts` (`toggleTaskAtIndex` for checked/unchecked/nested/fenced-code exclusion, `countTasks`)
- [x] New tests: `paste-helpers.ts` (`isUrl` positive/negative cases, `tsvToMarkdownTable` including ragged/narrow/lone-URL negative cases)
- [x] New tests: preview checkbox click/Enter toggles the right source-order index end-to-end through `MarkdownEditor`
- [x] New tests: the editor pipeline emits `<input type="checkbox">` without `disabled`, the shared pipeline still emits it with `disabled`, and inputs are still restricted to checkboxes

## Review findings (fixed in this PR)
Self-review before merge turned up two blockers, both fixed here:

1. **Task-list checkboxes shipped `disabled`, so the toggle feature did not work at all.** `markdownEditorSanitizeSchema` was a no-op — it dropped the explicit `['disabled', true]` allowlist entry but still spread `defaultSchema.attributes.input`, which contains the same entry, and inherited `defaultSchema.required = { input: { disabled: true, type: 'checkbox' } }`, which re-attaches the attribute *after* filtering. Both pipelines emitted byte-identical HTML. Browsers don't dispatch click events from disabled form controls, so the checkbox was inert in the app; the tests passed because `fireEvent.click` fires on a disabled node regardless — they asserted the handler, never the rendered attribute. Fixed both halves of the schema and added tests that pin the emitted HTML.
2. **A stray `.playwright-mcp/` artifact** from the debugging session was committed. Removed, and the directory is now gitignored.

Verified in Chromium against the dev server rather than argued from the code: clicking a preview checkbox rewrites the source to `- [x]`, and the same click on a `disabled` checkbox changes nothing even with `force: true`. Drag-select and double-click select in the preview both hold. Also dropped the unused `processMarkdownForEditor` export and corrected the harness doc (dev server is `:1420`, not `:5173`).

## Known limitations
- The selection fix cannot be regression-tested end-to-end in Vitest — jsdom has no real layout or selection. The unit test asserts the observable proxy (DOM node identity across re-render), and the browser harness is checked in so the real behaviour can be re-verified by hand.
- `src-tauri/Cargo.toml` is still at `0.1.54` while `package.json` / `tauri.conf.json` are at `0.1.57`. Pre-existing drift, not touched here.
- Ordered-list renumbering after Tab/Shift-Tab only renumbers the contiguous run(s) directly touching the moved line; it does not merge numbering across a gap left behind (e.g. a nested/blank-line-separated run keeps its own start number rather than continuing the outer list's sequence). Kept intentionally simple rather than over-engineered.


