### PR TITLE
refactor(cockpit): unify tool UI patterns

### DIFF
--- a/apps/cockpit/documentation/API_COMPONENTS.md
+++ b/apps/cockpit/documentation/API_COMPONENTS.md
@@ -98,8 +98,9 @@ A customizable button component with different visual variants.
 
 **Props:**
 
-- `variant`: Button style variant ('primary' | 'secondary' | 'ghost')
-- `size`: Button size ('sm' | 'md')
+- `variant`: Button style variant (`primary`, `secondary`, `ghost`, `danger`, or `icon`)
+- `size`: Button size (`xs`, `sm`, or `md`)
+- `loading`: Preserves width while showing the shared spinner and disabling the button
 - All standard HTMLButtonElement props
 
 **Example:**
@@ -143,6 +144,7 @@ Horizontal tab navigation component.
 - `tabs`: Array of tab objects with id and label
 - `activeTab`: Currently active tab ID
 - `onTabChange`: Callback when tab changes
+- `aria-label`: Optional tab-list label (defaults to "Tool sections")
 
 **Example:**
 
@@ -204,6 +206,27 @@ import { CopyButton } from '@/components/shared/CopyButton'
 
 <CopyButton text={output} label="Copy result" />
 ```
+
+### TextArea
+
+Standard multiline input with shared typography, focus, disabled, border, and radius behavior.
+
+**Location:** `src/components/shared/TextArea.tsx`
+
+Use `monospace` for source or code and `size="md"` for larger prose input.
+
+### StatusBadge
+
+Compact semantic status treatment for `neutral`, `info`, `success`, `warning`, and `error` states.
+
+**Location:** `src/components/shared/StatusBadge.tsx`
+
+### Toolbar
+
+Shared action row with optional wrapping. Use `ToolbarGroup` to label related actions and
+`ToolbarSpacer` to keep trailing actions predictably aligned.
+
+**Location:** `src/components/shared/Toolbar.tsx`
 
 ### ErrorBoundary
 

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -208,14 +208,17 @@ import { Button } from '@/components/shared/Button'
 <Button variant="primary">Run</Button>        // accent background — main CTA
 <Button variant="secondary">Cancel</Button>   // border style — default
 <Button variant="ghost">Settings</Button>     // text only — minimal chrome
+<Button variant="danger">Delete</Button>      // destructive action
+<Button variant="icon" aria-label="Save">…</Button> // icon-only action
 
 // Sizes
 <Button size="md">Default</Button>            // px-4 py-2
 <Button size="sm">Compact</Button>            // px-2 py-1
+<Button size="xs">Dense toolbar</Button>       // px-1.5 py-0.5
 
 // All standard HTMLButtonElement props pass through
-<Button variant="primary" disabled={loading} onClick={handleRun}>
-  {loading ? 'Running…' : 'Run'}
+<Button variant="primary" loading={loading} onClick={handleRun}>
+  Run
 </Button>
 ```
 
@@ -223,7 +226,12 @@ import { Button } from '@/components/shared/Button'
 
 - `primary` — one per tool, the main action (Format, Run, Generate, etc.)
 - `secondary` — secondary actions (Clear, Reset, Copy as…)
-- `ghost` — tertiary actions, icon-only buttons, navigation
+- `ghost` — tertiary actions and navigation
+- `danger` — destructive actions only
+- `icon` — icon-only controls; always provide `aria-label` (it also becomes the tooltip)
+
+Use `loading` for asynchronous actions. It preserves the button width, announces busy state, and
+disables repeat clicks. Use one `primary` action per action group, not one per screen.
 
 ### `CopyButton`
 
@@ -235,7 +243,7 @@ import { CopyButton } from '@/components/shared/CopyButton'
 <CopyButton text={output} className="ml-auto" />
 ```
 
-Shows "✓ Copied" for 1.5s after click. Triggers a success toast automatically.
+Shows a check icon and "Copied" for 1.5s after click. Triggers a success toast automatically.
 
 ### `TabBar`
 
@@ -255,6 +263,40 @@ const TABS = [
 ```
 
 Active tab has a 2px bottom border in `--color-accent`. Use `TabBar` for multi-mode tools.
+It exposes the ARIA tab pattern, supports arrow/Home/End navigation, and scrolls horizontally when
+the available width is narrow. Use `SegmentedControl` for a view mode rather than document sections.
+
+### `Toolbar` and `ToolbarGroup`
+
+```typescript
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
+
+<Toolbar aria-label="Editor actions">
+  <ToolbarGroup label="Document actions">…</ToolbarGroup>
+  <ToolbarGroup label="Formatting" separated>…</ToolbarGroup>
+  <ToolbarSpacer />
+  <ToolbarGroup label="Export actions">…</ToolbarGroup>
+</Toolbar>
+```
+
+Place document-wide actions in the tool toolbar. Use groups and separators for different action
+families; keep actions for a specific pane in that pane's header.
+
+### `Input`, `Select`, and `TextArea`
+
+Use these primitives for native form controls instead of duplicating border, radius, focus, and
+disabled styles. Set `monospace` on `TextArea` for source/code. Full-bleed editor textareas may
+override radius and border while retaining the shared typography and focus contract.
+
+### `Alert`, `StatusBadge`, and `EmptyState`
+
+- `Alert` is for a message that needs attention or explains an operation outcome.
+- `StatusBadge` is for a compact state or metadata value, such as HTTP status or validity.
+- `EmptyState` replaces ambiguous blank panes and may include a single next-step action.
+
+Use semantic variants (`info`, `success`, `warning`, `error`) rather than styling status text at the
+call site. Do not add check marks, warning glyphs, emoji, or custom SVG; the shared component or a
+Phosphor icon supplies the visual cue.
 
 ### `Toggle`
 

--- a/apps/cockpit/src/components/shared/Alert.tsx
+++ b/apps/cockpit/src/components/shared/Alert.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import type { ComponentType, ReactNode } from 'react'
+import { CheckCircleIcon, InfoIcon, WarningCircleIcon, XCircleIcon } from '@phosphor-icons/react'
 
 type AlertVariant = 'error' | 'success' | 'warning' | 'info'
 
@@ -17,14 +18,23 @@ const VARIANT_CLASSES: Record<AlertVariant, string> = {
   info: 'bg-[var(--color-info)]/10 text-[var(--color-info)] border-l-[var(--color-info)]',
 }
 
+const VARIANT_ICONS = {
+  error: XCircleIcon,
+  success: CheckCircleIcon,
+  warning: WarningCircleIcon,
+  info: InfoIcon,
+} satisfies Record<AlertVariant, ComponentType<{ size?: number; weight?: 'fill' }>>
+
 export function Alert({ variant, children, className = '' }: AlertProps) {
+  const Icon = VARIANT_ICONS[variant]
   return (
     <div
       role="alert"
       aria-live={variant === 'error' ? 'assertive' : 'polite'}
-      className={`rounded border-l-2 px-3 py-2 text-xs ${VARIANT_CLASSES[variant]} ${className}`}
+      className={`flex items-start gap-2 rounded-[var(--radius-md)] border-l-2 px-3 py-2 text-xs ${VARIANT_CLASSES[variant]} ${className}`}
     >
-      {children}
+      <Icon size={14} weight="fill" aria-hidden="true" className="mt-px shrink-0" />
+      <div className="min-w-0 flex-1">{children}</div>
     </div>
   )
 }

--- a/apps/cockpit/src/components/shared/Button.tsx
+++ b/apps/cockpit/src/components/shared/Button.tsx
@@ -44,6 +44,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       size = 'md',
       loading = false,
       disabled,
+      title,
       className = '',
       children,
       ...props
@@ -54,9 +55,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
+        type="button"
         disabled={disabled || loading}
         aria-busy={loading || undefined}
-        className={`font-ui relative inline-flex items-center justify-center rounded-[var(--radius-sm)] transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${VARIANT_CLASSES[variant]} ${sizeClasses} ${className}`}
+        title={title ?? (variant === 'icon' ? props['aria-label'] : undefined)}
+        className={`font-ui relative inline-flex items-center justify-center gap-1.5 rounded-[var(--radius-sm)] transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${VARIANT_CLASSES[variant]} ${sizeClasses} ${className}`}
         {...props}
       >
         {loading ? (

--- a/apps/cockpit/src/components/shared/CopyButton.tsx
+++ b/apps/cockpit/src/components/shared/CopyButton.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
+import { CheckIcon, CopyIcon } from '@phosphor-icons/react'
 import { useUiStore } from '@/stores/ui.store'
+import { Button } from '@/components/shared/Button'
 
 type CopyButtonProps = {
   text: string
@@ -23,13 +25,22 @@ export function CopyButton({ text, label = 'Copy', className = '' }: CopyButtonP
   }
 
   return (
-    <button
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
       onClick={() => {
         void handleCopy()
       }}
-      className={`min-w-[5rem] rounded border border-[var(--color-border)] px-2 py-1 text-xs transition-colors duration-150 text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${copied ? 'border-[var(--color-success)] text-[var(--color-success)]' : ''} ${className}`}
+      aria-label={copied ? `${label}: copied` : label}
+      className={`min-w-[5rem] ${copied ? 'border-[var(--color-success)] text-[var(--color-success)]' : ''} ${className}`}
     >
-      {copied ? '✓ Copied' : label}
-    </button>
+      {copied ? (
+        <CheckIcon size={12} weight="bold" aria-hidden="true" />
+      ) : (
+        <CopyIcon size={12} aria-hidden="true" />
+      )}
+      {copied ? 'Copied' : label}
+    </Button>
   )
 }

--- a/apps/cockpit/src/components/shared/Input.tsx
+++ b/apps/cockpit/src/components/shared/Input.tsx
@@ -17,7 +17,7 @@ const SIZE_CLASSES: Record<InputSize, string> = {
 }
 
 const BASE_CLASSES =
-  'rounded border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-150 disabled:opacity-50'
+  'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-150 disabled:opacity-50'
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ size = 'sm', className = '', ...props }, ref) => {

--- a/apps/cockpit/src/components/shared/StatusBadge.tsx
+++ b/apps/cockpit/src/components/shared/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+type StatusBadgeVariant = 'neutral' | 'info' | 'success' | 'warning' | 'error'
+
+type StatusBadgeProps = {
+  variant?: StatusBadgeVariant
+  children: ReactNode
+  className?: string
+}
+
+const VARIANT_CLASSES: Record<StatusBadgeVariant, string> = {
+  neutral: 'bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]',
+  info: 'bg-[var(--color-info)]/15 text-[var(--color-info)]',
+  success: 'bg-[var(--color-success)]/15 text-[var(--color-success)]',
+  warning: 'bg-[var(--color-warning)]/15 text-[var(--color-warning)]',
+  error: 'bg-[var(--color-error)]/15 text-[var(--color-error)]',
+}
+
+export function StatusBadge({ variant = 'neutral', children, className = '' }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-bold ${VARIANT_CLASSES[variant]} ${className}`}
+    >
+      {children}
+    </span>
+  )
+}

--- a/apps/cockpit/src/components/shared/TabBar.tsx
+++ b/apps/cockpit/src/components/shared/TabBar.tsx
@@ -1,6 +1,9 @@
+import { useRef } from 'react'
+
 type Tab = {
   id: string
   label: string
+  disabled?: boolean
 }
 
 type TabBarProps = {
@@ -9,19 +12,72 @@ type TabBarProps = {
   onTabChange: (tabId: string) => void
   /** Pass true when the parent container already provides the bottom border. */
   noBorder?: boolean
+  'aria-label'?: string
+  className?: string
 }
 
-export function TabBar({ tabs, activeTab, onTabChange, noBorder }: TabBarProps) {
+export function TabBar({
+  tabs,
+  activeTab,
+  onTabChange,
+  noBorder,
+  className = '',
+  'aria-label': ariaLabel = 'Tool sections',
+}: TabBarProps) {
+  const buttonRefs = useRef(new Map<string, HTMLButtonElement>())
+
+  const selectAndFocus = (startIndex: number, direction: 1 | -1) => {
+    if (tabs.length === 0) return
+    for (let offset = 0; offset < tabs.length; offset += 1) {
+      const index = (startIndex + offset * direction + tabs.length) % tabs.length
+      const tab = tabs[index]
+      if (tab && !tab.disabled) {
+        onTabChange(tab.id)
+        buttonRefs.current.get(tab.id)?.focus()
+        return
+      }
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      selectAndFocus(index + 1, 1)
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      selectAndFocus(index - 1, -1)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      selectAndFocus(0, 1)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      selectAndFocus(tabs.length - 1, -1)
+    }
+  }
   // Tab switching via Cmd+1/2/3 is handled globally in useGlobalShortcuts
   // via the 'switch-tab' tool action — no duplicate registration here.
 
   return (
-    <div className={`flex ${noBorder ? '' : 'border-b border-[var(--color-border)]'}`}>
-      {tabs.map((tab) => (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={`flex min-w-0 overflow-x-auto ${noBorder ? '' : 'border-b border-[var(--color-border)]'} ${className}`}
+    >
+      {tabs.map((tab, index) => (
         <button
           key={tab.id}
+          ref={(element) => {
+            if (element) buttonRefs.current.set(tab.id, element)
+            else buttonRefs.current.delete(tab.id)
+          }}
+          type="button"
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          tabIndex={activeTab === tab.id ? 0 : -1}
+          disabled={tab.disabled}
           onClick={() => onTabChange(tab.id)}
-          className={`px-4 py-2 text-xs transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
+          onKeyDown={(event) => handleKeyDown(event, index)}
+          className={`shrink-0 px-4 py-2 text-xs transition-colors duration-150 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
             activeTab === tab.id
               ? 'border-b-2 border-[var(--color-accent)] bg-[var(--color-accent-dim)]/30 font-bold text-[var(--color-accent)]'
               : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'

--- a/apps/cockpit/src/components/shared/TextArea.tsx
+++ b/apps/cockpit/src/components/shared/TextArea.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react'
+
+type TextAreaSize = 'sm' | 'md'
+
+type TextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  size?: TextAreaSize
+  monospace?: boolean
+}
+
+const SIZE_CLASSES: Record<TextAreaSize, string> = {
+  sm: 'px-3 py-2 text-xs leading-5',
+  md: 'px-3 py-2 text-sm leading-6',
+}
+
+const BASE_CLASSES =
+  'w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] outline-none transition-colors duration-150 focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] disabled:pointer-events-none disabled:opacity-50'
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ size = 'sm', monospace = false, className = '', ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={`${BASE_CLASSES} ${SIZE_CLASSES[size]} ${monospace ? 'font-mono' : ''} ${className}`}
+      {...props}
+    />
+  )
+)
+
+TextArea.displayName = 'TextArea'

--- a/apps/cockpit/src/components/shared/ToolLayout.tsx
+++ b/apps/cockpit/src/components/shared/ToolLayout.tsx
@@ -50,7 +50,7 @@ export function ToolLayout({
           )}
         </div>
       )}
-      {toolbar}
+      {toolbar && <div className="shrink-0 bg-[var(--color-surface)]">{toolbar}</div>}
       {fullBleed ? (
         <div className="flex flex-1 flex-col overflow-hidden">{children}</div>
       ) : (

--- a/apps/cockpit/src/components/shared/Toolbar.tsx
+++ b/apps/cockpit/src/components/shared/Toolbar.tsx
@@ -85,6 +85,10 @@ type DocumentIdentityProps = {
   status?: ReactNode
   statusIcon?: ReactNode
   statusTestId?: string
+  /**
+   * Off for identity lines whose "status" is static context (a file path, say)
+   * rather than a result worth announcing. Keep it on for anything that settles.
+   */
   statusLive?: boolean
   className?: string
 }
@@ -115,6 +119,7 @@ export function DocumentIdentity({
       </span>
       {stateLabel && (
         <span
+          aria-live="polite"
           className={`shrink-0 text-2xs ${stateChanged ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
         >
           {stateLabel}

--- a/apps/cockpit/src/components/shared/Toolbar.tsx
+++ b/apps/cockpit/src/components/shared/Toolbar.tsx
@@ -5,17 +5,57 @@ type ToolbarProps = {
   className?: string
   /** Bottom border — the common `border-b` toolbar row. Off for toolbars stacked under another bordered row. */
   border?: boolean
+  /** Accessible label for a toolbar containing several action groups. */
+  'aria-label'?: string
+  /** Disable wrapping for horizontally scrollable editor toolbars. */
+  wrap?: boolean
 }
 
 // Horizontal control bar — codifies the
 // `flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2`
 // row hand-rolled at the top of most tools (CsvTools, ApiClient, CodeFormatter, ...).
-export function Toolbar({ children, className = '', border = true }: ToolbarProps) {
+export function Toolbar({
+  children,
+  className = '',
+  border = true,
+  wrap = true,
+  'aria-label': ariaLabel,
+}: ToolbarProps) {
   return (
     <div
-      className={`flex items-center gap-2 px-4 py-2 ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
+      role="toolbar"
+      aria-label={ariaLabel}
+      className={`flex items-center gap-2 px-4 py-2 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
     >
       {children}
     </div>
   )
+}
+
+type ToolbarGroupProps = {
+  children: ReactNode
+  label?: string
+  separated?: boolean
+  className?: string
+}
+
+export function ToolbarGroup({
+  children,
+  label,
+  separated = false,
+  className = '',
+}: ToolbarGroupProps) {
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className={`flex shrink-0 items-center gap-1.5 ${separated ? 'border-l border-[var(--color-border)] pl-2' : ''} ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function ToolbarSpacer() {
+  return <div className="min-w-2 flex-1" aria-hidden="true" />
 }

--- a/apps/cockpit/src/components/shared/Toolbar.tsx
+++ b/apps/cockpit/src/components/shared/Toolbar.tsx
@@ -25,7 +25,7 @@ export function Toolbar({
     <div
       role="toolbar"
       aria-label={ariaLabel}
-      className={`flex items-center gap-2 px-4 py-2 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
+      className={`flex min-h-10 items-center gap-2 bg-[var(--color-surface)] px-4 py-2 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
     >
       {children}
     </div>
@@ -58,4 +58,79 @@ export function ToolbarGroup({
 
 export function ToolbarSpacer() {
   return <div className="min-w-2 flex-1" aria-hidden="true" />
+}
+
+type DocumentToolbarProps = ToolbarProps
+
+/**
+ * Compact, wrapping chrome for document-oriented tools. Identity, view controls,
+ * and primary actions share one row at normal widths and wrap as groups when the
+ * workspace narrows.
+ */
+export function DocumentToolbar({ children, className = '', ...props }: DocumentToolbarProps) {
+  return (
+    <Toolbar {...props} className={`gap-x-3 gap-y-2 ${className}`}>
+      {children}
+    </Toolbar>
+  )
+}
+
+type DocumentIdentityProps = {
+  title: string
+  titleTooltip?: string
+  titleTestId?: string
+  icon?: ReactNode
+  stateLabel?: string
+  stateChanged?: boolean
+  status?: ReactNode
+  statusIcon?: ReactNode
+  statusTestId?: string
+  statusLive?: boolean
+  className?: string
+}
+
+/** File identity and live status used at the leading edge of a document toolbar. */
+export function DocumentIdentity({
+  title,
+  titleTooltip,
+  titleTestId,
+  icon,
+  stateLabel,
+  stateChanged = false,
+  status,
+  statusIcon,
+  statusTestId,
+  statusLive = true,
+  className = '',
+}: DocumentIdentityProps) {
+  return (
+    <div className={`flex min-w-0 flex-1 items-center gap-2 ${className}`}>
+      {icon}
+      <span
+        data-testid={titleTestId}
+        className="font-ui max-w-56 truncate text-xs font-semibold text-[var(--color-text)]"
+        title={titleTooltip ?? title}
+      >
+        {title}
+      </span>
+      {stateLabel && (
+        <span
+          className={`shrink-0 text-2xs ${stateChanged ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
+        >
+          {stateLabel}
+        </span>
+      )}
+      {status && (
+        <span
+          data-testid={statusTestId}
+          role={statusLive ? 'status' : undefined}
+          aria-live={statusLive ? 'polite' : undefined}
+          className="flex min-w-0 items-center gap-1 truncate text-2xs text-[var(--color-text-muted)]"
+        >
+          {statusIcon}
+          <span className="truncate">{status}</span>
+        </span>
+      )}
+    </div>
+  )
 }

--- a/apps/cockpit/src/components/shared/__tests__/CopyButton.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/CopyButton.test.tsx
@@ -20,4 +20,11 @@ describe('CopyButton', () => {
       'focus-visible:shadow-[var(--focus-ring)]'
     )
   })
+
+  it('uses the shared secondary button treatment', () => {
+    render(<CopyButton text="hello" />)
+    expect(screen.getByRole('button', { name: 'Copy' }).className).toContain(
+      'border-[var(--color-border)]'
+    )
+  })
 })

--- a/apps/cockpit/src/components/shared/__tests__/StatusBadge.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+
+describe('StatusBadge', () => {
+  it('uses the requested semantic token treatment', () => {
+    render(<StatusBadge variant="success">Ready</StatusBadge>)
+    const badge = screen.getByText('Ready')
+    expect(badge.className).toContain('bg-[var(--color-success)]/15')
+    expect(badge.className).toContain('text-[var(--color-success)]')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/TabBar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/TabBar.test.tsx
@@ -11,16 +11,28 @@ describe('TabBar', () => {
   it('renders each tab and reports clicks', () => {
     const onTabChange = vi.fn()
     render(<TabBar tabs={TABS} activeTab="a" onTabChange={onTabChange} />)
-    fireEvent.click(screen.getByRole('button', { name: 'B' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'B' }))
     expect(onTabChange).toHaveBeenCalledWith('b')
   })
 
   it('draws a focus-visible ring from the --focus-ring token on every tab button', () => {
     render(<TabBar tabs={TABS} activeTab="a" onTabChange={() => {}} />)
     for (const tab of TABS) {
-      expect(screen.getByRole('button', { name: tab.label }).className).toContain(
+      expect(screen.getByRole('tab', { name: tab.label }).className).toContain(
         'focus-visible:shadow-[var(--focus-ring)]'
       )
     }
+  })
+
+  it('exposes selection and supports arrow-key navigation', () => {
+    const onTabChange = vi.fn()
+    render(<TabBar tabs={TABS} activeTab="a" onTabChange={onTabChange} />)
+
+    const activeTab = screen.getByRole('tab', { name: 'A' })
+    expect(activeTab).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'B' })).toHaveAttribute('tabindex', '-1')
+
+    fireEvent.keyDown(activeTab, { key: 'ArrowRight' })
+    expect(onTabChange).toHaveBeenCalledWith('b')
   })
 })

--- a/apps/cockpit/src/components/shared/__tests__/TextArea.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/TextArea.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TextArea } from '@/components/shared/TextArea'
+
+describe('TextArea', () => {
+  it('provides the shared field and focus treatment', () => {
+    render(<TextArea aria-label="Source" />)
+    const input = screen.getByRole('textbox', { name: 'Source' })
+    expect(input.className).toContain('border-[var(--color-border)]')
+    expect(input.className).toContain('focus-visible:shadow-[var(--focus-ring)]')
+  })
+
+  it('supports code-oriented input', () => {
+    render(<TextArea aria-label="Code" monospace />)
+    expect(screen.getByRole('textbox', { name: 'Code' }).className).toContain('font-mono')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/ToolLayout.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/ToolLayout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { ToolLayout } from '../ToolLayout'
+import { ToolLayout } from '@/components/shared/ToolLayout'
 
 describe('ToolLayout', () => {
   it('renders children', () => {
@@ -41,6 +41,7 @@ describe('ToolLayout', () => {
       </ToolLayout>
     )
     expect(screen.getByTestId('toolbar')).toBeInTheDocument()
+    expect(screen.getByTestId('toolbar').parentElement).toHaveClass('bg-[var(--color-surface)]')
   })
 
   it('constrains body width to the default max-w when not full-bleed', () => {

--- a/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
@@ -59,5 +59,13 @@ describe('Toolbar', () => {
     expect(screen.getByText('styles.css')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('No problems')
     expect(screen.getByText('Modified')).toHaveClass('text-[var(--color-accent)]')
+    expect(screen.getByText('Modified')).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('leaves static context out of the live region', () => {
+    render(<DocumentIdentity title="notes.md" status="~/notes.md" statusLive={false} />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByText('~/notes.md')).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { Toolbar } from '../Toolbar'
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
 
 describe('Toolbar', () => {
   it('renders children in a row', () => {
@@ -19,5 +19,20 @@ describe('Toolbar', () => {
     const { container: noBorder } = render(<Toolbar border={false}>content</Toolbar>)
     expect(withBorder.firstElementChild?.className).toContain('border-b')
     expect(noBorder.firstElementChild?.className).not.toContain('border-b')
+  })
+
+  it('labels related action groups and provides a flexible spacer', () => {
+    const { container } = render(
+      <Toolbar aria-label="Editor actions">
+        <ToolbarGroup label="Document actions">
+          <button>Save</button>
+        </ToolbarGroup>
+        <ToolbarSpacer />
+      </Toolbar>
+    )
+
+    expect(screen.getByRole('toolbar', { name: 'Editor actions' })).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Document actions' })).toBeInTheDocument()
+    expect(container.querySelector('[aria-hidden="true"]')).toHaveClass('flex-1')
   })
 })

--- a/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
+import {
+  DocumentIdentity,
+  DocumentToolbar,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarSpacer,
+} from '@/components/shared/Toolbar'
 
 describe('Toolbar', () => {
   it('renders children in a row', () => {
@@ -34,5 +40,24 @@ describe('Toolbar', () => {
     expect(screen.getByRole('toolbar', { name: 'Editor actions' })).toBeInTheDocument()
     expect(screen.getByRole('group', { name: 'Document actions' })).toBeInTheDocument()
     expect(container.querySelector('[aria-hidden="true"]')).toHaveClass('flex-1')
+  })
+
+  it('keeps document identity and status inside compact wrapping chrome', () => {
+    render(
+      <DocumentToolbar aria-label="Document actions">
+        <DocumentIdentity
+          title="styles.css"
+          stateLabel="Modified"
+          stateChanged
+          status="No problems"
+        />
+        <button>Save</button>
+      </DocumentToolbar>
+    )
+
+    expect(screen.getByRole('toolbar', { name: 'Document actions' })).toHaveClass('min-h-10')
+    expect(screen.getByText('styles.css')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('No problems')
+    expect(screen.getByText('Modified')).toHaveClass('text-[var(--color-accent)]')
   })
 })

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -197,7 +197,7 @@ describe('NotesDrawer', () => {
     })
     render(<NotesDrawer />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'History' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'History' }))
     fireEvent.click(screen.getByRole('button', { name: 'Replay JSON Formatter history entry' }))
 
     expect(useUiStore.getState().pendingSendTo).toBe('{"ok":true}')

--- a/apps/cockpit/src/tools/__tests__/api-client.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/api-client.test.tsx
@@ -205,7 +205,7 @@ describe('ApiClient', () => {
     expect(screen.queryByText('Body is disabled')).not.toBeInTheDocument()
 
     // The tab label now carries the active-header count.
-    fireEvent.click(screen.getByRole('button', { name: 'Headers (1)' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'Headers (1)' }))
     expect(screen.getByDisplayValue('Content-Type')).toBeInTheDocument()
     expect(screen.getByDisplayValue('application/json')).toBeInTheDocument()
   })

--- a/apps/cockpit/src/tools/__tests__/base64.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/base64.test.tsx
@@ -13,7 +13,7 @@ describe('Base64Tool', () => {
 
   it('renders encode mode by default', () => {
     renderTool(Base64Tool)
-    expect(screen.getByText('Encode →')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Encode' })).toBeInTheDocument()
   })
 
   it('encodes text to base64', () => {
@@ -25,13 +25,13 @@ describe('Base64Tool', () => {
 
   it('toggles to decode mode', () => {
     renderTool(Base64Tool)
-    fireEvent.click(screen.getByText('Encode →'))
-    expect(screen.getByText('← Decode')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Encode' }))
+    expect(screen.getByRole('button', { name: 'Decode' })).toBeInTheDocument()
   })
 
   it('decodes base64 to text', () => {
     renderTool(Base64Tool)
-    fireEvent.click(screen.getByText('Encode →'))
+    fireEvent.click(screen.getByRole('button', { name: 'Encode' }))
     const input = screen.getByPlaceholderText(/enter base64/i)
     fireEvent.change(input, { target: { value: 'aGVsbG8=' } })
     expect(screen.getByText('hello')).toBeInTheDocument()
@@ -44,7 +44,7 @@ describe('Base64Tool', () => {
 
   it('does not render Encode File button in decode mode', () => {
     renderTool(Base64Tool)
-    fireEvent.click(screen.getByText('Encode →'))
+    fireEvent.click(screen.getByRole('button', { name: 'Encode' }))
     expect(screen.queryByTitle('Encode a file to Base64')).not.toBeInTheDocument()
   })
 
@@ -54,7 +54,7 @@ describe('Base64Tool', () => {
     // Can't easily trigger in unit test without actual image data,
     // but we can verify the zoom badge infrastructure exists by checking
     // the component renders without error
-    expect(screen.getByText('Encode →')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Encode' })).toBeInTheDocument()
   })
 
   it('shows drag overlay placeholder in encode textarea', () => {
@@ -66,7 +66,7 @@ describe('Base64Tool', () => {
   it('clears Encode File button when switching to decode mode', () => {
     renderTool(Base64Tool)
     expect(screen.getByTitle('Encode a file to Base64')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('Encode →')) // switch to decode
+    fireEvent.click(screen.getByRole('button', { name: 'Encode' })) // switch to decode
     expect(screen.queryByTitle('Encode a file to Base64')).not.toBeInTheDocument()
   })
 

--- a/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/mermaid-editor.test.tsx
@@ -439,7 +439,7 @@ describe('MermaidEditor — templates', () => {
     renderTool(MermaidEditor)
     type('flowchart TD\n  A --> B')
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    fireEvent.click(screen.getByRole('button', { name: 'New diagram' }))
     fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }))
 
     expect(editor().value).toBe('')
@@ -487,7 +487,7 @@ describe('MermaidEditor — files and export', () => {
     })
     renderTool(MermaidEditor)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Open Mermaid file' }))
 
     await waitFor(() => expect(screen.getByTestId('file-name')).toHaveTextContent('votes.mmd'))
     expect(screen.getByText('Saved')).toBeInTheDocument()

--- a/apps/cockpit/src/tools/__tests__/prompt-templates.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/prompt-templates.test.tsx
@@ -111,11 +111,11 @@ describe('PromptTemplates', () => {
     renderTool(PromptTemplates)
 
     expect(screen.getAllByText('Review: Detect Code Smells').length).toBeGreaterThan(0)
-    expect(screen.getByRole('button', { name: /fill variables/i })).toHaveAttribute(
-      'aria-pressed',
+    expect(screen.getByRole('tab', { name: /fill variables/i })).toHaveAttribute(
+      'aria-selected',
       'true'
     )
-    fireEvent.click(screen.getByRole('button', { name: /preview/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /preview/i }))
     expect(screen.getByText('[ 03-PREVIEW ]')).toBeInTheDocument()
   })
 

--- a/apps/cockpit/src/tools/__tests__/refactoring-toolkit.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/refactoring-toolkit.test.tsx
@@ -169,7 +169,7 @@ describe('RefactoringToolkit', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('const x = 1;'))
 
     fireEvent.click(screen.getByRole('radio', { name: 'Source' }))
-    // The button still reads "✓ Copied" from the click above.
+    // The button still reads "Copied" from the click above.
     fireEvent.click(screen.getByRole('button', { name: /Cop(y|ied)/ }))
     await waitFor(() => expect(writeText).toHaveBeenLastCalledWith('var x = 1;'))
   })

--- a/apps/cockpit/src/tools/__tests__/url-codec.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/url-codec.test.tsx
@@ -6,7 +6,7 @@ import UrlCodec from '../url-codec/UrlCodec'
 describe('UrlCodec', () => {
   it('renders encode mode by default', () => {
     renderTool(UrlCodec)
-    expect(screen.getByText('Encode →')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Encode' })).toBeInTheDocument()
   })
 
   it('encodes special characters', () => {
@@ -25,7 +25,7 @@ describe('UrlCodec', () => {
 
   it('toggles to decode mode', () => {
     renderTool(UrlCodec)
-    fireEvent.click(screen.getByText('Encode →'))
-    expect(screen.getByText('← Decode')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Encode' }))
+    expect(screen.getByRole('button', { name: 'Decode' })).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -13,6 +13,7 @@ import { Spinner } from '@/components/shared/Spinner'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Alert } from '@/components/shared/Alert'
+import { StatusBadge } from '@/components/shared/StatusBadge'
 import { useUiStore } from '@/stores/ui.store'
 import { sendToTool } from '@/lib/tool-handoff'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -808,7 +809,7 @@ export default function ApiClient() {
         id: 'headers',
         label: activeHeaderCount > 0 ? `Headers (${activeHeaderCount})` : 'Headers',
       },
-      { id: 'auth', label: auth.type === 'none' ? 'Auth' : 'Auth ✓' },
+      { id: 'auth', label: auth.type === 'none' ? 'Auth' : 'Auth (set)' },
       { id: 'body', label: 'Body' },
     ],
     [activeHeaderCount, auth.type, params.length]
@@ -1216,15 +1217,12 @@ export default function ApiClient() {
               {response && (
                 <>
                   <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
-                    <span
-                      className={`rounded px-1.5 py-0.5 font-mono text-xs font-bold ${
-                        response.status < 400
-                          ? 'bg-[var(--color-success)]/10 text-[var(--color-success)]'
-                          : 'bg-[var(--color-error)]/10 text-[var(--color-error)]'
-                      }`}
+                    <StatusBadge
+                      variant={response.status < 400 ? 'success' : 'error'}
+                      className="font-mono"
                     >
                       {response.status} {response.statusText}
-                    </span>
+                    </StatusBadge>
                     <span className="text-2xs text-[var(--color-text-muted)]">
                       {response.time}ms
                     </span>

--- a/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { Input } from '@/components/shared/Input'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { Alert } from '@/components/shared/Alert'
 import { ConfirmDialog } from './ConfirmDialog'
 import { PlusIcon, StackIcon, TrashIcon, XIcon } from '@phosphor-icons/react'
 
@@ -221,12 +222,12 @@ export function EnvironmentModal({ onClose }: Props) {
               </div>
 
               {error && (
-                <p
-                  role="alert"
-                  className="border-b border-[var(--color-border)] px-3 py-2 text-xs text-[var(--color-error)]"
+                <Alert
+                  variant="error"
+                  className="rounded-none border-b border-[var(--color-border)] px-3 py-2"
                 >
                   {error}
-                </p>
+                </Alert>
               )}
 
               <div className="min-h-0 flex-1 overflow-y-auto p-3">

--- a/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
+import { Alert } from '@/components/shared/Alert'
+import { TextArea } from '@/components/shared/TextArea'
 import { openFileDialog } from '@/lib/file-io'
 import { importApiSpec } from '@/lib/api-import'
 import type { ApiImportFormat, ApiImportResult } from '@/types/models'
@@ -120,7 +122,7 @@ export function ImportSpecModal({ onImport, onClose }: Props) {
           </Button>
         </div>
 
-        <textarea
+        <TextArea
           ref={textareaRef}
           value={content}
           onChange={(e) => {
@@ -129,14 +131,11 @@ export function ImportSpecModal({ onImport, onClose }: Props) {
             setError(null)
           }}
           placeholder="Paste API specification content here..."
-          className="min-h-56 resize-y rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 font-mono text-xs text-[var(--color-text)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+          monospace
+          className="min-h-56 resize-y"
         />
 
-        {error && (
-          <div className="rounded border border-[var(--color-error)] bg-[var(--color-surface)] p-3 text-xs text-[var(--color-error)]">
-            {error}
-          </div>
-        )}
+        {error && <Alert variant="error">{error}</Alert>}
 
         {preview && (
           <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -7,7 +7,18 @@ import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { UploadSimpleIcon, FileIcon, XIcon } from '@phosphor-icons/react'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { TextArea } from '@/components/shared/TextArea'
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
+import { Toggle } from '@/components/shared/Toggle'
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowsLeftRightIcon,
+  UploadSimpleIcon,
+  FileIcon,
+  XIcon,
+} from '@phosphor-icons/react'
 
 type Base64State = {
   input: string
@@ -338,41 +349,41 @@ export default function Base64Tool() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
-          <Button variant="primary" size="sm" onClick={handleToggle}>
-            {state.mode === 'encode' ? 'Encode →' : '← Decode'}
-          </Button>
-          <Button variant="secondary" size="sm" onClick={handleSwap} disabled={!output.text}>
-            ⇄ Swap
-          </Button>
-          <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
+        <Toolbar aria-label="Base64 conversion actions">
+          <ToolbarGroup label="Conversion actions">
+            <Button variant="primary" size="sm" onClick={handleToggle}>
+              {state.mode === 'decode' && <ArrowLeftIcon size={12} aria-hidden="true" />}
+              {state.mode === 'encode' ? 'Encode' : 'Decode'}
+              {state.mode === 'encode' && <ArrowRightIcon size={12} aria-hidden="true" />}
+            </Button>
+            <Button variant="secondary" size="sm" onClick={handleSwap} disabled={!output.text}>
+              <ArrowsLeftRightIcon size={12} aria-hidden="true" />
+              Swap
+            </Button>
+            <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
+          </ToolbarGroup>
 
-          <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
-            <input
-              type="checkbox"
+          <ToolbarGroup label="Encoding options" separated>
+            <Toggle
               checked={state.urlSafe}
-              onChange={(e) => updateState({ urlSafe: e.target.checked })}
-              className="accent-[var(--color-accent)]"
+              onChange={(urlSafe) => updateState({ urlSafe })}
+              label="URL-safe"
             />
-            URL-safe
-          </label>
-          {state.mode === 'encode' && !droppedFile && (
-            <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
-              <input
-                type="checkbox"
+            {state.mode === 'encode' && !droppedFile && (
+              <Toggle
                 checked={state.lineWrap}
-                onChange={(e) => updateState({ lineWrap: e.target.checked })}
-                className="accent-[var(--color-accent)]"
+                onChange={(lineWrap) => updateState({ lineWrap })}
+                label="Wrap 76"
               />
-              Wrap 76
-            </label>
-          )}
+            )}
 
-          {autoDetect && !droppedFile && (
-            <span className="text-xs text-[var(--color-success)]">✓ Valid Base64</span>
-          )}
+            {autoDetect && !droppedFile && (
+              <StatusBadge variant="success">Valid Base64</StatusBadge>
+            )}
+          </ToolbarGroup>
 
-          <div className="ml-auto flex items-center gap-2 text-2xs tabular-nums text-[var(--color-text-muted)]">
+          <ToolbarSpacer />
+          <div className="flex items-center gap-2 text-2xs tabular-nums text-[var(--color-text-muted)]">
             {!droppedFile && state.input.trim() && (
               <>
                 <span>{formatSize(inputBytes)}</span>
@@ -387,7 +398,7 @@ export default function Base64Tool() {
               </span>
             )}
           </div>
-        </div>
+        </Toolbar>
       }
     >
       {/* ── Panels ────────────────────────────────────────────────── */}
@@ -468,7 +479,7 @@ export default function Base64Tool() {
               onDragLeave={handleDragLeave}
               onDrop={handleDrop}
             >
-              <textarea
+              <TextArea
                 value={state.input}
                 onChange={(e) => updateState({ input: e.target.value })}
                 placeholder={
@@ -476,7 +487,9 @@ export default function Base64Tool() {
                     ? 'Enter text to encode, or drop a file…'
                     : 'Enter Base64 to decode (data URIs supported)…'
                 }
-                className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+                monospace
+                size="md"
+                className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
               />
               {isDragOver && (
                 <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-[var(--color-surface)]/90 backdrop-blur-sm">

--- a/apps/cockpit/src/tools/case-converter/CaseConverter.tsx
+++ b/apps/cockpit/src/tools/case-converter/CaseConverter.tsx
@@ -6,7 +6,9 @@ import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { EmptyState } from '@/components/shared/EmptyState'
-import { TextAaIcon } from '@phosphor-icons/react'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { TextArea } from '@/components/shared/TextArea'
+import { ArrowUpIcon, TextAaIcon } from '@phosphor-icons/react'
 
 type CaseConverterState = {
   input: string
@@ -119,23 +121,20 @@ export default function CaseConverter() {
         <div className="border-b border-[var(--color-border)] p-4">
           <div className="mb-2 flex items-center gap-3">
             <span className="font-mono text-xs text-[var(--color-text-muted)]">Input</span>
-            {detected && (
-              <span className="rounded-full bg-[var(--color-accent-dim)] px-2 py-0.5 text-2xs font-bold text-[var(--color-accent)]">
-                {detected}
-              </span>
-            )}
+            {detected && <StatusBadge variant="info">{detected}</StatusBadge>}
             {words.length > 0 && (
               <span className="text-2xs text-[var(--color-text-muted)]">
                 {words.length} word{words.length !== 1 ? 's' : ''}: {words.join(' · ')}
               </span>
             )}
           </div>
-          <textarea
+          <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
             placeholder="Type or paste text to convert..."
             rows={3}
-            className="w-full resize-none rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+            size="md"
+            className="resize-none"
           />
         </div>
       }
@@ -147,18 +146,14 @@ export default function CaseConverter() {
             return (
               <div
                 key={c.id}
-                className={`flex items-center justify-between rounded border px-3 py-2 ${
-                  isCurrent
-                    ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)]/30'
-                    : 'border-[var(--color-border)] bg-[var(--color-surface)]'
+                className={`flex items-center justify-between rounded-[var(--radius-md)] border px-3 py-2 ${
+                  isCurrent ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)]/30' : ''
                 }`}
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                     {c.label}
-                    {isCurrent && (
-                      <span className="text-2xs font-bold text-[var(--color-accent)]">current</span>
-                    )}
+                    {isCurrent && <StatusBadge variant="info">Current</StatusBadge>}
                   </div>
                   <div className="truncate font-mono text-sm text-[var(--color-text)]">
                     {c.value}
@@ -172,7 +167,8 @@ export default function CaseConverter() {
                       onClick={() => handleUseAsInput(c.value, c.label)}
                       title="Use as input"
                     >
-                      ↑ Use
+                      <ArrowUpIcon size={12} weight="bold" aria-hidden="true" />
+                      Use
                     </Button>
                   )}
                   <CopyButton text={c.value} />

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -22,6 +22,7 @@ import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Toolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
 import { FORMATTER_WORKER_METHODS } from '@/workers/formatter.methods'
@@ -233,9 +234,9 @@ export default function CodeFormatter() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
+          <Toolbar border={false} aria-label="Code formatting actions">
             {/* Document identity — what am I looking at, and is it formatted? */}
-            <div className="flex min-w-0 items-center gap-2">
+            <ToolbarGroup label="Document status" className="min-w-0 shrink">
               <CodeBlockIcon
                 size={15}
                 aria-hidden="true"
@@ -259,11 +260,11 @@ export default function CodeFormatter() {
                 {status === 'modified' && <PencilSimpleIcon size={12} aria-hidden="true" />}
                 {isFormatting ? 'Formatting…' : describeStatus(status)}
               </span>
-            </div>
+            </ToolbarGroup>
 
             {/* Two groups so a narrow window breaks between "what to format" and
                 "act on it" rather than orphaning a single icon on its own row. */}
-            <div className="ml-auto flex items-center gap-2">
+            <ToolbarGroup label="Formatting options" className="ml-auto">
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 <span className="max-[900px]:hidden">Language</span>
                 <Select
@@ -301,9 +302,9 @@ export default function CodeFormatter() {
                 <SlidersHorizontalIcon size={13} aria-hidden="true" />
                 Style
               </Button>
-            </div>
+            </ToolbarGroup>
 
-            <div className="flex items-center gap-2">
+            <ToolbarGroup label="Document actions" separated>
               <Button
                 variant="primary"
                 size="sm"
@@ -339,8 +340,8 @@ export default function CodeFormatter() {
               >
                 <FloppyDiskIcon size={15} aria-hidden="true" />
               </Button>
-            </div>
-          </div>
+            </ToolbarGroup>
+          </Toolbar>
 
           {state.optionsOpen && (
             <div

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -22,7 +22,7 @@ import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { Toolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
 import { FORMATTER_WORKER_METHODS } from '@/workers/formatter.methods'
@@ -234,37 +234,33 @@ export default function CodeFormatter() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <Toolbar border={false} aria-label="Code formatting actions">
-            {/* Document identity — what am I looking at, and is it formatted? */}
-            <ToolbarGroup label="Document status" className="min-w-0 shrink">
-              <CodeBlockIcon
-                size={15}
-                aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
-              />
-              <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-                {state.fileName ?? 'Untitled'}
-              </span>
-              <span
-                role="status"
-                aria-live="polite"
-                className="flex shrink-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-              >
-                {status === 'formatted' && (
+          <DocumentToolbar border={false} aria-label="Code formatting actions">
+            <DocumentIdentity
+              title={state.fileName ?? 'Untitled'}
+              icon={
+                <CodeBlockIcon
+                  size={15}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-text-muted)]"
+                />
+              }
+              status={isFormatting ? 'Formatting…' : describeStatus(status)}
+              statusIcon={
+                status === 'formatted' ? (
                   <CheckCircleIcon
                     size={12}
                     aria-hidden="true"
-                    className="text-[var(--color-success)]"
+                    className="shrink-0 text-[var(--color-success)]"
                   />
-                )}
-                {status === 'modified' && <PencilSimpleIcon size={12} aria-hidden="true" />}
-                {isFormatting ? 'Formatting…' : describeStatus(status)}
-              </span>
-            </ToolbarGroup>
+                ) : status === 'modified' ? (
+                  <PencilSimpleIcon size={12} aria-hidden="true" className="shrink-0" />
+                ) : undefined
+              }
+            />
 
             {/* Two groups so a narrow window breaks between "what to format" and
                 "act on it" rather than orphaning a single icon on its own row. */}
-            <ToolbarGroup label="Formatting options" className="ml-auto">
+            <ToolbarGroup label="Formatting options" separated>
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 <span className="max-[900px]:hidden">Language</span>
                 <Select
@@ -331,7 +327,7 @@ export default function CodeFormatter() {
               </Button>
               <CopyButton text={input} />
               <Button
-                variant="ghost"
+                variant="icon"
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasCode}
@@ -341,7 +337,7 @@ export default function CodeFormatter() {
                 <FloppyDiskIcon size={15} aria-hidden="true" />
               </Button>
             </ToolbarGroup>
-          </Toolbar>
+          </DocumentToolbar>
 
           {state.optionsOpen && (
             <div

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -6,6 +6,8 @@ import { Button } from '@/components/shared/Button'
 import { Input } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { ArrowsLeftRightIcon, CheckCircleIcon, XCircleIcon } from '@phosphor-icons/react'
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -482,7 +484,8 @@ function ContrastInputs({
         className="mb-1"
         title="Swap foreground and background"
       >
-        ⇄
+        <ArrowsLeftRightIcon size={14} aria-hidden="true" />
+        <span className="sr-only">Swap colors</span>
       </Button>
       <div className="flex-1">
         <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Background</label>
@@ -841,28 +844,21 @@ export default function ColorConverter() {
               >
                 Sample Text
               </div>
-              <div className="flex flex-col gap-1 text-xs">
-                <span
-                  className={
-                    contrast.aa ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-                  }
-                >
-                  {contrast.aa ? '✓' : '✗'} AA Normal (≥4.5)
-                </span>
-                <span
-                  className={
-                    contrast.aaLarge ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-                  }
-                >
-                  {contrast.aaLarge ? '✓' : '✗'} AA Large (≥3.0)
-                </span>
-                <span
-                  className={
-                    contrast.aaa ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-                  }
-                >
-                  {contrast.aaa ? '✓' : '✗'} AAA (≥7.0)
-                </span>
+              <div className="flex flex-wrap gap-1.5">
+                {[
+                  { passes: contrast.aa, label: 'AA Normal (≥4.5)' },
+                  { passes: contrast.aaLarge, label: 'AA Large (≥3.0)' },
+                  { passes: contrast.aaa, label: 'AAA (≥7.0)' },
+                ].map(({ passes, label }) => (
+                  <StatusBadge key={label} variant={passes ? 'success' : 'error'}>
+                    {passes ? (
+                      <CheckCircleIcon size={12} weight="fill" aria-hidden="true" />
+                    ) : (
+                      <XCircleIcon size={12} weight="fill" aria-hidden="true" />
+                    )}
+                    {label}
+                  </StatusBadge>
+                ))}
               </div>
             </div>
           )}

--- a/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
+++ b/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
@@ -4,6 +4,7 @@ import { CopyButton } from '@/components/shared/CopyButton'
 import { Button } from '@/components/shared/Button'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { TextArea } from '@/components/shared/TextArea'
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -241,13 +242,15 @@ export default function CssSpecificity() {
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
             Selectors (one per line)
           </div>
-          <textarea
+          <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
             placeholder={
               '#main .content p\n.sidebar a:hover\ndiv > p:first-child\n#nav ul li.active'
             }
-            className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+            monospace
+            size="md"
+            className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
           />
         </div>
 

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -28,7 +28,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { Toolbar } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { openFileDialog, saveFileDialog, filenameFromPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -465,126 +465,116 @@ export default function CssValidator() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <div className="flex min-h-14 items-center gap-2 px-3 max-[1000px]:flex-wrap max-[1000px]:py-2">
-          <FileCssIcon
-            size={16}
-            aria-hidden="true"
-            className="shrink-0 text-[var(--color-text-muted)]"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h1
-                data-testid="file-name"
-                className="truncate text-sm font-semibold text-[var(--color-text)]"
-                title={state.filePath ?? state.fileName ?? 'Untitled stylesheet'}
-              >
-                {state.fileName ?? 'Untitled stylesheet'}
-              </h1>
-              <span
-                className={`shrink-0 text-2xs ${isDirty ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
-              >
-                {isDirty ? 'Modified' : 'Saved'}
-              </span>
-            </div>
-            <p
-              data-testid="validation-status"
-              role="status"
-              aria-live="polite"
-              className="mt-0.5 flex items-center gap-1 truncate text-2xs text-[var(--color-text-muted)]"
-            >
-              {hasInput && hasAnalyzed && issues.length === 0 && (
+        <DocumentToolbar border={false} aria-label="Stylesheet actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled stylesheet'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled stylesheet'}
+            titleTestId="file-name"
+            icon={
+              <FileCssIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            stateLabel={isDirty ? 'Modified' : 'Saved'}
+            stateChanged={isDirty}
+            status={status}
+            statusTestId="validation-status"
+            statusIcon={
+              hasInput && hasAnalyzed && issues.length === 0 ? (
                 <CheckCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-success)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              )}
-              {errorCount > 0 && (
+              ) : errorCount > 0 ? (
                 <WarningCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-error)]"
+                  className="shrink-0 text-[var(--color-error)]"
                 />
-              )}
-              {errorCount === 0 && warningCount > 0 && (
-                <WarningIcon size={12} aria-hidden="true" className="text-[var(--color-warning)]" />
-              )}
-              {status}
-            </p>
-          </div>
-        </div>
+              ) : errorCount === 0 && warningCount > 0 ? (
+                <WarningIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-warning)]"
+                />
+              ) : undefined
+            }
+          />
 
-        <Toolbar border={false} className="flex-wrap gap-x-2 gap-y-1 pt-0 pb-2">
-          <Button variant="ghost" size="sm" onClick={handleNew} className="gap-1">
-            <FilePlusIcon size={13} aria-hidden="true" />
-            New
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleOpen()}
-            className="gap-1"
-            title="Open a .css file (⌘O)"
-          >
-            <FolderOpenIcon size={13} aria-hidden="true" />
-            Open
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleSave()}
-            className="gap-1"
-            title="Save the stylesheet (⌘S)"
-          >
-            <FloppyDiskIcon size={13} aria-hidden="true" />
-            Save
-          </Button>
+          <ToolbarGroup label="Document actions" separated>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={handleNew}
+              title="New stylesheet"
+              aria-label="New stylesheet"
+            >
+              <FilePlusIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleOpen()}
+              title="Open a .css file (⌘O)"
+              aria-label="Open CSS file"
+            >
+              <FolderOpenIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleSave()}
+              title="Save the stylesheet (⌘S)"
+              aria-label="Save stylesheet"
+            >
+              <FloppyDiskIcon size={13} aria-hidden="true" />
+            </Button>
+          </ToolbarGroup>
 
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
+          <ToolbarGroup label="Template actions" separated>
+            <Select
+              aria-label="Starter template"
+              value={state.templateId}
+              onChange={(e) => updateState({ templateId: e.target.value })}
+            >
+              {TEMPLATES.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.label}
+                </option>
+              ))}
+            </Select>
+            <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+              Load
+            </Button>
+          </ToolbarGroup>
 
-          <Select
-            aria-label="Starter template"
-            value={state.templateId}
-            onChange={(e) => updateState({ templateId: e.target.value })}
-          >
-            {TEMPLATES.map((template) => (
-              <option key={template.id} value={template.id}>
-                {template.label}
-              </option>
-            ))}
-          </Select>
-          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
-            Load
-          </Button>
-
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
-
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={() => void handleFormat()}
-            // `useWorker` returns null until its effect runs; an enabled button
-            // that silently does nothing in that window is worse than a disabled one.
-            disabled={!hasInput || isFormatting || !formatter}
-            loading={isFormatting}
-            title="Reformat the stylesheet (⌘↵)"
-          >
-            Format
-            <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-              ⌘↵
-            </span>
-          </Button>
-          <CopyButton text={input} label="Copy CSS" />
+          <ToolbarGroup label="Stylesheet output" separated>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleFormat()}
+              disabled={!hasInput || isFormatting || !formatter}
+              loading={isFormatting}
+              title="Reformat the stylesheet (⌘↵)"
+            >
+              Format
+              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
+                ⌘↵
+              </span>
+            </Button>
+            <CopyButton text={input} label="Copy CSS" />
+          </ToolbarGroup>
 
           <Button
             variant={state.showRules ? 'secondary' : 'ghost'}
             size="sm"
             onClick={() => updateState({ showRules: !state.showRules })}
             aria-expanded={state.showRules}
-            // The panel is only in the tree when it is open, and a reference to
-            // an element that is not there reads as a broken relationship.
             {...(state.showRules ? { 'aria-controls': rulesPanelId } : {})}
-            className="ml-auto gap-1"
+            className="gap-1"
           >
             <SlidersHorizontalIcon size={13} aria-hidden="true" />
             Rules
@@ -594,7 +584,7 @@ export default function CssValidator() {
               </span>
             )}
           </Button>
-        </Toolbar>
+        </DocumentToolbar>
 
         {state.showRules && (
           <section

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { sendToTool } from '@/lib/tool-handoff'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { TextArea } from '@/components/shared/TextArea'
+import { Alert } from '@/components/shared/Alert'
 import { PlayIcon } from '@phosphor-icons/react'
 
 type CurlToFetchState = {
@@ -322,13 +324,14 @@ export default function CurlToFetch() {
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
             cURL Command
           </div>
-          <textarea
+          <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
             placeholder={
               "curl 'https://api.example.com/data' \\\n  -H 'Authorization: Bearer token' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"key\": \"value\"}'"
             }
-            className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+            monospace
+            className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
           />
         </div>
 
@@ -352,9 +355,9 @@ export default function CurlToFetch() {
               />
             </div>
           ) : state.input.trim() ? (
-            <div className="p-4 text-sm text-[var(--color-error)]">
+            <Alert variant="error" className="m-4">
               Could not parse cURL command
-            </div>
+            </Alert>
           ) : (
             <div className="p-4 text-sm text-[var(--color-text-muted)]">
               Paste a cURL command on the left

--- a/apps/cockpit/src/tools/docs-browser/DocsBrowser.tsx
+++ b/apps/cockpit/src/tools/docs-browser/DocsBrowser.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Alert } from '@/components/shared/Alert'
+import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
 
 type DocsBrowserProps = {
   defaultLoadError?: boolean
@@ -38,8 +40,9 @@ export default function DocsBrowser({
       fullBleed
       toolbar={
         <>
-          <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2">
+          <Toolbar aria-label="Documentation navigation">
             <span className="font-mono text-xs text-[var(--color-text-muted)]">DevDocs.io</span>
+            <ToolbarSpacer />
             <a
               href="https://devdocs.io"
               target="_blank"
@@ -49,9 +52,12 @@ export default function DocsBrowser({
             >
               Open externally
             </a>
-          </div>
+          </Toolbar>
           {(loading || loadError || showSlowFallback) && (
-            <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-xs text-[var(--color-text-muted)]">
+            <Alert
+              variant={loadError ? 'error' : showSlowFallback ? 'warning' : 'info'}
+              className="rounded-none border-b border-[var(--color-border)] px-4 py-3"
+            >
               {loadError ? (
                 <div className="flex items-center justify-between gap-3">
                   <span>Embedded docs failed to load. Open DevDocs in your browser or retry.</span>
@@ -71,7 +77,7 @@ export default function DocsBrowser({
               ) : (
                 <span>Loading DevDocs…</span>
               )}
-            </div>
+            </Alert>
           )}
         </>
       }

--- a/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
+++ b/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
@@ -4,7 +4,11 @@ import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { EmptyState } from '@/components/shared/EmptyState'
-import { HashIcon } from '@phosphor-icons/react'
+import { Input } from '@/components/shared/Input'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { TextArea } from '@/components/shared/TextArea'
+import { Toggle } from '@/components/shared/Toggle'
+import { CheckCircleIcon, HashIcon, XCircleIcon } from '@phosphor-icons/react'
 import { computeHashes, computeHmac, type Hashes } from './hash-utils'
 
 type HashGeneratorState = {
@@ -122,40 +126,34 @@ export default function HashGenerator() {
               <span className="text-2xs text-[var(--color-text-muted)]">Computing…</span>
             )}
           </div>
-          <textarea
+          <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
             placeholder="Enter text to hash..."
             rows={4}
-            className="w-full resize-none rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+            size="md"
+            className="resize-none"
           />
 
           {/* Options row */}
           <div className="mt-2 flex flex-wrap items-center gap-3">
-            <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
-              <input
-                type="checkbox"
-                checked={state.uppercase}
-                onChange={(e) => updateState({ uppercase: e.target.checked })}
-                className="accent-[var(--color-accent)]"
-              />
-              Uppercase
-            </label>
-            <label className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
-              <input
-                type="checkbox"
-                checked={state.hmacMode}
-                onChange={(e) => updateState({ hmacMode: e.target.checked })}
-                className="accent-[var(--color-accent)]"
-              />
-              HMAC
-            </label>
+            <Toggle
+              checked={state.uppercase}
+              onChange={(uppercase) => updateState({ uppercase })}
+              label="Uppercase"
+            />
+            <Toggle
+              checked={state.hmacMode}
+              onChange={(hmacMode) => updateState({ hmacMode })}
+              label="HMAC"
+            />
             {state.hmacMode && (
-              <input
+              <Input
                 value={state.hmacKey}
                 onChange={(e) => updateState({ hmacKey: e.target.value })}
                 placeholder="Secret key..."
-                className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 font-mono text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+                aria-label="HMAC secret key"
+                className="flex-1 font-mono"
               />
             )}
           </div>
@@ -163,20 +161,22 @@ export default function HashGenerator() {
           {/* Compare hash */}
           <div className="mt-2">
             <div className="flex items-center gap-2">
-              <input
+              <Input
                 value={state.compareHash}
                 onChange={(e) => updateState({ compareHash: e.target.value })}
                 placeholder="Paste a hash to compare..."
-                className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 font-mono text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+                aria-label="Hash to compare"
+                className="flex-1 font-mono"
               />
               {compareNormalized && hashes && (
-                <span
-                  className={`shrink-0 text-xs font-bold ${
-                    matchedAlgo ? 'text-[var(--color-success)]' : 'text-[var(--color-error)]'
-                  }`}
-                >
-                  {matchedAlgo ? `✓ Matches ${matchedAlgo}` : '✗ No match'}
-                </span>
+                <StatusBadge variant={matchedAlgo ? 'success' : 'error'}>
+                  {matchedAlgo ? (
+                    <CheckCircleIcon size={12} weight="fill" aria-hidden="true" />
+                  ) : (
+                    <XCircleIcon size={12} weight="fill" aria-hidden="true" />
+                  )}
+                  {matchedAlgo ? `Matches ${matchedAlgo}` : 'No match'}
+                </StatusBadge>
               )}
             </div>
           </div>
@@ -191,10 +191,8 @@ export default function HashGenerator() {
             return (
               <div
                 key={h.label}
-                className={`flex items-center justify-between rounded border px-3 py-2 ${
-                  isMatch
-                    ? 'border-[var(--color-success)] bg-[var(--color-success)]/10'
-                    : 'border-[var(--color-border)] bg-[var(--color-surface)]'
+                className={`flex items-center justify-between rounded-[var(--radius-md)] border px-3 py-2 ${
+                  isMatch ? 'border-[var(--color-success)] bg-[var(--color-success)]/10' : ''
                 }`}
               >
                 <div className="min-w-0 flex-1">
@@ -203,21 +201,13 @@ export default function HashGenerator() {
                       {state.hmacMode ? `HMAC-${h.label}` : h.label}
                     </span>
                     <span className="text-2xs text-[var(--color-text-muted)]">{h.bits}-bit</span>
-                    {isMatch && (
-                      <span className="text-2xs font-bold text-[var(--color-success)]">
-                        ✓ Match
-                      </span>
-                    )}
+                    {isMatch && <StatusBadge variant="success">Match</StatusBadge>}
                   </div>
                   <div className="truncate font-mono text-xs text-[var(--color-text)]">
                     {displayValue}
                   </div>
                 </div>
-                <CopyButton
-                  text={displayValue}
-                  className="ml-2 shrink-0"
-                  label={isMatch ? '✓ Copy' : 'Copy'}
-                />
+                <CopyButton text={displayValue} className="ml-2 shrink-0" label="Copy" />
               </div>
             )
           })}

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -30,7 +30,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Select } from '@/components/shared/Input'
 import { SegmentedControl, type SegmentedControlOption } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { Toolbar } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { openFileDialog, saveFileDialog, filenameFromPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -51,7 +51,7 @@ import {
   toggleRule,
   type HtmlIssue,
   type RuleConfig,
-} from './html-helpers'
+} from '@/tools/html-validator/html-helpers'
 
 type ViewMode = 'editor' | 'split' | 'preview'
 type Panel = 'problems' | 'outline'
@@ -527,121 +527,117 @@ export default function HtmlValidator() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <div className="flex min-h-14 items-center gap-2 px-3 max-[1000px]:flex-wrap max-[1000px]:py-2">
-          <FileHtmlIcon
-            size={16}
-            aria-hidden="true"
-            className="shrink-0 text-[var(--color-text-muted)]"
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h1
-                data-testid="file-name"
-                className="truncate text-sm font-semibold text-[var(--color-text)]"
-                title={state.filePath ?? state.fileName ?? 'Untitled document'}
-              >
-                {state.fileName ?? 'Untitled document'}
-              </h1>
-              <span
-                className={`shrink-0 text-2xs ${isDirty ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
-              >
-                {isDirty ? 'Modified' : 'Saved'}
-              </span>
-            </div>
-            <p
-              data-testid="validation-status"
-              role="status"
-              aria-live="polite"
-              className="mt-0.5 flex items-center gap-1 truncate text-2xs text-[var(--color-text-muted)]"
-            >
-              {hasInput && hasValidated && issues.length === 0 && (
+        <DocumentToolbar border={false} aria-label="HTML document actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled document'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}
+            titleTestId="file-name"
+            icon={
+              <FileHtmlIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            stateLabel={isDirty ? 'Modified' : 'Saved'}
+            stateChanged={isDirty}
+            status={status}
+            statusTestId="validation-status"
+            statusIcon={
+              hasInput && hasValidated && issues.length === 0 ? (
                 <CheckCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-success)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              )}
-              {errorCount > 0 && (
+              ) : errorCount > 0 ? (
                 <WarningCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-error)]"
+                  className="shrink-0 text-[var(--color-error)]"
                 />
-              )}
-              {errorCount === 0 && warningCount > 0 && (
-                <WarningIcon size={12} aria-hidden="true" className="text-[var(--color-warning)]" />
-              )}
-              {status}
-            </p>
-          </div>
-
-          <SegmentedControl
-            aria-label="View mode"
-            options={VIEW_OPTIONS}
-            value={viewMode}
-            onChange={(next) => updateState({ viewMode: next })}
+              ) : errorCount === 0 && warningCount > 0 ? (
+                <WarningIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-warning)]"
+                />
+              ) : undefined
+            }
           />
-        </div>
 
-        <Toolbar border={false} className="flex-wrap gap-x-2 gap-y-1 pt-0 pb-2">
-          <Button variant="ghost" size="sm" onClick={handleNew} className="gap-1">
-            <FilePlusIcon size={13} aria-hidden="true" />
-            New
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleOpen()}
-            className="gap-1"
-            title="Open an .html file (⌘O)"
-          >
-            <FolderOpenIcon size={13} aria-hidden="true" />
-            Open
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleSave()}
-            className="gap-1"
-            title="Save the document (⌘S)"
-          >
-            <FloppyDiskIcon size={13} aria-hidden="true" />
-            Save
-          </Button>
+          <ToolbarGroup label="View controls" separated>
+            <SegmentedControl
+              aria-label="View mode"
+              options={VIEW_OPTIONS}
+              value={viewMode}
+              onChange={(next) => updateState({ viewMode: next })}
+            />
+          </ToolbarGroup>
 
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
+          <ToolbarGroup label="Document actions" separated>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={handleNew}
+              title="New HTML document"
+              aria-label="New HTML document"
+            >
+              <FilePlusIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleOpen()}
+              title="Open an .html file (⌘O)"
+              aria-label="Open HTML file"
+            >
+              <FolderOpenIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleSave()}
+              title="Save the document (⌘S)"
+              aria-label="Save HTML document"
+            >
+              <FloppyDiskIcon size={13} aria-hidden="true" />
+            </Button>
+          </ToolbarGroup>
 
-          <Select
-            aria-label="Starter template"
-            value={state.templateId}
-            onChange={(e) => updateState({ templateId: e.target.value })}
-          >
-            {TEMPLATES.map((template) => (
-              <option key={template.id} value={template.id}>
-                {template.label}
-              </option>
-            ))}
-          </Select>
-          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
-            Load
-          </Button>
+          <ToolbarGroup label="Template actions" separated>
+            <Select
+              aria-label="Starter template"
+              value={state.templateId}
+              onChange={(e) => updateState({ templateId: e.target.value })}
+            >
+              {TEMPLATES.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.label}
+                </option>
+              ))}
+            </Select>
+            <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+              Load
+            </Button>
+          </ToolbarGroup>
 
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
-
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={() => void handleFormat()}
-            disabled={!hasInput || isFormatting}
-            loading={isFormatting}
-            title="Reformat the markup (⌘↵)"
-          >
-            Format
-            <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-              ⌘↵
-            </span>
-          </Button>
-          <CopyButton text={input} label="Copy HTML" />
+          <ToolbarGroup label="Markup output" separated>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleFormat()}
+              disabled={!hasInput || isFormatting}
+              loading={isFormatting}
+              title="Reformat the markup (⌘↵)"
+            >
+              Format
+              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
+                ⌘↵
+              </span>
+            </Button>
+            <CopyButton text={input} label="Copy HTML" />
+          </ToolbarGroup>
 
           <Button
             variant={state.showRules ? 'secondary' : 'ghost'}
@@ -649,7 +645,7 @@ export default function HtmlValidator() {
             onClick={() => updateState({ showRules: !state.showRules })}
             aria-expanded={state.showRules}
             aria-controls={rulesPanelId}
-            className="ml-auto gap-1"
+            className="gap-1"
           >
             <SlidersHorizontalIcon size={13} aria-hidden="true" />
             Rules
@@ -659,7 +655,7 @@ export default function HtmlValidator() {
               </span>
             )}
           </Button>
-        </Toolbar>
+        </DocumentToolbar>
 
         {state.showRules && (
           <section

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -27,6 +27,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Toolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -484,8 +485,8 @@ export default function JsonTools() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
-            <div className="flex min-w-0 items-center gap-2">
+          <Toolbar border={false} aria-label="JSON document actions">
+            <ToolbarGroup label="Document status" className="min-w-0 shrink">
               <BracketsCurlyIcon
                 size={15}
                 aria-hidden="true"
@@ -527,9 +528,9 @@ export default function JsonTools() {
                   Go to error
                 </Button>
               )}
-            </div>
+            </ToolbarGroup>
 
-            <div className="ml-auto flex items-center gap-2">
+            <ToolbarGroup label="View options" className="ml-auto">
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 <span className="max-[900px]:hidden">Indent</span>
                 <Select
@@ -558,9 +559,9 @@ export default function JsonTools() {
                 onChange={(next) => updateState({ view: next })}
                 options={VIEW_OPTIONS}
               />
-            </div>
+            </ToolbarGroup>
 
-            <div className="flex items-center gap-2">
+            <ToolbarGroup label="Document actions" separated>
               <Button
                 variant="primary"
                 size="sm"
@@ -597,9 +598,10 @@ export default function JsonTools() {
                 aria-label="Save JSON to file"
               >
                 <FloppyDiskIcon size={15} aria-hidden="true" />
+                Save
               </Button>
-            </div>
-          </div>
+            </ToolbarGroup>
+          </Toolbar>
 
           {state.queryOpen && (
             <div

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -27,7 +27,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { Toolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -485,52 +485,47 @@ export default function JsonTools() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <Toolbar border={false} aria-label="JSON document actions">
-            <ToolbarGroup label="Document status" className="min-w-0 shrink">
-              <BracketsCurlyIcon
-                size={15}
-                aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
-              />
-              <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-                {state.fileName ?? 'Untitled'}
-              </span>
-              <span
-                role="status"
-                aria-live="polite"
-                className="flex shrink-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-              >
-                {isValid && (
+          <DocumentToolbar border={false} aria-label="JSON document actions">
+            <DocumentIdentity
+              title={state.fileName ?? 'Untitled'}
+              icon={
+                <BracketsCurlyIcon
+                  size={15}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-text-muted)]"
+                />
+              }
+              status={isFormatting ? 'Formatting…' : status}
+              statusIcon={
+                isValid ? (
                   <CheckCircleIcon
                     size={12}
                     aria-hidden="true"
-                    className="text-[var(--color-success)]"
+                    className="shrink-0 text-[var(--color-success)]"
                   />
-                )}
-                {parsed.status === 'invalid' && (
+                ) : parsed.status === 'invalid' ? (
                   <WarningCircleIcon
                     size={12}
                     aria-hidden="true"
-                    className="text-[var(--color-error)]"
+                    className="shrink-0 text-[var(--color-error)]"
                   />
-                )}
-                {isFormatting ? 'Formatting…' : status}
-              </span>
-              {parsed.status === 'invalid' && parsed.location && (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={handleGoToError}
-                  title="Move the cursor to the parse error"
-                  className="gap-1"
-                >
-                  <CrosshairSimpleIcon size={12} aria-hidden="true" />
-                  Go to error
-                </Button>
-              )}
-            </ToolbarGroup>
+                ) : undefined
+              }
+            />
+            {parsed.status === 'invalid' && parsed.location && (
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={handleGoToError}
+                title="Move the cursor to the parse error"
+                className="shrink-0 gap-1"
+              >
+                <CrosshairSimpleIcon size={12} aria-hidden="true" />
+                Go to error
+              </Button>
+            )}
 
-            <ToolbarGroup label="View options" className="ml-auto">
+            <ToolbarGroup label="View options" separated>
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 <span className="max-[900px]:hidden">Indent</span>
                 <Select
@@ -590,7 +585,7 @@ export default function JsonTools() {
               </Button>
               <CopyButton text={input} label="Copy JSON" />
               <Button
-                variant="ghost"
+                variant="icon"
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasInput}
@@ -598,10 +593,9 @@ export default function JsonTools() {
                 aria-label="Save JSON to file"
               >
                 <FloppyDiskIcon size={15} aria-hidden="true" />
-                Save
               </Button>
             </ToolbarGroup>
-          </Toolbar>
+          </DocumentToolbar>
 
           {state.queryOpen && (
             <div

--- a/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -6,6 +6,9 @@ import { CopyButton } from '@/components/shared/CopyButton'
 import { Button } from '@/components/shared/Button'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Alert } from '@/components/shared/Alert'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { TextArea } from '@/components/shared/TextArea'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 
 type JwtDecoderState = {
@@ -155,23 +158,18 @@ export default function JwtDecoder() {
         <div className="mb-2 flex items-center gap-3">
           <span className="font-mono text-xs text-[var(--color-text-muted)]">JWT Token</span>
           {expiry && (
-            <span
-              className={`rounded-full px-2 py-0.5 text-xs font-bold ${
-                expiry.expired
-                  ? 'bg-[var(--color-error)]/15 text-[var(--color-error)]'
-                  : 'bg-[var(--color-success)]/15 text-[var(--color-success)]'
-              }`}
-            >
+            <StatusBadge variant={expiry.expired ? 'error' : 'success'}>
               {expiry.expired ? 'Expired' : 'Valid'} · {expiry.relative}
-            </span>
+            </StatusBadge>
           )}
         </div>
-        <textarea
+        <TextArea
           value={state.input}
           onChange={(e) => updateState({ input: e.target.value })}
           placeholder="Paste a JWT token (eyJ...)"
           rows={3}
-          className="w-full resize-none rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 font-mono text-xs text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+          monospace
+          className="resize-none"
         />
         {/* Color-coded token preview */}
         {tokenParts && decoded && (
@@ -191,16 +189,10 @@ export default function JwtDecoder() {
           <div className="flex flex-col gap-4">
             {/* Expiry banner */}
             {expiry && (
-              <div
-                className={`rounded border px-3 py-2 text-sm ${
-                  expiry.expired
-                    ? 'border-[var(--color-error)] bg-[var(--color-error)]/10 text-[var(--color-error)]'
-                    : 'border-[var(--color-success)] bg-[var(--color-success)]/10 text-[var(--color-success)]'
-                }`}
-              >
-                {expiry.expired ? '⚠ Token expired' : '✓ Token valid'} — {expiry.expiresAt} (
-                {expiry.relative})
-              </div>
+              <Alert variant={expiry.expired ? 'error' : 'success'}>
+                Token {expiry.expired ? 'expired' : 'valid'} — {expiry.expiresAt} ({expiry.relative}
+                )
+              </Alert>
             )}
 
             {/* Header + Payload side by side */}
@@ -284,9 +276,9 @@ export default function JwtDecoder() {
             </section>
           </div>
         ) : state.input.trim() ? (
-          <div className="text-sm text-[var(--color-error)]">
+          <Alert variant="error">
             Invalid JWT token — expected format: header.payload.signature
-          </div>
+          </Alert>
         ) : (
           <EmptyState
             icon={IdentificationCardIcon}

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -956,6 +956,9 @@ export default function MarkdownEditor() {
             stateLabel={isDirty ? 'Modified' : 'Saved'}
             stateChanged={isDirty}
             status={state.filePath ?? 'Local markdown workspace'}
+            // The path is context, not a result — announcing it on every open
+            // would talk over the Modified/Saved indicator that matters.
+            statusLive={false}
           />
 
           <ToolbarGroup label="View options" separated>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useIsInstanceActive } from '@/app/tool-instance'
@@ -948,29 +948,17 @@ export default function MarkdownEditor() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <div className="flex min-h-14 items-center gap-2 px-3 max-[1000px]:flex-wrap max-[1000px]:py-2">
-          <div className="min-w-0 flex-1 max-[1000px]:basis-full">
-            <div className="flex items-center gap-2">
-              <h1
-                data-testid="file-name"
-                className="truncate text-sm font-semibold text-[var(--color-text)]"
-                title={state.filePath ?? state.fileName ?? 'Untitled document'}
-              >
-                {state.fileName ?? 'Untitled document'}
-              </h1>
-              <span
-                className={`shrink-0 text-2xs ${isDirty ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
-                aria-live="polite"
-              >
-                {isDirty ? 'Modified' : 'Saved'}
-              </span>
-            </div>
-            <p className="mt-0.5 truncate text-2xs text-[var(--color-text-muted)]">
-              {state.filePath ?? 'Local markdown workspace'}
-            </p>
-          </div>
+        <DocumentToolbar border={false} aria-label="Markdown document actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled document'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}
+            titleTestId="file-name"
+            stateLabel={isDirty ? 'Modified' : 'Saved'}
+            stateChanged={isDirty}
+            status={state.filePath ?? 'Local markdown workspace'}
+          />
 
-          <ToolbarGroup label="View options">
+          <ToolbarGroup label="View options" separated>
             <SegmentedControl
               aria-label="Editor view mode"
               options={MODE_OPTIONS}
@@ -1231,7 +1219,7 @@ export default function MarkdownEditor() {
               </div>
             )}
           </div>
-        </div>
+        </DocumentToolbar>
       </header>
 
       {/* ─── Formatting Toolbar ─────────────────────────────────── */}

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useIsInstanceActive } from '@/app/tool-instance'
@@ -969,48 +970,51 @@ export default function MarkdownEditor() {
             </p>
           </div>
 
-          <SegmentedControl
-            aria-label="Editor view mode"
-            options={MODE_OPTIONS}
-            value={state.mode as EditorMode}
-            onChange={(mode) => updateState({ mode })}
-          />
+          <ToolbarGroup label="View options">
+            <SegmentedControl
+              aria-label="Editor view mode"
+              options={MODE_OPTIONS}
+              value={state.mode as EditorMode}
+              onChange={(mode) => updateState({ mode })}
+            />
 
-          {state.mode === 'split' && (
-            <Button
-              type="button"
-              variant="icon"
-              size="sm"
-              onClick={() => updateState({ scrollSync: !state.scrollSync })}
-              title={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
-              aria-label={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
-              aria-pressed={state.scrollSync}
-              className={state.scrollSync ? 'text-[var(--color-accent)]' : ''}
-            >
-              <ArrowsClockwiseIcon
-                size={14}
-                weight={state.scrollSync ? 'bold' : 'regular'}
-                aria-hidden="true"
-              />
-            </Button>
-          )}
+            {state.mode === 'split' && (
+              <Button
+                type="button"
+                variant="icon"
+                size="sm"
+                onClick={() => updateState({ scrollSync: !state.scrollSync })}
+                title={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
+                aria-label={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
+                aria-pressed={state.scrollSync}
+                className={state.scrollSync ? 'text-[var(--color-accent)]' : ''}
+              >
+                <ArrowsClockwiseIcon
+                  size={14}
+                  weight={state.scrollSync ? 'bold' : 'regular'}
+                  aria-hidden="true"
+                />
+              </Button>
+            )}
 
-          {toc.length > 0 && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => updateState({ showToc: !state.showToc })}
-              className={
-                state.showToc ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''
-              }
-              title="Table of contents"
-              aria-pressed={state.showToc}
-            >
-              Contents
-            </Button>
-          )}
+            {toc.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => updateState({ showToc: !state.showToc })}
+                className={
+                  state.showToc ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''
+                }
+                title="Table of contents"
+                aria-pressed={state.showToc}
+              >
+                Contents
+              </Button>
+            )}
+          </ToolbarGroup>
 
+          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-[var(--color-border)]" />
           <Button
             type="button"
             variant="icon"

--- a/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
 import { Input } from '@/components/shared/Input'
 import { Dialog } from '@/components/shared/Dialog'
+import { Alert } from '@/components/shared/Alert'
 
 type Props = {
   onInsert: (markdown: string) => void
@@ -91,9 +92,7 @@ export function ImageModal({ onInsert, onClose }: Props) {
               Paste
             </Button>
           </div>
-          {pasteError && (
-            <p className="font-mono text-xs text-[var(--color-error)]">{pasteError}</p>
-          )}
+          {pasteError && <Alert variant="error">{pasteError}</Alert>}
         </div>
 
         <div className="flex flex-col gap-1">

--- a/apps/cockpit/src/tools/markdown-editor/modals/TableModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/TableModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
+import { Input } from '@/components/shared/Input'
 import { useIsInstanceActive } from '@/app/tool-instance'
 
 type Props = {
@@ -58,26 +59,28 @@ export function TableModal({ onInsert, onClose }: Props) {
         <div className="flex gap-6">
           <div className="flex flex-col gap-1">
             <label className="font-mono text-xs text-[var(--color-text-muted)]">Rows (1–10)</label>
-            <input
+            <Input
               type="number"
               min={1}
               max={10}
               value={rows}
               onChange={(e) => setRows(clamp(parseInt(e.target.value) || 1))}
-              className="w-20 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+              size="md"
+              className="w-20"
             />
           </div>
           <div className="flex flex-col gap-1">
             <label className="font-mono text-xs text-[var(--color-text-muted)]">
               Columns (1–10)
             </label>
-            <input
+            <Input
               type="number"
               min={1}
               max={10}
               value={cols}
               onChange={(e) => setCols(clamp(parseInt(e.target.value) || 1))}
-              className="w-20 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+              size="md"
+              className="w-20"
             />
           </div>
         </div>

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -19,7 +19,7 @@ import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Select } from '@/components/shared/Select'
-import { Toolbar } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Toggle } from '@/components/shared/Toggle'
 import { useUiStore } from '@/stores/ui.store'
@@ -32,7 +32,7 @@ import {
   saveFileDialog,
   saveFileToPath,
 } from '@/lib/file-io'
-import MermaidPreview from './MermaidPreview'
+import MermaidPreview from '@/tools/mermaid-editor/MermaidPreview'
 import {
   TEMPLATES,
   countStatements,
@@ -44,7 +44,7 @@ import {
   templateById,
   withSourceLine,
   type MermaidError,
-} from './mermaid-helpers'
+} from '@/tools/mermaid-editor/mermaid-helpers'
 
 type EditorMode = 'edit' | 'split' | 'preview'
 type ExportFormat = 'svg' | 'png'
@@ -530,142 +530,142 @@ export default function MermaidEditor() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <div className="flex min-h-14 items-center gap-2 px-3 max-[1000px]:flex-wrap max-[1000px]:py-2">
-          <div className="min-w-0 flex-1 max-[1000px]:basis-full">
-            <div className="flex items-center gap-2">
-              <h1
-                data-testid="file-name"
-                className="truncate text-sm font-semibold text-[var(--color-text)]"
-                title={state.filePath ?? state.fileName ?? 'Untitled diagram'}
-              >
-                {state.fileName ?? 'Untitled diagram'}
-              </h1>
-              <span
-                className={`shrink-0 text-2xs ${isDirty ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
-                aria-live="polite"
-              >
-                {isDirty ? 'Modified' : 'Saved'}
-              </span>
-            </div>
-            <p className="mt-0.5 truncate text-2xs text-[var(--color-text-muted)]">
-              {state.filePath ?? 'Local Mermaid diagram'}
-            </p>
-          </div>
-
-          <SegmentedControl
-            aria-label="Editor view mode"
-            options={MODE_OPTIONS}
-            value={mode}
-            onChange={(next) => updateState({ mode: next })}
-          />
-        </div>
-
-        <Toolbar border={false} className="flex-wrap gap-x-2 gap-y-1 pt-0 pb-2">
-          <Button variant="ghost" size="sm" onClick={handleNewDiagram} className="gap-1">
-            <FilePlusIcon size={13} aria-hidden="true" />
-            New
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleOpen()}
-            className="gap-1"
-            title="Open a .mmd file (⌘O)"
-          >
-            <FolderOpenIcon size={13} aria-hidden="true" />
-            Open
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleSave()}
-            className="gap-1"
-            title="Save the source (⌘S)"
-          >
-            <FloppyDiskIcon size={13} aria-hidden="true" />
-            Save
-          </Button>
-
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
-
-          <Select
-            aria-label="Diagram template"
-            value={state.templateId}
-            onChange={(e) => updateState({ templateId: e.target.value })}
-          >
-            {TEMPLATES.map((template) => (
-              <option key={template.id} value={template.id}>
-                {template.label}
-              </option>
-            ))}
-          </Select>
-          <Button variant="secondary" size="sm" onClick={() => handleLoadTemplate()}>
-            Load
-          </Button>
-
-          <span className="h-4 w-px bg-[var(--color-border)]" aria-hidden="true" />
-
-          <Select
-            aria-label="Export format"
-            value={exportFormat}
-            onChange={(e) => updateState({ exportFormat: e.target.value as ExportFormat })}
-          >
-            <option value="svg">SVG</option>
-            <option value="png">PNG</option>
-          </Select>
-          {exportFormat === 'png' && (
-            <>
-              <Select
-                aria-label="PNG resolution"
-                value={String(exportScale)}
-                onChange={(e) => updateState({ exportScale: Number(e.target.value) })}
-              >
-                {EXPORT_SCALES.map((scale) => (
-                  <option key={scale} value={scale}>
-                    {scale}×
-                  </option>
-                ))}
-              </Select>
-              <Toggle
-                checked={transparent}
-                onChange={(checked) => updateState({ transparentBackground: checked })}
-                label="Transparent"
+        <DocumentToolbar border={false} aria-label="Diagram actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled diagram'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled diagram'}
+            titleTestId="file-name"
+            icon={
+              <GraphIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
               />
-            </>
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleCopyImage()}
-            disabled={!svgHtml}
-            loading={isExporting}
-            className="gap-1"
-          >
-            <CopyIcon size={13} aria-hidden="true" />
-            Copy {exportFormat.toUpperCase()}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => void handleExportImage()}
-            disabled={!svgHtml}
-            loading={isExporting}
-            className="gap-1"
-          >
-            <DownloadSimpleIcon size={13} aria-hidden="true" />
-            Export
-          </Button>
+            }
+            stateLabel={isDirty ? 'Modified' : 'Saved'}
+            stateChanged={isDirty}
+            status={statusText}
+          />
+
+          <ToolbarGroup label="View controls" separated>
+            <SegmentedControl
+              aria-label="Editor view mode"
+              options={MODE_OPTIONS}
+              value={mode}
+              onChange={(next) => updateState({ mode: next })}
+            />
+          </ToolbarGroup>
+
+          <ToolbarGroup label="Document actions" separated>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={handleNewDiagram}
+              title="New diagram"
+              aria-label="New diagram"
+            >
+              <FilePlusIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleOpen()}
+              title="Open a .mmd file (⌘O)"
+              aria-label="Open Mermaid file"
+            >
+              <FolderOpenIcon size={13} aria-hidden="true" />
+            </Button>
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={() => void handleSave()}
+              title="Save the source (⌘S)"
+              aria-label="Save Mermaid source"
+            >
+              <FloppyDiskIcon size={13} aria-hidden="true" />
+            </Button>
+          </ToolbarGroup>
+
+          <ToolbarGroup label="Template actions" separated>
+            <Select
+              aria-label="Diagram template"
+              value={state.templateId}
+              onChange={(e) => updateState({ templateId: e.target.value })}
+            >
+              {TEMPLATES.map((template) => (
+                <option key={template.id} value={template.id}>
+                  {template.label}
+                </option>
+              ))}
+            </Select>
+            <Button variant="secondary" size="sm" onClick={() => handleLoadTemplate()}>
+              Load
+            </Button>
+          </ToolbarGroup>
+
+          <ToolbarGroup label="Diagram export" separated>
+            <Select
+              aria-label="Export format"
+              value={exportFormat}
+              onChange={(e) => updateState({ exportFormat: e.target.value as ExportFormat })}
+            >
+              <option value="svg">SVG</option>
+              <option value="png">PNG</option>
+            </Select>
+            {exportFormat === 'png' && (
+              <>
+                <Select
+                  aria-label="PNG resolution"
+                  value={String(exportScale)}
+                  onChange={(e) => updateState({ exportScale: Number(e.target.value) })}
+                >
+                  {EXPORT_SCALES.map((scale) => (
+                    <option key={scale} value={scale}>
+                      {scale}×
+                    </option>
+                  ))}
+                </Select>
+                <Toggle
+                  checked={transparent}
+                  onChange={(checked) => updateState({ transparentBackground: checked })}
+                  label="Transparent"
+                />
+              </>
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleCopyImage()}
+              disabled={!svgHtml}
+              loading={isExporting}
+              className="gap-1"
+            >
+              <CopyIcon size={13} aria-hidden="true" />
+              Copy {exportFormat.toUpperCase()}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleExportImage()}
+              disabled={!svgHtml}
+              loading={isExporting}
+              className="gap-1"
+            >
+              <DownloadSimpleIcon size={13} aria-hidden="true" />
+              Export
+            </Button>
+          </ToolbarGroup>
 
           <Button
-            variant="ghost"
+            variant="secondary"
             size="sm"
             onClick={() => void handleCopySource()}
-            className="ml-auto gap-1"
+            className="gap-1"
           >
             <CopyIcon size={13} aria-hidden="true" />
             Copy source
           </Button>
-        </Toolbar>
+        </DocumentToolbar>
       </header>
 
       {error && (

--- a/apps/cockpit/src/tools/placeholder/Placeholder.tsx
+++ b/apps/cockpit/src/tools/placeholder/Placeholder.tsx
@@ -1,10 +1,17 @@
+import { WrenchIcon } from '@phosphor-icons/react'
+import { EmptyState } from '@/components/shared/EmptyState'
+import { ToolLayout } from '@/components/shared/ToolLayout'
+
 export default function Placeholder() {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <div className="font-mono text-xl text-[var(--color-text-muted)]">Coming Soon</div>
-      <div className="text-sm text-[var(--color-text-muted)]">
-        This tool is not yet implemented.
+    <ToolLayout fullBleed>
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <EmptyState
+          icon={WrenchIcon}
+          title="Coming soon"
+          description="This tool is not yet implemented."
+        />
       </div>
-    </div>
+    </ToolLayout>
   )
 }

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -23,7 +23,11 @@ import {
 import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { Alert } from '@/components/shared/Alert'
 import { Input, Select } from '@/components/shared/Input'
+import { TextArea } from '@/components/shared/TextArea'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { TabBar } from '@/components/shared/TabBar'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useToolState } from '@/hooks/useToolState'
 import { useIsInstanceActive } from '@/app/tool-instance'
@@ -146,13 +150,13 @@ function VariableForm({ template, values, onChange }: VariableFormProps) {
               ))}
             </Select>
           ) : variable.type === 'textarea' ? (
-            <textarea
+            <TextArea
               value={values[variable.name] ?? ''}
               onChange={(event) => onChange(variable.name, event.target.value)}
               placeholder={variable.placeholder}
               rows={variable.name === 'code' || variable.name === 'logs' ? 10 : 5}
               aria-label={variable.label}
-              className="min-h-24 w-full resize-none rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-xs text-[var(--color-text)] outline-none transition-colors placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)]"
+              className="min-h-24 resize-none"
             />
           ) : (
             <Input
@@ -531,14 +535,14 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                 <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
                   Description
                 </span>
-                <textarea
+                <TextArea
                   value={draft.description}
                   onChange={(event) =>
                     setDraft((current) => ({ ...current, description: event.target.value }))
                   }
                   rows={3}
                   aria-label="Template description"
-                  className="w-full resize-none rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-xs text-[var(--color-text)] outline-none transition-colors placeholder:text-[var(--color-text-muted)] focus:border-[var(--color-accent)]"
+                  className="resize-none"
                 />
               </label>
               <div className="grid grid-cols-2 gap-3">
@@ -623,7 +627,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
               <span className="border-b border-[var(--color-border)] px-4 py-2 font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
                 Prompt Body
               </span>
-              <textarea
+              <TextArea
                 value={draft.prompt}
                 onChange={(event) => {
                   const prompt = event.target.value
@@ -635,7 +639,8 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                   }))
                 }}
                 aria-label="Prompt body"
-                className="min-h-0 flex-1 resize-none bg-[var(--color-bg)] p-4 font-mono text-xs leading-5 text-[var(--color-text)] outline-none"
+                monospace
+                className="min-h-0 flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
               />
             </label>
             <div className="max-h-56 overflow-auto border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
@@ -751,7 +756,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
         </div>
 
         <div className="flex h-12 shrink-0 items-center justify-between border-t border-[var(--color-border)] px-4">
-          <div className="text-xs text-[var(--color-error)]">{error}</div>
+          <div>{error && <Alert variant="error">{error}</Alert>}</div>
           <div className="flex gap-2">
             <Button size="sm" variant="ghost" onClick={onClose}>
               Cancel
@@ -1135,9 +1140,9 @@ export default function PromptTemplates() {
                       {template.name}
                     </span>
                     {template.author === 'user' && (
-                      <span className="shrink-0 rounded bg-[var(--color-accent-dim)] px-1.5 py-0.5 text-[9px] font-semibold uppercase text-[var(--color-accent)]">
+                      <StatusBadge variant="info" className="shrink-0 uppercase">
                         Custom
-                      </span>
+                      </StatusBadge>
                     )}
                   </span>
                   <span className="mt-1 block line-clamp-2 text-2xs leading-4 text-[var(--color-text-muted)]">
@@ -1174,9 +1179,9 @@ export default function PromptTemplates() {
                 <h2 className="truncate text-sm font-semibold text-[var(--color-text)]">
                   {selectedTemplate.name}
                 </h2>
-                <span className="shrink-0 rounded bg-[var(--color-accent-dim)] px-1.5 py-0.5 text-[9px] font-semibold uppercase text-[var(--color-accent)]">
+                <StatusBadge variant="info" className="shrink-0 uppercase">
                   {selectedTemplate.author === 'user' ? 'Custom' : 'Built-in'}
-                </span>
+                </StatusBadge>
               </div>
               <p className="mt-0.5 truncate text-2xs text-[var(--color-text-muted)]">
                 {selectedTemplate.description}
@@ -1236,36 +1241,17 @@ export default function PromptTemplates() {
               <ClipboardTextIcon size={13} aria-hidden="true" /> Copy prompt
             </Button>
           </div>
-          <div className="flex items-center gap-1 border-t border-[var(--color-border)] px-4 py-1.5">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-pressed={workspaceTab === 'fill'}
-              onClick={() => setWorkspaceTab('fill')}
-              className={
-                workspaceTab === 'fill'
-                  ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]'
-                  : ''
-              }
-            >
-              Fill variables{' '}
-              <span className="ml-1 text-2xs">{selectedTemplate.variables.length}</span>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-pressed={workspaceTab === 'preview'}
-              onClick={() => setWorkspaceTab('preview')}
-              className={
-                workspaceTab === 'preview'
-                  ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]'
-                  : ''
-              }
-            >
-              Preview <span className="ml-1 text-2xs">~{tokens}</span>
-            </Button>
+          <div className="flex items-center border-t border-[var(--color-border)] pr-4">
+            <TabBar
+              noBorder
+              aria-label="Template workspace"
+              activeTab={workspaceTab}
+              onTabChange={(tab) => setWorkspaceTab(tab as 'fill' | 'preview')}
+              tabs={[
+                { id: 'fill', label: `Fill variables (${selectedTemplate.variables.length})` },
+                { id: 'preview', label: `Preview (~${tokens})` },
+              ]}
+            />
             <span className="ml-auto text-2xs text-[var(--color-text-muted)]" aria-live="polite">
               {savingTemplates
                 ? 'Saving template…'

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/shared/Button'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { REFACTORING_SAMPLE } from '@/lib/tool-samples'
@@ -33,7 +34,7 @@ import {
   LANGUAGES,
   type Transform,
   type TransformCategory,
-} from './transforms'
+} from '@/tools/refactoring-toolkit/transforms'
 
 type RefactoringView = 'source' | 'diff'
 
@@ -318,40 +319,35 @@ export default function RefactoringToolkit() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--color-border)] px-4 py-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <ArrowsClockwiseIcon
-              size={15}
-              aria-hidden="true"
-              className="shrink-0 text-[var(--color-text-muted)]"
-            />
-            <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-              {state.fileName ?? 'Untitled'}
-            </span>
-            <span
-              role="status"
-              aria-live="polite"
-              className="flex shrink-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-            >
-              {canApply && !isPreviewing && (
+        <DocumentToolbar aria-label="Refactoring actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled'}
+            icon={
+              <ArrowsClockwiseIcon
+                size={15}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            status={status}
+            statusIcon={
+              canApply && !isPreviewing ? (
                 <CheckCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-success)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              )}
-              {error && (
+              ) : error ? (
                 <WarningCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-error)]"
+                  className="shrink-0 text-[var(--color-error)]"
                 />
-              )}
-              {status}
-            </span>
-          </div>
+              ) : undefined
+            }
+          />
 
-          <div className="ml-auto flex items-center gap-2">
+          <ToolbarGroup label="Refactoring options" separated>
             <Button
               variant="ghost"
               size="sm"
@@ -399,9 +395,9 @@ export default function RefactoringToolkit() {
                 { value: 'diff', label: 'Diff' },
               ]}
             />
-          </div>
+          </ToolbarGroup>
 
-          <div className="flex items-center gap-2">
+          <ToolbarGroup label="Document actions" separated>
             <Button
               variant={hasDestructive ? 'danger' : 'primary'}
               size="sm"
@@ -431,7 +427,7 @@ export default function RefactoringToolkit() {
             </Button>
             <CopyButton text={copyText} label={showDiff ? 'Copy transformed code' : 'Copy code'} />
             <Button
-              variant="ghost"
+              variant="icon"
               size="sm"
               onClick={handleSave}
               disabled={!hasCode}
@@ -440,8 +436,8 @@ export default function RefactoringToolkit() {
             >
               <FloppyDiskIcon size={15} aria-hidden="true" />
             </Button>
-          </div>
-        </div>
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
       {error && (

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -7,6 +7,7 @@ import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Alert } from '@/components/shared/Alert'
+import { TextArea } from '@/components/shared/TextArea'
 import { REGEX_TIMEOUT_MS, useRegexEvaluation } from '@/hooks/useRegexEvaluation'
 import { MAX_REGEX_MATCHES } from '@/workers/regex.api'
 
@@ -301,11 +302,13 @@ export default function RegexTester() {
               <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
                 Test String
               </div>
-              <textarea
+              <TextArea
                 value={state.testString}
                 onChange={(e) => updateState({ testString: e.target.value })}
                 placeholder="Enter text to test against..."
-                className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+                monospace
+                size="md"
+                className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
               />
             </div>
             <div className="flex w-1/2 flex-col">

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -256,8 +256,17 @@ export default function TsPlayground() {
                   className="shrink-0 text-[var(--color-text-muted)]"
                 />
               }
-              status={summary}
-              statusLive={!(isTranspiling && hasCode)}
+              // Only the settled result is announced. "Compiling…" goes in
+              // aria-hidden so a keystroke-triggered run does not speak twice,
+              // while the live region itself stays mounted — a region added and
+              // removed around each run announces nothing at all.
+              status={
+                isTranspiling && hasCode ? (
+                  <span aria-hidden="true">{summary}</span>
+                ) : (
+                  settledSummary
+                )
+              }
               statusIcon={
                 !isTranspiling && hasCode && !error && sorted.length === 0 ? (
                   <CheckCircleIcon

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TS_PLAYGROUND_SAMPLE } from '@/lib/tool-samples'
@@ -245,44 +246,39 @@ export default function TsPlayground() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <FileTsIcon
-                size={15}
-                aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
-              />
-              <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-                {state.fileName ?? 'Untitled.ts'}
-              </span>
-              <span className="flex shrink-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]">
-                {!isTranspiling && hasCode && !error && sorted.length === 0 && (
+          <DocumentToolbar border={false} aria-label="TypeScript playground actions">
+            <DocumentIdentity
+              title={state.fileName ?? 'Untitled.ts'}
+              icon={
+                <FileTsIcon
+                  size={15}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-text-muted)]"
+                />
+              }
+              status={summary}
+              statusLive={!(isTranspiling && hasCode)}
+              statusIcon={
+                !isTranspiling && hasCode && !error && sorted.length === 0 ? (
                   <CheckCircleIcon
                     size={12}
                     aria-hidden="true"
-                    className="text-[var(--color-success)]"
+                    className="shrink-0 text-[var(--color-success)]"
                   />
-                )}
-                {/* Warning-only compiles get a glyph too, in their own colour. */}
-                {!isTranspiling && sorted.length > 0 && (
+                ) : !isTranspiling && sorted.length > 0 ? (
                   <WarningCircleIcon
                     size={12}
                     aria-hidden="true"
+                    className="shrink-0"
                     style={{
                       color: errorCount > 0 ? 'var(--color-error)' : 'var(--color-warning)',
                     }}
                   />
-                )}
-                {/* Only the settled result is live: announcing "Compiling…" as
-                    well would make every keystroke-triggered run speak twice. */}
-                <span role="status" aria-live="polite">
-                  {isTranspiling && hasCode ? '' : settledSummary}
-                </span>
-                {isTranspiling && hasCode && <span aria-hidden="true">Compiling…</span>}
-              </span>
-            </div>
+                ) : undefined
+              }
+            />
 
-            <div className="ml-auto flex items-center gap-2">
+            <ToolbarGroup label="Playground actions" separated>
               <Button
                 variant="ghost"
                 size="sm"
@@ -310,7 +306,7 @@ export default function TsPlayground() {
               </Button>
               <CopyButton text={output} label="Copy output" />
               <Button
-                variant="ghost"
+                variant="icon"
                 size="sm"
                 onClick={handleSave}
                 disabled={!output}
@@ -319,8 +315,8 @@ export default function TsPlayground() {
               >
                 <FloppyDiskIcon size={15} aria-hidden="true" />
               </Button>
-            </div>
-          </div>
+            </ToolbarGroup>
+          </DocumentToolbar>
 
           {state.optionsOpen && (
             <div

--- a/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
+++ b/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
@@ -8,6 +8,10 @@ import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { TextArea } from '@/components/shared/TextArea'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
+import { ArrowLeftIcon, ArrowRightIcon, ArrowsLeftRightIcon } from '@phosphor-icons/react'
 
 type UrlCodecState = {
   input: string
@@ -147,31 +151,35 @@ export default function UrlCodec() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-2">
-          <Button variant="primary" size="sm" onClick={handleToggle}>
-            {state.mode === 'encode' ? 'Encode →' : '← Decode'}
-          </Button>
-          <Button variant="secondary" size="sm" onClick={handleSwap} disabled={!output.text}>
-            ⇄ Swap
-          </Button>
-          <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
-          <Select
-            value={state.encodeMode}
-            onChange={(e) =>
-              updateState({ encodeMode: e.target.value as UrlCodecState['encodeMode'] })
-            }
-          >
-            <option value="component">Component</option>
-            <option value="full">Full URL</option>
-          </Select>
+        <Toolbar aria-label="URL conversion actions">
+          <ToolbarGroup label="Conversion actions">
+            <Button variant="primary" size="sm" onClick={handleToggle}>
+              {state.mode === 'decode' && <ArrowLeftIcon size={12} aria-hidden="true" />}
+              {state.mode === 'encode' ? 'Encode' : 'Decode'}
+              {state.mode === 'encode' && <ArrowRightIcon size={12} aria-hidden="true" />}
+            </Button>
+            <Button variant="secondary" size="sm" onClick={handleSwap} disabled={!output.text}>
+              <ArrowsLeftRightIcon size={12} aria-hidden="true" />
+              Swap
+            </Button>
+            <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
+          </ToolbarGroup>
+          <ToolbarGroup label="Encoding options" separated>
+            <Select
+              value={state.encodeMode}
+              onChange={(e) =>
+                updateState({ encodeMode: e.target.value as UrlCodecState['encodeMode'] })
+              }
+            >
+              <option value="component">Component</option>
+              <option value="full">Full URL</option>
+            </Select>
+          </ToolbarGroup>
 
           {/* Status badges */}
-          <div className="ml-auto flex items-center gap-2">
-            {doubleEncoded && (
-              <span className="rounded-full bg-[var(--color-warning)]/15 px-2 py-0.5 text-2xs font-bold text-[var(--color-warning)]">
-                Double-encoded?
-              </span>
-            )}
+          <ToolbarSpacer />
+          <div className="flex items-center gap-2">
+            {doubleEncoded && <StatusBadge variant="warning">Double-encoded?</StatusBadge>}
             {noChange && <span className="text-2xs text-[var(--color-text-muted)]">No change</span>}
             {encodedCount > 0 && !noChange && (
               <span className="text-2xs tabular-nums text-[var(--color-text-muted)]">
@@ -180,7 +188,7 @@ export default function UrlCodec() {
               </span>
             )}
           </div>
-        </div>
+        </Toolbar>
       }
     >
       {/* Input / Output panels */}
@@ -189,11 +197,13 @@ export default function UrlCodec() {
           <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
             Input ({state.mode === 'encode' ? 'Text' : 'Encoded'})
           </div>
-          <textarea
+          <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
             placeholder="Enter text or URL..."
-            className="flex-1 resize-none border-none bg-[var(--color-bg)] p-4 font-mono text-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none"
+            monospace
+            size="md"
+            className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
           />
         </div>
         <div className="flex w-1/2 flex-col">

--- a/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
+++ b/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
@@ -6,6 +6,8 @@ import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { Input, Select } from '@/components/shared/Input'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Alert } from '@/components/shared/Alert'
+import { StatusBadge } from '@/components/shared/StatusBadge'
 
 // ── UUID Generation ──────────────────────────────────────────────────
 
@@ -332,10 +334,10 @@ export default function UuidGenerator() {
               {parsed.valid ? (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center gap-2">
-                    <span className="text-sm text-[var(--color-success)]">✓ Valid UUID</span>
-                    <span className="rounded bg-[var(--color-accent-dim)] px-2 py-0.5 text-xs text-[var(--color-accent)]">
+                    <StatusBadge variant="success">Valid UUID</StatusBadge>
+                    <StatusBadge variant="info">
                       {parsed.version === 0 ? parsed.variant : `Version ${parsed.version}`}
-                    </span>
+                    </StatusBadge>
                   </div>
                   <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
                     {parsed.version > 0 && (
@@ -359,7 +361,7 @@ export default function UuidGenerator() {
                   </div>
                 </div>
               ) : (
-                <span className="text-sm text-[var(--color-error)]">✗ {parsed.message}</span>
+                <Alert variant="error">{parsed.message}</Alert>
               )}
             </div>
           )}

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -381,7 +381,7 @@ export default function XmlTools() {
             </Button>
             <CopyButton text={input} label="Copy XML" />
             <Button
-              variant="ghost"
+              variant="icon"
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/shared/Button'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -296,52 +297,47 @@ export default function XmlTools() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[var(--color-border)] px-4 py-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <BracketsAngleIcon
-              size={15}
-              aria-hidden="true"
-              className="shrink-0 text-[var(--color-text-muted)]"
-            />
-            <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-              {state.fileName ?? 'Untitled'}
-            </span>
-            <span
-              role="status"
-              aria-live="polite"
-              className="flex shrink-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-            >
-              {hasInput && isValid && (
+        <DocumentToolbar aria-label="XML document actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled'}
+            icon={
+              <BracketsAngleIcon
+                size={15}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            status={status}
+            statusIcon={
+              hasInput && isValid ? (
                 <CheckCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-success)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              )}
-              {blockingIssue && (
+              ) : blockingIssue ? (
                 <WarningCircleIcon
                   size={12}
                   aria-hidden="true"
-                  className="text-[var(--color-error)]"
+                  className="shrink-0 text-[var(--color-error)]"
                 />
-              )}
-              {status}
-            </span>
-            {blockingIssue?.line !== undefined && (
-              <Button
-                variant="ghost"
-                size="xs"
-                onClick={handleGoToError}
-                title="Move the cursor to the parse error"
-                className="gap-1"
-              >
-                <CrosshairSimpleIcon size={12} aria-hidden="true" />
-                Go to error
-              </Button>
-            )}
-          </div>
+              ) : undefined
+            }
+          />
+          {blockingIssue?.line !== undefined && (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleGoToError}
+              title="Move the cursor to the parse error"
+              className="gap-1"
+            >
+              <CrosshairSimpleIcon size={12} aria-hidden="true" />
+              Go to error
+            </Button>
+          )}
 
-          <div className="ml-auto flex items-center gap-2">
+          <ToolbarGroup label="XML view options" separated>
             <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
               <span className="max-[900px]:hidden">Indent</span>
               <Select
@@ -359,9 +355,9 @@ export default function XmlTools() {
               onChange={(next) => updateState({ view: next })}
               options={VIEW_OPTIONS}
             />
-          </div>
+          </ToolbarGroup>
 
-          <div className="flex items-center gap-2">
+          <ToolbarGroup label="XML output" separated>
             <Button
               variant="primary"
               size="sm"
@@ -394,8 +390,8 @@ export default function XmlTools() {
             >
               <FloppyDiskIcon size={15} aria-hidden="true" />
             </Button>
-          </div>
-        </div>
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
       {error && (

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -21,6 +21,7 @@ import { Alert } from '@/components/shared/Alert'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -329,61 +330,56 @@ export default function YamlTools() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <FileCodeIcon
-                size={15}
-                aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
-              />
-              <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-                {state.fileName ?? 'Untitled'}
-              </span>
-              <span
-                role="status"
-                aria-live="polite"
-                className="flex min-w-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-              >
-                {isValid && (
+          <DocumentToolbar border={false} aria-label="YAML document actions">
+            <DocumentIdentity
+              title={state.fileName ?? 'Untitled'}
+              icon={
+                <FileCodeIcon
+                  size={15}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-text-muted)]"
+                />
+              }
+              status={isFormatting ? 'Formatting…' : status}
+              statusIcon={
+                isValid ? (
                   <CheckCircleIcon
                     size={12}
                     aria-hidden="true"
                     className="shrink-0 text-[var(--color-success)]"
                   />
-                )}
-                {parsed.status === 'invalid' && (
+                ) : parsed.status === 'invalid' ? (
                   <WarningCircleIcon
                     size={12}
                     aria-hidden="true"
                     className="shrink-0 text-[var(--color-error)]"
                   />
-                )}
-                <span className="truncate">{isFormatting ? 'Formatting…' : status}</span>
-              </span>
-              {parsed.status === 'invalid' && parsed.location && (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={handleGoToError}
-                  title="Move the cursor to the parse error"
-                  className="shrink-0 gap-1"
-                >
-                  <CrosshairSimpleIcon size={12} aria-hidden="true" />
-                  Go to error
-                </Button>
-              )}
-            </div>
+                ) : undefined
+              }
+            />
+            {parsed.status === 'invalid' && parsed.location && (
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={handleGoToError}
+                title="Move the cursor to the parse error"
+                className="shrink-0 gap-1"
+              >
+                <CrosshairSimpleIcon size={12} aria-hidden="true" />
+                Go to error
+              </Button>
+            )}
 
-            <div className="ml-auto flex items-center gap-2">
+            <ToolbarGroup label="View options" separated>
               <SegmentedControl
                 aria-label="View"
                 value={view}
                 onChange={(next) => updateState({ view: next })}
                 options={VIEW_OPTIONS}
               />
-            </div>
+            </ToolbarGroup>
 
-            <div className="flex items-center gap-2">
+            <ToolbarGroup label="Document actions" separated>
               <Button
                 variant="primary"
                 size="sm"
@@ -418,7 +414,7 @@ export default function YamlTools() {
               )}
               <CopyButton text={input} label="Copy YAML" />
               <Button
-                variant="ghost"
+                variant="icon"
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasInput}
@@ -427,8 +423,8 @@ export default function YamlTools() {
               >
                 <FloppyDiskIcon size={15} aria-hidden="true" />
               </Button>
-            </div>
-          </div>
+            </ToolbarGroup>
+          </DocumentToolbar>
         </div>
       }
     >


### PR DESCRIPTION
## Summary

- standardize tool actions, tabs, text areas, status badges, alerts, copy feedback, and empty states around shared UI primitives
- enforce one compact toolbar surface, height, padding, identity pattern, grouping model, and action hierarchy across document-oriented tools
- align JSON, YAML, XML, Code Formatter, TypeScript Playground, Refactoring Toolkit, CSS/HTML validators, Mermaid, and Markdown on shared document chrome
- keep secondary rows only for genuinely dense or expandable controls such as formatting palettes, rules, queries, and option panels
- improve keyboard navigation, responsive wrapping, icon-button tooltips, loading states, and semantic status feedback

## User impact

Tool workflows now use consistent controls and feedback across editors, converters, validators, generators, and managers. Document titles, status, view controls, file actions, and primary operations share the same visual surface and predictable hierarchy while narrow workspaces wrap complete control groups safely.

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run` — 1,286 tests passed
- [x] `bun run lint`
- [x] `bun run tauri build`
- [x] pre-commit secret and architecture scans