### PR TITLE
fix(cockpit): restore Windows title-bar window controls

### DIFF
--- a/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
+++ b/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
@@ -1,7 +1,7 @@
 # Native UI Harness
 
-Tools for testing the **real** Tauri window on macOS — client-side decorations, the drag region,
-window controls, edge resizing, and IPC health.
+Tools for testing the **real** Tauri window on macOS and Windows — client-side decorations, the
+drag region, window controls, edge resizing, and IPC health.
 
 This is the counterpart to [BROWSER_HARNESS.md](BROWSER_HARNESS.md). The browser harness stubs the
 Tauri API and runs the UI in Chromium; it is faster and has devtools, but it cannot tell you
@@ -10,15 +10,25 @@ file exists because a bug was invisible in both vitest and the browser harness.
 
 Files live in [`scripts/native-ui/`](../scripts/native-ui/).
 
-| File             | Purpose                                                           |
-| ---------------- | ----------------------------------------------------------------- |
-| `mouse.swift`    | CGEvent mouse driver — move/click/dblclick/drag with real motion  |
-| `window.sh`      | Window bounds, minimized state, cropped screenshots, keep-awake   |
-| `DebugProbe.tsx` | In-app overlay: event targets, rejections, timed IPC health check |
+| File                         | Platform | Purpose                                                            |
+| ---------------------------- | -------- | ------------------------------------------------------------------ |
+| `mouse.swift`                | macOS    | CGEvent mouse driver — move/click/dblclick/drag with real motion   |
+| `window.sh`                  | macOS    | Window bounds, minimized state, cropped screenshots, keep-awake    |
+| `mouse.ps1`                  | Windows  | SendInput mouse driver, plus `selftest` for the input channel      |
+| `window.ps1`                 | Windows  | Bounds, DPI scale, min/max state, control coordinates, screenshots |
+| `native.psm1`                | Windows  | Shared Win32 interop behind the two Windows scripts                |
+| `verify-window-controls.ps1` | Windows  | Automated pass/fail run over every title-bar control               |
+| `DebugProbe.tsx`             | both     | In-app overlay: event targets, rejections, timed IPC health check  |
+
+The two platforms are not interchangeable, and not only for tooling reasons: `WindowControls`
+renders a **different component** on each. macOS gets `MacTrafficLights` on the left, Windows and
+Linux get `WindowsControls` on the right, and the two sit in differently-positioned wrappers. A
+control bug on one platform says nothing about the other — the Windows regression below existed
+while macOS was fine.
 
 ---
 
-## Setup
+## macOS setup
 
 Grant **Accessibility** (to post events) and **Screen Recording** (to capture) to the terminal or
 agent that will drive the tests: System Settings → Privacy & Security. Without Accessibility the
@@ -39,7 +49,7 @@ cp scripts/native-ui/DebugProbe.tsx src/app/__DebugProbe.tsx
 # App.tsx: import { DebugProbe } from './__DebugProbe'  +  <DebugProbe /> before the closing </div>
 ```
 
-## Driving the window
+## Driving the window (macOS)
 
 ```bash
 scripts/native-ui/window.sh bounds      # -> "220 130 900 600"  (x y w h, top-left origin)
@@ -53,7 +63,101 @@ scripts/native-ui/window.sh shot /tmp/a.png
 /tmp/mouse drag 1120 430 1240 430       # resize from the East edge
 ```
 
-## Rules that cost time to learn
+---
+
+## Windows setup
+
+No permission dialog to grant, unlike macOS Accessibility — but synthetic input is discarded just
+as silently, so the equivalent preflight still matters.
+
+```powershell
+cd apps/cockpit
+bun install                              # a partial node_modules fails `tauri dev` at the vite step
+bun run tauri dev                        # process is `cockpit`, window title is `devdrivr`
+
+pwsh -File scripts/native-ui/mouse.ps1 selftest    # ALWAYS run this first
+```
+
+`selftest` moves the cursor, reads it back, and posts a press/release pair. If it fails, every
+subsequent finding is a harness artefact rather than a bug. The three causes:
+
+- **UIPI integrity mismatch.** The app is elevated and the shell is not (or vice versa). Windows
+  drops the input with no error. Run both at the same integrity level.
+- **Locked session.** No cursor movement and black screenshots.
+- **UAC secure desktop.** Anything on it swallows all synthetic input until dismissed.
+
+### Driving the window
+
+```powershell
+$w = 'scripts/native-ui/window.ps1'
+pwsh -File $w bounds            # -> "-3413 413 1296 1531"  (x y w h, PHYSICAL px)
+pwsh -File $w dpi               # -> "dpi=144 scale=1.5"
+pwsh -File $w state             # -> normal | minimized | maximized
+pwsh -File $w buttons           # every control's target point, clickability checked
+pwsh -File $w button close      # -> "x y" for one control
+pwsh -File $w raw               # GetWindowRect vs. the DWM frame
+pwsh -File $w shot C:\temp\a.png
+pwsh -File $w info              # everything in one object
+
+pwsh -File scripts/native-ui/mouse.ps1 click 1234 445
+pwsh -File scripts/native-ui/mouse.ps1 dblclick 1234 445
+pwsh -File scripts/native-ui/mouse.ps1 drag 900 445 1100 505
+```
+
+Use `window.ps1 button <name>` instead of computing coordinates by hand. It derives them from the
+live rect and the window's DPI scale, and refuses to return a point a resize handle would intercept.
+
+For a packaged build, override the process name: `$env:COCKPIT_PROC = 'devdrivr'`.
+
+### The automated run
+
+```powershell
+bun run tauri dev
+pwsh -File scripts/native-ui/verify-window-controls.ps1              # last check closes the app
+pwsh -File scripts/native-ui/verify-window-controls.ps1 -SkipClose   # leave it running
+```
+
+Nine checks: minimize, maximize, restore-via-maximize, double-click zoom and restore on the drag
+region, a drag that moves the window, and close. Each one clicks a real control and then asserts
+against the **OS** — `IsIconic`, `IsZoomed`, window destroyed — never against the DOM, because a
+click the drag region absorbs leaves the DOM looking perfectly healthy. Failures write a cropped
+screenshot to `%TEMP%\cockpit-native-ui\`. Exit code is 1 if anything failed.
+
+The drag-region checks are not incidental. The fix for the regression below works by raising the
+control cluster above the drag layer, so dragging is the thing most at risk from it.
+
+## Windows rules that cost time to learn
+
+**Coordinates are physical pixels; the app lays out in CSS pixels.** This machine runs at 150%
+scaling, so a control 31 CSS px from the right edge sits 46 physical px from it. Get the scale from
+`GetDpiForWindow` and multiply — `window.ps1` does. Hard-coding CSS offsets misses every button by
+a third of the bar and reads as "the controls are dead".
+
+**Anchor to the DWM frame, not `GetWindowRect`.** `GetWindowRect` includes an invisible resize
+border — measured 7px per side here — so right-edge-relative coordinates drift outward. `window.ps1
+raw` shows both; `DWMWA_EXTENDED_FRAME_BOUNDS` is what the user sees.
+
+**The top 4px and the 10×10 corners belong to `WindowResizeHandles`.** They are `fixed` at `z-39`,
+above the title bar. A click there starts a resize, so the control underneath looks broken.
+`Assert-ControlPointIsClickable` fails loudly rather than returning a false negative.
+
+**Re-read the bounds before every interaction** — same rule as macOS, same reason.
+
+**Poll for the state change; don't read it immediately.** The click crosses into WebView2, out
+through IPC to Rust, and back into the OS. An instant read returns the old value and manufactures a
+failure. `Wait-CockpitWindowState` polls with a timeout.
+
+**`$input` and `$pid` are PowerShell automatic variables.** Assigning to `$pid` throws outright;
+`$input` breaks in subtler ways. Both bit this harness during development.
+
+**`Marshal.SizeOf` needs the struct instance, not the type.** Passing `[DevDrivr.INPUT]` resolves to
+the object overload and throws about `System.RuntimeType`.
+
+**Windows may refuse `SetForegroundWindow` from a background process.** If the app is not focused,
+the first click can be consumed by activation. The verify script warns when it detects this; click
+the window once yourself and re-run.
+
+## Rules that cost time to learn (macOS)
 
 **Re-read the bounds before every single interaction.** They change after any move, zoom, minimize,
 or restore. Clicking cached coordinates lands in empty space and produces confident, entirely false
@@ -104,7 +208,53 @@ To reproduce the historical failure, check out a revision before the Rust comman
 the probe, note the three baseline timings, click the green traffic light once, and watch the two
 plugin lanes flip to `NO RESPONSE` while `custom` stays fine.
 
-## Findings so far
+## Findings so far — Windows
+
+Recorded against Tauri 2.10.3 / WebView2 / Windows 11 Pro 26200, at 150% display scaling.
+
+- **The drag layer swallowed every Windows window control.** `TitleBar.tsx` renders
+  `data-tauri-drag-region` as `absolute inset-0`. A positioned element with `z-index: auto` paints
+  above every _non-positioned_ sibling regardless of DOM order, and the Windows control cluster was
+  `ml-auto flex items-center` — static. So all three buttons sat under the drag layer and clicks
+  started a window drag instead. The macOS cluster is `absolute`, which is why only Windows broke.
+  Fixed by making the cluster `relative`. `verify-window-controls.ps1` reproduces it exactly: revert
+  the class and the three control checks fail while all three drag-region checks still pass.
+- **Hover proves hit-testing; state proves the handler.** With the bug present the close button still
+  turned red on hover, because `onMouseEnter` fires on the element the cursor is over even when a
+  sibling layer would win the click. Do not read a hover response as "the button works".
+- **A vacuous pass is the harness's worst failure mode.** An assertion of the form "wait until the
+  window is normal" passes instantly when the window is _already_ normal, so
+  "maximize restores the window" reported PASS while maximize was completely broken. Every check now
+  refuses to run when the window already holds the expected state.
+- **`decorations: false` leaves an invisible resize border in `GetWindowRect`.** Measured 7-9px per
+  side. Right-edge-anchored coordinates drift outward unless you use
+  `DWMWA_EXTENDED_FRAME_BOUNDS`.
+- **Verified working, no action needed:** minimize, maximize and restore via the button, double-click
+  zoom and restore on the drag region, dragging the window from the bar, close, and the
+  `custom`/`plugin:window`/`plugin:sql` IPC lanes all responding in 1-4ms throughout — the macOS
+  deadlock has no Windows counterpart in this build.
+
+### The harness bug that faked an app bug
+
+Worth reading before trusting any run, because the false result was completely convincing: the app
+accepted hover but ignored every click, on the title bar _and_ on the sidebar, while IPC was healthy.
+
+The cause was in the harness. PowerShell cannot assign through a value-type member chain —
+`$evt.mi.dwFlags = ...` mutates a temporary copy of the nested `MOUSEINPUT` and throws the write
+away. `dwFlags` stayed `0`, so `SendInput` was handed a flagless mouse event, **returned 1 for it**,
+and delivered nothing. Cursor positioning went through `SetCursorPos`, which kept working — hence
+hover without clicks.
+
+Two lessons are now baked into the code. `INPUT` structs are filled in C# (`Native.SendMouseButton`),
+not PowerShell. And `Test-SyntheticInput` no longer trusts a return code: it asserts a SendInput
+absolute move actually lands, and that `GetAsyncKeyState(VK_LBUTTON)` observes the press and the
+release. The old check passed happily throughout the failure.
+
+The general rule from the macOS section applies verbatim and would have caught it in one step:
+**validate the input method against a control window.** Clicking Notepad and confirming it takes the
+foreground is a two-line check that no app logic can influence.
+
+## Findings so far — macOS
 
 Recorded against Tauri 2.10.3 / macOS 15, on branch `feat/ui-polish-phase-2`.
 

--- a/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
+++ b/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
@@ -117,7 +117,7 @@ pwsh -File scripts/native-ui/verify-window-controls.ps1              # last chec
 pwsh -File scripts/native-ui/verify-window-controls.ps1 -SkipClose   # leave it running
 ```
 
-Nine checks: minimize, maximize, restore-via-maximize, double-click zoom and restore on the drag
+Seven checks: minimize, maximize, restore-via-maximize, double-click zoom and restore on the drag
 region, a drag that moves the window, and close. Each one clicks a real control and then asserts
 against the **OS** — `IsIconic`, `IsZoomed`, window destroyed — never against the DOM, because a
 click the drag region absorbs leaves the DOM looking perfectly healthy. Failures write a cropped

--- a/apps/cockpit/documentation/README.md
+++ b/apps/cockpit/documentation/README.md
@@ -15,7 +15,7 @@ Welcome to the devdrivr cockpit documentation. This directory contains all the d
 9. [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) - Visual design language, theming, and CSS tokens
 10. [TESTING.md](TESTING.md) - Testing documentation and best practices
 11. [BROWSER_HARNESS.md](BROWSER_HARNESS.md) - Running the UI in Chromium for DOM-level debugging
-12. [NATIVE_UI_HARNESS.md](NATIVE_UI_HARNESS.md) - Testing the real Tauri window on macOS: synthetic input, window controls, IPC health
+12. [NATIVE_UI_HARNESS.md](NATIVE_UI_HARNESS.md) - Testing the real Tauri window on macOS and Windows: synthetic input, window controls, IPC health
 13. [../CONTRIBUTING.md](../CONTRIBUTING.md) - Contribution guidelines for the project (lives at `apps/cockpit/CONTRIBUTING.md`)
 14. [QUICK_START.md](QUICK_START.md) - Quick start guide for new users
 15. [USER_GUIDE.md](USER_GUIDE.md) - Comprehensive user guide

--- a/apps/cockpit/scripts/native-ui/mouse.ps1
+++ b/apps/cockpit/scripts/native-ui/mouse.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+  Synthetic mouse driver for native-UI debugging on Windows. Counterpart to mouse.swift.
+
+.DESCRIPTION
+  ./mouse.ps1 selftest                    # prove input reaches the desktop — run this first
+  ./mouse.ps1 move     <x> <y>
+  ./mouse.ps1 click    <x> <y>
+  ./mouse.ps1 dblclick <x> <y>
+  ./mouse.ps1 drag     <x1> <y1> <x2> <y2>
+
+  Coordinates are physical screen pixels with the origin at the top-left of the primary monitor —
+  the same space window.ps1 reports. They are NOT CSS pixels: under display scaling the two differ
+  by the scale factor, so compute targets with `window.ps1 button <name>` rather than by hand.
+
+  There is no permission dialog to grant, unlike macOS Accessibility, but synthetic input is
+  silently discarded when the target process runs at a higher integrity level than this shell
+  (UIPI) — typically the app launched elevated and the harness did not. `selftest` catches that,
+  along with a locked session and an open UAC secure desktop. Without it, every result reads as
+  "the app ignores clicks".
+
+  Double-click uses two press/release pairs 90ms apart at an identical point. WebView2 derives
+  `e.detail === 2` from that timing itself, which is what Tauri's injected drag script
+  (tauri-2.x/src/window/scripts/drag.js) keys maximize-on-double-click off.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)][string]$Command,
+  [Parameter(Position = 1)][int]$X1,
+  [Parameter(Position = 2)][int]$Y1,
+  [Parameter(Position = 3)][int]$X2,
+  [Parameter(Position = 4)][int]$Y2
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'native.psm1') -Force
+
+function Show-Usage {
+  (Get-Help -Full $PSCommandPath).Description.Text
+  exit 2
+}
+
+[void](Initialize-DpiAwareness)
+
+switch ($Command) {
+  'selftest' {
+    [void](Test-SyntheticInput)
+    "synthetic input OK — cursor obeyed and SendInput was accepted"
+    "foreground window belongs to: $(Get-ForegroundProcessName)"
+  }
+  'move' {
+    if (-not $PSBoundParameters.ContainsKey('Y1')) { Show-Usage }
+    Set-MousePosition -X $X1 -Y $Y1
+  }
+  'click' {
+    if (-not $PSBoundParameters.ContainsKey('Y1')) { Show-Usage }
+    Invoke-MouseClick -X $X1 -Y $Y1
+  }
+  'dblclick' {
+    if (-not $PSBoundParameters.ContainsKey('Y1')) { Show-Usage }
+    Invoke-MouseClick -X $X1 -Y $Y1 -Count 2
+  }
+  'drag' {
+    if (-not $PSBoundParameters.ContainsKey('Y2')) { Show-Usage }
+    Invoke-MouseDrag -FromX $X1 -FromY $Y1 -ToX $X2 -ToY $Y2
+  }
+  default { Show-Usage }
+}

--- a/apps/cockpit/scripts/native-ui/native.psm1
+++ b/apps/cockpit/scripts/native-ui/native.psm1
@@ -1,0 +1,711 @@
+<#
+.SYNOPSIS
+  Shared Win32 interop for the Windows native-UI harness.
+
+.DESCRIPTION
+  Backs window.ps1, mouse.ps1, and verify-window-controls.ps1. Nothing here is part of the app
+  build; it exists to drive and inspect the *real* Tauri window, which neither vitest (no layout)
+  nor the browser harness (no window) can do.
+
+  This is the Windows counterpart to mouse.swift + window.sh. See
+  documentation/NATIVE_UI_HARNESS.md.
+
+  Two Windows-specific hazards are handled here rather than left to callers:
+
+  1. DPI. Window rects and cursor positions are physical pixels, but the app lays out in CSS
+     pixels. At 150% scaling a control 31 CSS px from the right edge is 46 physical px from it.
+     Get-CockpitWindow reports the per-window scale factor and Get-CockpitControlPoint applies it,
+     so button coordinates are correct on any monitor. Ignoring this is the single most likely way
+     to produce a confident false "the button does nothing".
+
+  2. Input integrity. Synthetic input is silently discarded when the target process runs at a
+     higher integrity level than this one (UIPI), when the session is locked, or while a UAC
+     secure desktop is up. Test-SyntheticInput proves the channel works before any result is
+     believed — the analogue of macOS Accessibility permission.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not ('DevDrivr.Native' -as [type])) {
+  Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace DevDrivr {
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct POINT { public int X; public int Y; }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct MOUSEINPUT {
+    public int dx;
+    public int dy;
+    public uint mouseData;
+    public uint dwFlags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  // The real INPUT is a union of MOUSEINPUT/KEYBDINPUT/HARDWAREINPUT. Declaring the mouse arm
+  // directly gives the correct size and alignment for mouse-only use on both x64 and x86; a
+  // hand-rolled smaller struct makes SendInput return 0 with no other symptom.
+  [StructLayout(LayoutKind.Sequential)]
+  public struct INPUT { public uint type; public MOUSEINPUT mi; }
+
+  public static class Native {
+    public const uint INPUT_MOUSE = 0;
+    public const uint MOUSEEVENTF_MOVE = 0x0001;
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP = 0x0004;
+    public const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
+    public const uint MOUSEEVENTF_VIRTUALDESK = 0x4000;
+
+    public const int SW_RESTORE = 9;
+    public const int SW_MINIMIZE = 6;
+
+    // DwmGetWindowAttribute: the frame Windows actually paints, excluding the invisible resize
+    // border that GetWindowRect includes on some window styles.
+    public const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+
+    public const uint ES_CONTINUOUS = 0x80000000;
+    public const uint ES_DISPLAY_REQUIRED = 0x00000002;
+    public const uint ES_SYSTEM_REQUIRED = 0x00000001;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SetCursorPos(int X, int Y);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool GetCursorPos(out POINT lpPoint);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetProcessDpiAwarenessContext(IntPtr value);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetThreadDpiAwarenessContext();
+
+    [DllImport("user32.dll")]
+    public static extern uint GetAwarenessFromDpiAwarenessContext(IntPtr value);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetDpiForWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsZoomed(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowTextW(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmGetWindowAttribute(IntPtr hWnd, int attr, out RECT value, int size);
+
+    [DllImport("kernel32.dll")]
+    public static extern uint SetThreadExecutionState(uint esFlags);
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    /// Top-level windows owned by a PID. Deliberately not Process.MainWindowHandle: that caches
+    /// its answer, returns 0 during startup, and cannot tell you when a *second* window appears.
+    public static IntPtr[] TopLevelWindows(uint pid) {
+      List<IntPtr> found = new List<IntPtr>();
+      EnumWindows((hWnd, lParam) => {
+        uint owner;
+        GetWindowThreadProcessId(hWnd, out owner);
+        // GetWindow(hWnd, GW_OWNER=4) filters tool/popup windows owned by the main one.
+        if (owner == pid && GetWindow(hWnd, 4) == IntPtr.Zero) found.Add(hWnd);
+        return true;
+      }, IntPtr.Zero);
+      return found.ToArray();
+    }
+
+    public static string WindowTitle(IntPtr hWnd) {
+      StringBuilder sb = new StringBuilder(512);
+      GetWindowTextW(hWnd, sb, sb.Capacity);
+      return sb.ToString();
+    }
+
+    [DllImport("user32.dll")]
+    public static extern short GetAsyncKeyState(int vKey);
+
+    public const int VK_LBUTTON = 0x01;
+
+    /// Left button press or release at the current cursor position.
+    ///
+    /// Built here rather than in PowerShell on purpose. `$evt.mi.dwFlags = ...` in PowerShell
+    /// assigns to a *copy* of the nested value type and is silently discarded, so dwFlags stays 0.
+    /// SendInput then accepts a flagless mouse event and returns 1 — success — while delivering
+    /// nothing. Cursor movement kept working via SetCursorPos, so the app appeared to receive hover
+    /// but ignore every click: an entirely fictional "the window controls are dead".
+    public static uint SendMouseButton(bool down) {
+      INPUT[] inputs = new INPUT[1];
+      inputs[0].type = INPUT_MOUSE;
+      inputs[0].mi.dwFlags = down ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_LEFTUP;
+      return SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    /// Absolute move through SendInput. Coordinates are normalised to 0..65535 over the whole
+    /// virtual desktop, so this handles negative-origin secondary monitors. Used to prove the
+    /// flag plumbing works without clicking anything.
+    public static uint SendMouseMoveAbsolute(int x, int y, int vsLeft, int vsTop, int vsWidth, int vsHeight) {
+      INPUT[] inputs = new INPUT[1];
+      inputs[0].type = INPUT_MOUSE;
+      inputs[0].mi.dwFlags = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK;
+      inputs[0].mi.dx = (int)Math.Round((x - vsLeft) * 65535.0 / vsWidth);
+      inputs[0].mi.dy = (int)Math.Round((y - vsTop) * 65535.0 / vsHeight);
+      return SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT)));
+    }
+
+    [DllImport("user32.dll")]
+    public static extern int GetSystemMetrics(int nIndex);
+
+    // SM_XVIRTUALSCREEN / SM_YVIRTUALSCREEN / SM_CXVIRTUALSCREEN / SM_CYVIRTUALSCREEN
+    public static int[] VirtualScreen() {
+      return new int[] { GetSystemMetrics(76), GetSystemMetrics(77), GetSystemMetrics(78), GetSystemMetrics(79) };
+    }
+  }
+}
+'@
+}
+
+# ---------------------------------------------------------------------------------------------
+# Layout constants — must track the components, or every coordinate is quietly wrong.
+# ---------------------------------------------------------------------------------------------
+
+# src/components/shell/TitleBar.tsx: h-11 bar, pr-2 right padding.
+$script:BarHeightCss = 44
+$script:BarPaddingRightCss = 8
+
+# src/components/shell/WindowControls.tsx (WindowsControls): three h-8 w-[46px] buttons, in DOM
+# order minimize, maximize, close, laid out left-to-right against the right edge of the bar.
+$script:ControlWidthCss = 46
+$script:ControlOrder = @('minimize', 'maximize', 'close')
+
+# src/components/shell/WindowResizeHandles.tsx: fixed strips at z-39, above the title bar. The
+# North edge owns the top 4px of the full window width and the NorthEast corner owns a 10x10 box.
+# Clicks inside either start a resize instead of hitting a button, which reads exactly like a dead
+# control. Assert-ControlPointIsClickable rejects such points instead of returning a false result.
+$script:ResizeEdgeCss = 4
+$script:ResizeCornerCss = 10
+
+function Initialize-DpiAwareness {
+  <#
+    .SYNOPSIS
+      Make this process per-monitor DPI aware so window rects and cursor coordinates agree.
+    .DESCRIPTION
+      PowerShell 7 is already per-monitor-v2 aware via its manifest, so the call usually fails with
+      no effect — that is fine and expected. What matters is that we never proceed while *unaware*:
+      in that state Windows lies to us about both rects and cursor positions under scaling, and
+      every coordinate the harness computes lands in the wrong place.
+  #>
+  [CmdletBinding()]
+  param()
+
+  # DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+  [void][DevDrivr.Native]::SetProcessDpiAwarenessContext([IntPtr]::new(-4))
+
+  $awareness = [DevDrivr.Native]::GetAwarenessFromDpiAwarenessContext(
+    [DevDrivr.Native]::GetThreadDpiAwarenessContext()
+  )
+  # DPI_AWARENESS_UNAWARE = 0, SYSTEM_AWARE = 1, PER_MONITOR_AWARE = 2
+  if ($awareness -eq 0) {
+    throw 'This process is DPI-unaware; window and cursor coordinates would be wrong under display scaling. Run the harness from PowerShell 7 (pwsh).'
+  }
+  $awareness
+}
+
+function Get-CockpitWindow {
+  <#
+    .SYNOPSIS
+      Locate the app window and return its geometry, state, and DPI scale.
+    .PARAMETER ProcessName
+      Defaults to the dev binary. The process is `cockpit` (Cargo package name); `devdrivr` is the
+      *window title* and also appears in editor titles, so matching on it finds the wrong thing.
+    .PARAMETER TitleLike
+      Disambiguates when the process owns more than one top-level window.
+  #>
+  [CmdletBinding()]
+  param(
+    [string]$ProcessName = $(if ($env:COCKPIT_PROC) { $env:COCKPIT_PROC } else { 'cockpit' }),
+    [string]$TitleLike = 'devdrivr'
+  )
+
+  [void](Initialize-DpiAwareness)
+
+  $procs = @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
+  if ($procs.Count -eq 0) {
+    throw "No process named '$ProcessName'. Start the app with ``bun run tauri dev`` (or set COCKPIT_PROC for a packaged build)."
+  }
+
+  $candidates = foreach ($proc in $procs) {
+    foreach ($hWnd in [DevDrivr.Native]::TopLevelWindows([uint32]$proc.Id)) {
+      # A minimized window keeps WS_VISIBLE, so this does not exclude the minimize test's target.
+      if (-not [DevDrivr.Native]::IsWindowVisible($hWnd)) { continue }
+      $title = [DevDrivr.Native]::WindowTitle($hWnd)
+      if ([string]::IsNullOrWhiteSpace($title)) { continue }
+      [pscustomobject]@{ Handle = $hWnd; Title = $title; ProcessId = $proc.Id }
+    }
+  }
+  $candidates = @($candidates)
+
+  if ($candidates.Count -eq 0) {
+    throw "Process '$ProcessName' is running but owns no visible top-level window yet. Wait for the window to appear."
+  }
+
+  $match = @($candidates | Where-Object { $_.Title -like "*$TitleLike*" })
+  $chosen = if ($match.Count -gt 0) { $match[0] } else { $candidates[0] }
+  $hWnd = $chosen.Handle
+
+  $rect = [DevDrivr.RECT]::new()
+  if (-not [DevDrivr.Native]::GetWindowRect($hWnd, [ref]$rect)) {
+    throw "GetWindowRect failed for handle $hWnd."
+  }
+
+  # Prefer the DWM frame: for some styles GetWindowRect includes an invisible resize border, and
+  # anchoring button coordinates to a phantom edge shifts every click outward.
+  $frame = [DevDrivr.RECT]::new()
+  $usedFrame = $false
+  if ([DevDrivr.Native]::DwmGetWindowAttribute(
+      $hWnd, [DevDrivr.Native]::DWMWA_EXTENDED_FRAME_BOUNDS, [ref]$frame, 16) -eq 0) {
+    $usedFrame = $true
+  }
+  else {
+    $frame = $rect
+  }
+
+  $dpi = [DevDrivr.Native]::GetDpiForWindow($hWnd)
+  if ($dpi -eq 0) { $dpi = 96 }
+
+  [pscustomobject]@{
+    Handle      = $hWnd
+    ProcessId   = $chosen.ProcessId
+    Title       = $chosen.Title
+    X           = $frame.Left
+    Y           = $frame.Top
+    Width       = $frame.Right - $frame.Left
+    Height      = $frame.Bottom - $frame.Top
+    WindowRect  = "$($rect.Left) $($rect.Top) $($rect.Right - $rect.Left) $($rect.Bottom - $rect.Top)"
+    UsedDwmFrame = $usedFrame
+    Dpi         = $dpi
+    Scale       = [math]::Round($dpi / 96, 4)
+    IsMinimized = [DevDrivr.Native]::IsIconic($hWnd)
+    IsMaximized = [DevDrivr.Native]::IsZoomed($hWnd)
+    IsForeground = ([DevDrivr.Native]::GetForegroundWindow() -eq $hWnd)
+  }
+}
+
+function Get-CockpitWindowState {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][pscustomobject]$Window)
+  if ($Window.IsMinimized) { 'minimized' }
+  elseif ($Window.IsMaximized) { 'maximized' }
+  else { 'normal' }
+}
+
+function Get-CockpitControlPoint {
+  <#
+    .SYNOPSIS
+      Physical screen coordinates of a title-bar window control.
+    .DESCRIPTION
+      Derived from the live window rect and its DPI scale on every call. Never cache the result:
+      the rect changes on any move, maximize, restore, or monitor change, and a stale coordinate
+      lands in empty space and reads as a broken control.
+    .PARAMETER Control
+      minimize | maximize | close, or 'dragregion' for the empty centre of the bar.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][pscustomobject]$Window,
+    [Parameter(Mandatory)][ValidateSet('minimize', 'maximize', 'close', 'dragregion')][string]$Control
+  )
+
+  $scale = $Window.Scale
+  $y = $Window.Y + [int][math]::Round(($script:BarHeightCss / 2) * $scale)
+
+  if ($Control -eq 'dragregion') {
+    # Centre of the bar is occupied by the command palette, so aim between the left icon cluster
+    # and the palette rather than at the midpoint.
+    $x = $Window.X + [int][math]::Round(180 * $scale)
+    return [pscustomobject]@{ X = $x; Y = $y; Control = $Control }
+  }
+
+  # Buttons are flush to the right edge, inside the bar's 8px right padding, laid out
+  # minimize | maximize | close from left to right. Offset from the right edge to a button centre
+  # is therefore padding + (slots to its right * width) + half a width.
+  $index = [array]::IndexOf($script:ControlOrder, $Control)
+  $slotsToRight = ($script:ControlOrder.Count - 1) - $index
+  $offsetCss = $script:BarPaddingRightCss + ($slotsToRight * $script:ControlWidthCss) + ($script:ControlWidthCss / 2)
+  $x = $Window.X + $Window.Width - [int][math]::Round($offsetCss * $scale)
+
+  [pscustomobject]@{ X = $x; Y = $y; Control = $Control }
+}
+
+function Assert-ControlPointIsClickable {
+  <#
+    .SYNOPSIS
+      Reject a target that a resize handle would intercept before it is clicked.
+    .DESCRIPTION
+      WindowResizeHandles renders fixed strips at z-39 above the title bar: the top 4 CSS px of the
+      full width, and 10x10 corners. A click inside one starts a resize, so the control appears
+      dead. Failing loudly here beats recording a false negative.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][pscustomobject]$Window,
+    [Parameter(Mandatory)][pscustomobject]$Point
+  )
+
+  $scale = $Window.Scale
+  $edge = [int][math]::Round($script:ResizeEdgeCss * $scale)
+  $corner = [int][math]::Round($script:ResizeCornerCss * $scale)
+
+  $offsetY = $Point.Y - $Window.Y
+  $offsetRight = ($Window.X + $Window.Width) - $Point.X
+  $offsetLeft = $Point.X - $Window.X
+
+  if ($offsetY -lt $edge) {
+    throw "Target $($Point.Control) at $($Point.X),$($Point.Y) is inside the ${edge}px North resize strip; a click there resizes instead of activating the control."
+  }
+  if ($offsetY -lt $corner -and ($offsetRight -lt $corner -or $offsetLeft -lt $corner)) {
+    throw "Target $($Point.Control) at $($Point.X),$($Point.Y) is inside a ${corner}px corner resize handle."
+  }
+  $true
+}
+
+# ---------------------------------------------------------------------------------------------
+# Synthetic input
+# ---------------------------------------------------------------------------------------------
+
+function Set-MousePosition {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int]$X, [Parameter(Mandatory)][int]$Y)
+  # SetCursorPos rather than SendInput's normalised absolute move: the 0..65535 virtual-desktop
+  # mapping rounds, and a 1-2px error is enough to miss a small control or land in a resize strip.
+  if (-not [DevDrivr.Native]::SetCursorPos($X, $Y)) {
+    throw "SetCursorPos($X, $Y) failed (win32 error $([Runtime.InteropServices.Marshal]::GetLastWin32Error())). A locked session or UAC secure desktop blocks cursor movement."
+  }
+}
+
+function Get-MousePosition {
+  [CmdletBinding()]
+  param()
+  $point = [DevDrivr.POINT]::new()
+  [void][DevDrivr.Native]::GetCursorPos([ref]$point)
+  [pscustomobject]@{ X = $point.X; Y = $point.Y }
+}
+
+function Send-MouseButton {
+  <#
+    .SYNOPSIS
+      Press and/or release the left button at the current cursor position.
+  #>
+  [CmdletBinding()]
+  param([ValidateSet('down', 'up')][Parameter(Mandatory)][string]$Action)
+
+  # Delegated to C#. Filling the INPUT struct from PowerShell cannot work: `$evt.mi.dwFlags = ...`
+  # writes to a copy of the nested value type, leaving dwFlags at 0, and SendInput then reports
+  # success for an event that does nothing. See Native.SendMouseButton.
+  $sent = [DevDrivr.Native]::SendMouseButton($Action -eq 'down')
+  if ($sent -ne 1) {
+    throw "SendInput was blocked (win32 error $([Runtime.InteropServices.Marshal]::GetLastWin32Error())). The target process is probably running at a higher integrity level than this shell — run both elevated or both unelevated."
+  }
+}
+
+function Invoke-MouseClick {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][int]$X,
+    [Parameter(Mandatory)][int]$Y,
+    [int]$Count = 1
+  )
+  Set-MousePosition -X $X -Y $Y
+  Start-Sleep -Milliseconds 60   # let the webview process the hover before the press
+  for ($i = 0; $i -lt $Count; $i++) {
+    if ($i -gt 0) { Start-Sleep -Milliseconds 90 }  # inside the 500ms system double-click interval
+    Send-MouseButton -Action down
+    Start-Sleep -Milliseconds 40
+    Send-MouseButton -Action up
+  }
+}
+
+function Invoke-MouseDrag {
+  <#
+    .SYNOPSIS
+      Press, move in interpolated steps, release.
+    .DESCRIPTION
+      The intermediate motion is the point. Tauri's injected drag script and Windows' own resize
+      tracking both need movement while the button is held; a bare down-at-A / up-at-B moves
+      nothing and reads as "drag doesn't work".
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][int]$FromX,
+    [Parameter(Mandatory)][int]$FromY,
+    [Parameter(Mandatory)][int]$ToX,
+    [Parameter(Mandatory)][int]$ToY,
+    [int]$Steps = 25
+  )
+  Set-MousePosition -X $FromX -Y $FromY
+  Start-Sleep -Milliseconds 60
+  Send-MouseButton -Action down
+  Start-Sleep -Milliseconds 90
+  for ($step = 1; $step -le $Steps; $step++) {
+    $t = $step / $Steps
+    Set-MousePosition -X ([int][math]::Round($FromX + ($ToX - $FromX) * $t)) `
+      -Y ([int][math]::Round($FromY + ($ToY - $FromY) * $t))
+    Start-Sleep -Milliseconds 16
+  }
+  Start-Sleep -Milliseconds 90
+  Send-MouseButton -Action up
+}
+
+function Test-SyntheticInput {
+  <#
+    .SYNOPSIS
+      Prove synthetic input reaches the desktop before trusting any test result.
+    .DESCRIPTION
+      Three independent checks, none of which depend on the app:
+
+        1. SetCursorPos moves the cursor where it was told.
+        2. A SendInput *absolute move* lands on target — this proves dwFlags survives the trip into
+           the struct, which a PowerShell-side INPUT fill silently fails to do.
+        3. A press is observable in GetAsyncKeyState(VK_LBUTTON) and a release clears it — this
+           proves button events actually enter the input stream.
+
+      Check 3 exists because an earlier version asserted only that SendInput returned 1. It does
+      that for a flagless no-op event, so the harness reported healthy input while delivering no
+      clicks at all, and every window control looked broken. Never weaken this to a return-code
+      check: a false pass here turns the whole harness into a fabricator of bugs.
+  #>
+  [CmdletBinding()]
+  param()
+
+  [void](Initialize-DpiAwareness)
+  $origin = Get-MousePosition
+  try {
+    $target = [pscustomobject]@{ X = $origin.X + 7; Y = $origin.Y + 5 }
+    Set-MousePosition -X $target.X -Y $target.Y
+    Start-Sleep -Milliseconds 120
+    $observed = Get-MousePosition
+    if ($observed.X -ne $target.X -or $observed.Y -ne $target.Y) {
+      throw "SetCursorPos did not move the cursor where it was told: asked for $($target.X),$($target.Y), got $($observed.X),$($observed.Y). Something is filtering or remapping input."
+    }
+
+    $vs = [DevDrivr.Native]::VirtualScreen()
+    $moveTarget = [pscustomobject]@{ X = $origin.X + 13; Y = $origin.Y + 11 }
+    if ([DevDrivr.Native]::SendMouseMoveAbsolute(
+        $moveTarget.X, $moveTarget.Y, $vs[0], $vs[1], $vs[2], $vs[3]) -ne 1) {
+      throw 'SendInput rejected an absolute move.'
+    }
+    Start-Sleep -Milliseconds 120
+    $moved = Get-MousePosition
+    # Normalisation to 0..65535 rounds, so allow a couple of pixels.
+    if ([math]::Abs($moved.X - $moveTarget.X) -gt 2 -or [math]::Abs($moved.Y - $moveTarget.Y) -gt 2) {
+      throw "SendInput accepted a move that had no effect: asked for $($moveTarget.X),$($moveTarget.Y), cursor is at $($moved.X),$($moved.Y). The INPUT flags are not reaching the API."
+    }
+
+    # A press/release pair *is* a click somewhere on screen. It happens at the cursor's current
+    # position, a few pixels from where the caller left it.
+    Send-MouseButton -Action down
+    Start-Sleep -Milliseconds 40
+    $pressed = ([DevDrivr.Native]::GetAsyncKeyState([DevDrivr.Native]::VK_LBUTTON) -band 0x8000) -ne 0
+    Send-MouseButton -Action up
+    Start-Sleep -Milliseconds 40
+    $released = ([DevDrivr.Native]::GetAsyncKeyState([DevDrivr.Native]::VK_LBUTTON) -band 0x8000) -eq 0
+
+    if (-not $pressed) {
+      throw 'SendInput reported success but the left button never registered as pressed. Synthetic clicks are not reaching the desktop: check for a UIPI integrity mismatch (app elevated, shell not), a locked session, or a UAC secure desktop.'
+    }
+    if (-not $released) {
+      throw 'The left button stayed down after a release event. The input stream is in a bad state; move the physical mouse and re-run.'
+    }
+    $true
+  }
+  finally {
+    Set-MousePosition -X $origin.X -Y $origin.Y
+  }
+}
+
+# ---------------------------------------------------------------------------------------------
+# Observation helpers
+# ---------------------------------------------------------------------------------------------
+
+function Wait-CockpitWindowState {
+  <#
+    .SYNOPSIS
+      Poll until the window reaches a state, or time out.
+    .DESCRIPTION
+      Window state changes are asynchronous: the click crosses into the webview, out through IPC to
+      Rust, and back into the OS. Reading the state immediately after clicking reports the old
+      value and manufactures a failure.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][ValidateSet('normal', 'minimized', 'maximized', 'gone')][string]$State,
+    [int]$TimeoutMs = 4000,
+    [string]$ProcessName = $(if ($env:COCKPIT_PROC) { $env:COCKPIT_PROC } else { 'cockpit' })
+  )
+
+  $deadline = [datetime]::UtcNow.AddMilliseconds($TimeoutMs)
+  $last = 'unknown'
+  do {
+    try {
+      $window = Get-CockpitWindow -ProcessName $ProcessName
+      $last = Get-CockpitWindowState -Window $window
+      if ($last -eq $State) { return [pscustomobject]@{ Reached = $true; State = $last; Window = $window } }
+    }
+    catch {
+      # No process or no window: that *is* the 'gone' state.
+      $last = 'gone'
+      if ($State -eq 'gone') { return [pscustomobject]@{ Reached = $true; State = 'gone'; Window = $null } }
+    }
+    Start-Sleep -Milliseconds 120
+  } while ([datetime]::UtcNow -lt $deadline)
+
+  [pscustomobject]@{ Reached = $false; State = $last; Window = $null }
+}
+
+function Restore-CockpitWindow {
+  <#
+    .SYNOPSIS
+      Bring the window back to normal state and focus, out of band from the UI under test.
+  #>
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][pscustomobject]$Window)
+  [void][DevDrivr.Native]::ShowWindow($Window.Handle, [DevDrivr.Native]::SW_RESTORE)
+  [void][DevDrivr.Native]::SetForegroundWindow($Window.Handle)
+  Start-Sleep -Milliseconds 350
+}
+
+function Save-CockpitScreenshot {
+  <#
+    .SYNOPSIS
+      Screenshot cropped to the window, scaled down for reading.
+    .DESCRIPTION
+      GDI screen capture returns black on a locked session or a disconnected RDP session — the
+      Windows analogue of macOS's slept-display problem. A black PNG is a capture failure, not
+      evidence about the app.
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][pscustomobject]$Window,
+    [string]$Path = (Join-Path ([IO.Path]::GetTempPath()) 'native-ui-shot.png'),
+    [int]$ScaleToWidth = 1200
+  )
+
+  Add-Type -AssemblyName System.Drawing
+
+  $bitmap = [System.Drawing.Bitmap]::new($Window.Width, $Window.Height)
+  try {
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+      $graphics.CopyFromScreen($Window.X, $Window.Y, 0, 0, $bitmap.Size)
+    }
+    finally { $graphics.Dispose() }
+
+    if ($ScaleToWidth -gt 0 -and $Window.Width -gt $ScaleToWidth) {
+      $height = [int][math]::Round($Window.Height * ($ScaleToWidth / $Window.Width))
+      $scaled = [System.Drawing.Bitmap]::new($bitmap, $ScaleToWidth, $height)
+      try { $scaled.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png) }
+      finally { $scaled.Dispose() }
+    }
+    else {
+      $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    }
+  }
+  finally { $bitmap.Dispose() }
+
+  $Path
+}
+
+function Set-DisplayAwake {
+  <#
+    .SYNOPSIS
+      Hold the display on for the length of a harness run.
+    .DESCRIPTION
+      SetThreadExecutionState is scoped to the calling thread, so this only lasts while the shell
+      lives. It does not defeat a *locked* session, which is the failure mode that actually blacks
+      out captures — lock the screen and nothing here will save the run.
+  #>
+  [CmdletBinding()]
+  param()
+  $flags = [DevDrivr.Native]::ES_CONTINUOUS -bor
+  [DevDrivr.Native]::ES_DISPLAY_REQUIRED -bor
+  [DevDrivr.Native]::ES_SYSTEM_REQUIRED
+  $previous = [DevDrivr.Native]::SetThreadExecutionState($flags)
+  if ($previous -eq 0) { throw 'SetThreadExecutionState failed.' }
+  $true
+}
+
+function Get-ForegroundProcessName {
+  [CmdletBinding()]
+  param()
+  $hWnd = [DevDrivr.Native]::GetForegroundWindow()
+  if ($hWnd -eq [IntPtr]::Zero) { return '(none)' }
+  # Not $pid: that automatic variable is read-only and the assignment would throw.
+  $procId = [uint32]0
+  [void][DevDrivr.Native]::GetWindowThreadProcessId($hWnd, [ref]$procId)
+  $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
+  if ($proc) { $proc.ProcessName } else { "(pid $procId)" }
+}
+
+Export-ModuleMember -Function @(
+  'Initialize-DpiAwareness'
+  'Get-CockpitWindow'
+  'Get-CockpitWindowState'
+  'Get-CockpitControlPoint'
+  'Assert-ControlPointIsClickable'
+  'Set-MousePosition'
+  'Get-MousePosition'
+  'Send-MouseButton'
+  'Invoke-MouseClick'
+  'Invoke-MouseDrag'
+  'Test-SyntheticInput'
+  'Wait-CockpitWindowState'
+  'Restore-CockpitWindow'
+  'Save-CockpitScreenshot'
+  'Set-DisplayAwake'
+  'Get-ForegroundProcessName'
+)

--- a/apps/cockpit/scripts/native-ui/verify-window-controls.ps1
+++ b/apps/cockpit/scripts/native-ui/verify-window-controls.ps1
@@ -1,0 +1,299 @@
+<#
+.SYNOPSIS
+  Drive the real title-bar window controls on Windows and assert the OS window state changed.
+
+.DESCRIPTION
+  Written for the Windows regression where minimize/maximize/close did nothing: the
+  `data-tauri-drag-region` layer in TitleBar.tsx is `absolute inset-0`, so it painted above the
+  statically-positioned Windows control cluster and absorbed every click. Nothing in vitest or the
+  browser harness can see that — jsdom does no layout, and hit-testing is exactly what broke.
+
+  Each check clicks a real button with synthetic input and then asserts against the OS
+  (IsIconic / IsZoomed / window destroyed), not against the DOM. A click that the drag region
+  swallows leaves the window state unchanged and fails here.
+
+  The last two checks exercise the drag region itself. The fix works by *raising* the control
+  cluster above that layer, so the thing most likely to be broken by it is dragging — these guard
+  the trade.
+
+  Run against a running app:
+    bun run tauri dev
+    pwsh -File scripts/native-ui/verify-window-controls.ps1
+
+.PARAMETER SkipClose
+  Skip the close check, which terminates the app.
+
+.PARAMETER ShotDirectory
+  Where to write a cropped screenshot for each failing check.
+
+.PARAMETER ProcessName
+  Override the process name (default `cockpit`, the dev binary; use `devdrivr` for a packaged build).
+#>
+[CmdletBinding()]
+param(
+  [switch]$SkipClose,
+  [string]$ShotDirectory = (Join-Path ([IO.Path]::GetTempPath()) 'cockpit-native-ui'),
+  [string]$ProcessName = $(if ($env:COCKPIT_PROC) { $env:COCKPIT_PROC } else { 'cockpit' })
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'native.psm1') -Force
+
+$script:Results = [System.Collections.Generic.List[pscustomobject]]::new()
+
+function Write-Step { param([string]$Text) Write-Host "  $Text" -ForegroundColor DarkGray }
+
+function Add-Result {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][bool]$Passed,
+    [string]$Detail = ''
+  )
+  $script:Results.Add([pscustomobject]@{ Name = $Name; Passed = $Passed; Detail = $Detail })
+  if ($Passed) {
+    Write-Host "  PASS  $Name" -ForegroundColor Green
+  }
+  else {
+    Write-Host "  FAIL  $Name" -ForegroundColor Red
+    if ($Detail) { Write-Host "        $Detail" -ForegroundColor Red }
+  }
+}
+
+function Save-FailureShot {
+  param([Parameter(Mandatory)][string]$Name)
+  try {
+    if (-not (Test-Path $ShotDirectory)) {
+      New-Item -ItemType Directory -Path $ShotDirectory -Force | Out-Null
+    }
+    $window = Get-CockpitWindow -ProcessName $ProcessName
+    $slug = ($Name -replace '[^\w]+', '-').Trim('-').ToLower()
+    $path = Save-CockpitScreenshot -Window $window -Path (Join-Path $ShotDirectory "fail-$slug.png")
+    Write-Step "screenshot: $path"
+  }
+  catch {
+    Write-Step "screenshot unavailable: $($_.Exception.Message)"
+  }
+}
+
+# -----------------------------------------------------------------------------------------------
+# A check reads the window fresh, computes the target fresh, clicks, then waits for the OS state.
+# Re-reading is not optional: the rect changes on every maximize, restore, and move, and a cached
+# coordinate lands in empty space and produces a confident false failure.
+# -----------------------------------------------------------------------------------------------
+function Test-Control {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][ValidateSet('minimize', 'maximize', 'close', 'dragregion')][string]$Control,
+    [Parameter(Mandatory)][ValidateSet('normal', 'minimized', 'maximized', 'gone')][string]$Expect,
+    [int]$Clicks = 1,
+    [int]$TimeoutMs = 4000
+  )
+
+  try {
+    $window = Get-CockpitWindow -ProcessName $ProcessName
+    $point = Get-CockpitControlPoint -Window $window -Control $Control
+    [void](Assert-ControlPointIsClickable -Window $window -Point $point)
+
+    $before = Get-CockpitWindowState -Window $window
+    Write-Step "state=$before  click x$Clicks at $($point.X),$($point.Y)  (window $($window.X),$($window.Y) $($window.Width)x$($window.Height) scale=$($window.Scale))"
+
+    # Every check here is a *transition*. If the window is already in the expected state, waiting
+    # for that state succeeds without the control having done anything — a pass that means nothing.
+    # This bit during development: with the fix reverted, "maximize restores the window" passed
+    # while maximize was demonstrably broken, purely because the window had never left 'normal'.
+    if ($before -eq $Expect) {
+      Add-Result -Name $Name -Passed $false `
+        -Detail "precondition not met: the window was already '$Expect' before the click, so no transition could be observed (the preceding check most likely failed)"
+      return
+    }
+
+    Invoke-MouseClick -X $point.X -Y $point.Y -Count $Clicks
+
+    $outcome = Wait-CockpitWindowState -State $Expect -TimeoutMs $TimeoutMs -ProcessName $ProcessName
+    if ($outcome.Reached) {
+      Add-Result -Name $Name -Passed $true
+    }
+    else {
+      $hint = if ($outcome.State -eq $before) {
+        "state never changed from '$before' — consistent with the drag-region layer absorbing the click"
+      }
+      else {
+        "state went to '$($outcome.State)'"
+      }
+      Add-Result -Name $Name -Passed $false -Detail "expected '$Expect'; $hint"
+      Save-FailureShot -Name $Name
+    }
+  }
+  catch {
+    Add-Result -Name $Name -Passed $false -Detail $_.Exception.Message
+  }
+}
+
+function Reset-ToNormal {
+  <#
+    Return the window to a known normal, focused state using the OS directly, so a failure in one
+    check cannot cascade into the next.
+  #>
+  try {
+    $window = Get-CockpitWindow -ProcessName $ProcessName
+    Restore-CockpitWindow -Window $window
+    $window = Get-CockpitWindow -ProcessName $ProcessName
+    if ($window.IsMaximized) {
+      # No ShowWindow(SW_RESTORE) shortcut here: it is already un-minimized, so unmaximize needs a
+      # second restore pass.
+      [void][DevDrivr.Native]::ShowWindow($window.Handle, [DevDrivr.Native]::SW_RESTORE)
+      Start-Sleep -Milliseconds 350
+    }
+    $window = Get-CockpitWindow -ProcessName $ProcessName
+    if (-not $window.IsForeground) {
+      Write-Warning 'Window is not in the foreground. Windows can refuse SetForegroundWindow from a background process; the first click may be consumed by activation. Click the app window once yourself and re-run.'
+    }
+    $window
+  }
+  catch {
+    throw "Could not return the window to a normal state: $($_.Exception.Message)"
+  }
+}
+
+# -----------------------------------------------------------------------------------------------
+# Preflight
+# -----------------------------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host 'Preflight' -ForegroundColor Cyan
+
+try {
+  $awareness = Initialize-DpiAwareness
+  Write-Step "dpi awareness level: $awareness (0 would be fatal)"
+}
+catch {
+  Write-Host "  ABORT  $($_.Exception.Message)" -ForegroundColor Red
+  exit 2
+}
+
+try {
+  [void](Set-DisplayAwake)
+  Write-Step 'display held awake'
+}
+catch {
+  Write-Step "could not hold the display awake: $($_.Exception.Message)"
+}
+
+try {
+  [void](Test-SyntheticInput)
+  Write-Step 'synthetic input verified against the desktop'
+}
+catch {
+  # Everything downstream would report "the controls do nothing", which would be a lie.
+  Write-Host "  ABORT  synthetic input is not reaching the desktop: $($_.Exception.Message)" -ForegroundColor Red
+  Write-Host '         Run the app and this shell at the same integrity level, unlock the session, and dismiss any UAC prompt.' -ForegroundColor Red
+  exit 2
+}
+
+try {
+  $window = Get-CockpitWindow -ProcessName $ProcessName
+}
+catch {
+  Write-Host "  ABORT  $($_.Exception.Message)" -ForegroundColor Red
+  exit 2
+}
+
+Write-Step "window '$($window.Title)' pid=$($window.ProcessId) handle=$($window.Handle)"
+Write-Step "rect $($window.X),$($window.Y) $($window.Width)x$($window.Height)  dpi=$($window.Dpi) scale=$($window.Scale)  dwmFrame=$($window.UsedDwmFrame)"
+
+foreach ($control in 'minimize', 'maximize', 'close') {
+  $point = Get-CockpitControlPoint -Window $window -Control $control
+  try {
+    [void](Assert-ControlPointIsClickable -Window $window -Point $point)
+    Write-Step "target $control -> $($point.X),$($point.Y)"
+  }
+  catch {
+    Write-Host "  ABORT  $($_.Exception.Message)" -ForegroundColor Red
+    exit 2
+  }
+}
+
+[void](Reset-ToNormal)
+
+# -----------------------------------------------------------------------------------------------
+# Checks
+# -----------------------------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host 'Window controls' -ForegroundColor Cyan
+
+Test-Control -Name 'minimize button minimizes the window' -Control 'minimize' -Expect 'minimized'
+[void](Reset-ToNormal)
+
+Test-Control -Name 'maximize button maximizes the window' -Control 'maximize' -Expect 'maximized'
+Test-Control -Name 'maximize button restores the window' -Control 'maximize' -Expect 'normal'
+[void](Reset-ToNormal)
+
+Write-Host ''
+Write-Host 'Drag region (must survive raising the control cluster above it)' -ForegroundColor Cyan
+
+Test-Control -Name 'double-click on the drag region maximizes' -Control 'dragregion' -Expect 'maximized' -Clicks 2
+Test-Control -Name 'double-click on the drag region restores' -Control 'dragregion' -Expect 'normal' -Clicks 2
+[void](Reset-ToNormal)
+
+try {
+  $window = Get-CockpitWindow -ProcessName $ProcessName
+  $point = Get-CockpitControlPoint -Window $window -Control 'dragregion'
+  $originX = $window.X
+  $originY = $window.Y
+  $deltaX = 120
+  $deltaY = 60
+  Write-Step "drag from $($point.X),$($point.Y) by +$deltaX,+$deltaY"
+  Invoke-MouseDrag -FromX $point.X -FromY $point.Y -ToX ($point.X + $deltaX) -ToY ($point.Y + $deltaY)
+  Start-Sleep -Milliseconds 400
+
+  $moved = Get-CockpitWindow -ProcessName $ProcessName
+  $movedX = $moved.X - $originX
+  $movedY = $moved.Y - $originY
+  # Tolerance rather than exactness: the compositor can land a pixel or two off, and snapping may
+  # adjust the final position.
+  $ok = ([math]::Abs($movedX - $deltaX) -le 8) -and ([math]::Abs($movedY - $deltaY) -le 8)
+  if ($ok) {
+    Add-Result -Name 'drag on the drag region moves the window' -Passed $true
+  }
+  else {
+    Add-Result -Name 'drag on the drag region moves the window' -Passed $false `
+      -Detail "expected +$deltaX,+$deltaY, observed +$movedX,+$movedY"
+  }
+
+  # Put it back so a rerun starts from a comparable position.
+  Invoke-MouseDrag -FromX ($point.X + $deltaX) -FromY ($point.Y + $deltaY) -ToX $point.X -ToY $point.Y
+}
+catch {
+  Add-Result -Name 'drag on the drag region moves the window' -Passed $false -Detail $_.Exception.Message
+}
+
+if ($SkipClose) {
+  Write-Host ''
+  Write-Host 'Skipping the close check (-SkipClose); the app is left running.' -ForegroundColor Yellow
+}
+else {
+  Write-Host ''
+  Write-Host 'Close (terminates the app — run last)' -ForegroundColor Cyan
+  [void](Reset-ToNormal)
+  Test-Control -Name 'close button closes the window' -Control 'close' -Expect 'gone' -TimeoutMs 6000
+}
+
+# -----------------------------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------------------------
+
+$failed = @($script:Results | Where-Object { -not $_.Passed })
+Write-Host ''
+Write-Host ("{0} checks, {1} passed, {2} failed" -f $script:Results.Count,
+  ($script:Results.Count - $failed.Count), $failed.Count) -ForegroundColor Cyan
+
+if ($failed.Count -gt 0) {
+  foreach ($result in $failed) { Write-Host "  FAIL  $($result.Name) — $($result.Detail)" -ForegroundColor Red }
+  exit 1
+}
+
+Write-Host 'All window controls behave correctly.' -ForegroundColor Green
+exit 0

--- a/apps/cockpit/scripts/native-ui/window.ps1
+++ b/apps/cockpit/scripts/native-ui/window.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+  Window inspection helpers for native-UI debugging on Windows. Counterpart to window.sh.
+
+.DESCRIPTION
+  ./window.ps1 bounds          # x y w h of the app window (physical px, top-left origin)
+  ./window.ps1 raw             # GetWindowRect vs. the DWM frame, to spot an invisible border
+  ./window.ps1 dpi             # dpi and scale factor for the window's monitor
+  ./window.ps1 state           # normal | minimized | maximized
+  ./window.ps1 minimized       # true | false
+  ./window.ps1 maximized       # true | false
+  ./window.ps1 titlebar        # x y w h of the 44 CSS px title strip, scaled
+  ./window.ps1 button <name>   # x y of minimize | maximize | close | dragregion
+  ./window.ps1 buttons         # all four target points, with clickability checked
+  ./window.ps1 frontmost       # process name owning the foreground window
+  ./window.ps1 shot [file]     # screenshot cropped to the window, scaled to 1200px wide
+  ./window.ps1 awake           # hold the display on (lasts only while this shell runs)
+  ./window.ps1 info            # everything above in one object
+
+  COCKPIT_PROC overrides the process name for a packaged build:
+    $env:COCKPIT_PROC = 'devdrivr'; ./window.ps1 bounds
+
+  The process is `cockpit` (the Cargo package name); `devdrivr` is the *window title* and also
+  appears in editor window titles, so matching on it can find a completely unrelated window.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)][string]$Command,
+  [Parameter(Position = 1)][string]$Argument
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'native.psm1') -Force
+
+function Show-Usage {
+  (Get-Help -Full $PSCommandPath).Description.Text
+  exit 2
+}
+
+switch ($Command) {
+  'bounds' {
+    $w = Get-CockpitWindow
+    "$($w.X) $($w.Y) $($w.Width) $($w.Height)"
+  }
+  'raw' {
+    $w = Get-CockpitWindow
+    "GetWindowRect: $($w.WindowRect)"
+    "DWM frame:     $($w.X) $($w.Y) $($w.Width) $($w.Height)  (used: $($w.UsedDwmFrame))"
+  }
+  'dpi' {
+    $w = Get-CockpitWindow
+    "dpi=$($w.Dpi) scale=$($w.Scale)"
+  }
+  'state' { Get-CockpitWindowState -Window (Get-CockpitWindow) }
+  'minimized' { (Get-CockpitWindow).IsMinimized.ToString().ToLower() }
+  'maximized' { (Get-CockpitWindow).IsMaximized.ToString().ToLower() }
+  'titlebar' {
+    $w = Get-CockpitWindow
+    "$($w.X) $($w.Y) $($w.Width) $([int][math]::Round(44 * $w.Scale))"
+  }
+  'button' {
+    if (-not $Argument) { Show-Usage }
+    $w = Get-CockpitWindow
+    $point = Get-CockpitControlPoint -Window $w -Control $Argument
+    [void](Assert-ControlPointIsClickable -Window $w -Point $point)
+    "$($point.X) $($point.Y)"
+  }
+  'buttons' {
+    $w = Get-CockpitWindow
+    foreach ($control in 'minimize', 'maximize', 'close', 'dragregion') {
+      $point = Get-CockpitControlPoint -Window $w -Control $control
+      $status = try {
+        [void](Assert-ControlPointIsClickable -Window $w -Point $point); 'ok'
+      }
+      catch { "BLOCKED: $($_.Exception.Message)" }
+      "{0,-11} {1,5} {2,5}  {3}" -f $control, $point.X, $point.Y, $status
+    }
+  }
+  'frontmost' { Get-ForegroundProcessName }
+  'shot' {
+    $w = Get-CockpitWindow
+    if ($w.IsMinimized) {
+      Write-Warning 'Window is minimized; the crop will capture whatever is behind it.'
+    }
+    Save-CockpitScreenshot -Window $w -Path ($Argument ? $Argument : (Join-Path ([IO.Path]::GetTempPath()) 'native-ui-shot.png'))
+  }
+  'awake' {
+    [void](Set-DisplayAwake)
+    'display held awake for the lifetime of this shell'
+  }
+  'info' { Get-CockpitWindow | Format-List }
+  default { Show-Usage }
+}

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -19,9 +19,14 @@ const ICON_BUTTON_CLASS = `flex items-center justify-center rounded p-1.5 text-[
  * descendants of a native drag region; this keeps pointer and keyboard focus transitions under
  * normal browser control.
  *
- * Because that layer is absolutely positioned with `z-index: auto`, it paints above *any*
- * non-positioned sibling no matter the DOM order. Every interactive cluster in this bar must
- * therefore be positioned (`relative`) as well, or the drag layer silently eats its clicks.
+ * Layering inside the bar is explicit rather than inherited from DOM order: the drag layer is the
+ * floor (`z-0`) and every interactive cluster sits a tier above it (`relative z-10`). An
+ * absolutely-positioned `z-index: auto` layer paints above any *non-positioned* sibling no matter
+ * where it appears in the markup, so relying on source order alone is what let the drag layer
+ * swallow every Windows window-control click. Stating the tiers follows the same rule as the app's
+ * overlay scale in styles/tokens.css — layering must not depend on DOM position — and keeps this
+ * bar safe to reorder. Both tiers stay below the `z-[39]` window resize handles and the `--z-scrim`
+ * overlay tiers, which must still win over the title bar.
  */
 export function TitleBar() {
   const { isMac } = usePlatform()
@@ -44,18 +49,18 @@ export function TitleBar() {
         data-tauri-drag-region
         data-testid="titlebar-drag-region"
         aria-hidden="true"
-        className="absolute inset-0"
+        className="absolute inset-0 z-0"
       />
       {isMac && (
         <div
           data-testid="titlebar-mac-controls"
-          className="absolute left-3 top-1/2 -translate-y-1/2"
+          className="absolute left-3 top-1/2 z-10 -translate-y-1/2"
         >
           <WindowControls />
         </div>
       )}
 
-      <div className="relative flex items-center gap-1">
+      <div className="relative z-10 flex items-center gap-1">
         <button
           type="button"
           onClick={toggleNotes}
@@ -93,12 +98,15 @@ export function TitleBar() {
       {/* Absolutely centred on the full bar width (Safari-style) — stays centred regardless of
           how wide the left cluster or right-side window controls are, rather than merely sitting
           between two flex siblings. */}
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-2">
+      <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-2">
         <CommandPalette />
       </div>
 
       {!isMac && (
-        <div data-testid="titlebar-right-controls" className="relative ml-auto flex items-center">
+        <div
+          data-testid="titlebar-right-controls"
+          className="relative z-10 ml-auto flex items-center"
+        >
           <WindowControls />
         </div>
       )}

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -18,6 +18,10 @@ const ICON_BUTTON_CLASS = `flex items-center justify-center rounded p-1.5 text-[
  * dragged/double-click-zoomed from empty space. Interactive controls are siblings above it, never
  * descendants of a native drag region; this keeps pointer and keyboard focus transitions under
  * normal browser control.
+ *
+ * Because that layer is absolutely positioned with `z-index: auto`, it paints above *any*
+ * non-positioned sibling no matter the DOM order. Every interactive cluster in this bar must
+ * therefore be positioned (`relative`) as well, or the drag layer silently eats its clicks.
  */
 export function TitleBar() {
   const { isMac } = usePlatform()
@@ -94,7 +98,7 @@ export function TitleBar() {
       </div>
 
       {!isMac && (
-        <div data-testid="titlebar-right-controls" className="ml-auto flex items-center">
+        <div data-testid="titlebar-right-controls" className="relative ml-auto flex items-center">
           <WindowControls />
         </div>
       )}

--- a/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
@@ -195,4 +195,36 @@ describe('TitleBar — drag region', () => {
       expect(button).not.toHaveAttribute('data-tauri-drag-region')
     })
   })
+
+  // The drag layer is `absolute inset-0` with z-index auto, so it paints above every
+  // *non-positioned* sibling regardless of DOM order — a static wrapper puts its buttons
+  // underneath the layer and the drag region swallows their clicks. Windows/Linux window
+  // controls regressed exactly this way; assert the invariant on both platforms.
+  it.each(['mac', 'windows'] as const)(
+    'keeps every interactive cluster positioned above the drag layer on %s',
+    (platform) => {
+      mocks.platform.current = platform
+      const { container } = render(<TitleBar />)
+      const bar = container.firstElementChild as HTMLElement
+
+      const buttons = Array.from(bar.querySelectorAll('button'))
+      expect(buttons.length).toBeGreaterThan(0)
+
+      for (const button of buttons) {
+        let node: HTMLElement | null = button
+        let positioned = false
+        while (node && node !== bar) {
+          if (/(^|\s)(relative|absolute|fixed)(\s|$)/.test(node.className)) {
+            positioned = true
+            break
+          }
+          node = node.parentElement
+        }
+        expect(
+          positioned,
+          `"${button.getAttribute('aria-label')}" has no positioned wrapper — the drag region will eat its clicks`
+        ).toBe(true)
+      }
+    }
+  )
 })

--- a/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
@@ -196,34 +196,59 @@ describe('TitleBar — drag region', () => {
     })
   })
 
-  // The drag layer is `absolute inset-0` with z-index auto, so it paints above every
-  // *non-positioned* sibling regardless of DOM order — a static wrapper puts its buttons
-  // underneath the layer and the drag region swallows their clicks. Windows/Linux window
-  // controls regressed exactly this way; assert the invariant on both platforms.
+  // The drag layer covers the whole bar and captures pointer events, so anything interactive must
+  // sit explicitly above it. Two separate ways to get this wrong, both of which have to fail here:
+  //   - a static wrapper: an absolutely-positioned layer paints above every non-positioned sibling
+  //     regardless of source order (this is how the Windows controls originally broke);
+  //   - a wrapper with no z-index: correct only while it happens to follow the drag layer in the
+  //     markup, so reordering the JSX silently re-breaks it.
+  // Asserting the z-tier rather than mere positioning is what makes the guarantee order-independent,
+  // matching the stacking rule documented in styles/tokens.css.
+  const zIndexOf = (el: HTMLElement): number | null => {
+    const match = /(?:^|\s)z-(\d+)(?:\s|$)/.exec(el.className)
+    return match?.[1] ? Number(match[1]) : null
+  }
+
   it.each(['mac', 'windows'] as const)(
-    'keeps every interactive cluster positioned above the drag layer on %s',
+    'stacks every interactive cluster explicitly above the drag layer on %s',
     (platform) => {
       mocks.platform.current = platform
       const { container } = render(<TitleBar />)
       const bar = container.firstElementChild as HTMLElement
 
+      const dragRegion = screen.getByTestId('titlebar-drag-region')
+      const dragZ = zIndexOf(dragRegion)
+      expect(dragZ, 'the drag layer must declare its own z-tier').not.toBeNull()
+
       const buttons = Array.from(bar.querySelectorAll('button'))
       expect(buttons.length).toBeGreaterThan(0)
 
       for (const button of buttons) {
+        const label = button.getAttribute('aria-label')
         let node: HTMLElement | null = button
         let positioned = false
+        let z: number | null = null
+
         while (node && node !== bar) {
-          if (/(^|\s)(relative|absolute|fixed)(\s|$)/.test(node.className)) {
+          if (!positioned && /(?:^|\s)(relative|absolute|fixed)(?:\s|$)/.test(node.className)) {
             positioned = true
-            break
           }
+          if (z === null) z = zIndexOf(node)
           node = node.parentElement
         }
+
         expect(
           positioned,
-          `"${button.getAttribute('aria-label')}" has no positioned wrapper — the drag region will eat its clicks`
+          `"${label}" has no positioned wrapper — the drag region will eat its clicks`
         ).toBe(true)
+        expect(
+          z,
+          `"${label}" has no z-tier, so it only works while it follows the drag layer`
+        ).not.toBeNull()
+        expect(
+          z as number,
+          `"${label}" sits at z-${z}, not above the drag layer's z-${dragZ}`
+        ).toBeGreaterThan(dragZ as number)
       }
     }
   )

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+    watch: {
+      // Never watch the Rust side. `tauri dev` compiles into src-tauri/target while this watcher
+      // is crawling it; on Windows the watcher hits a half-written .dll and chokidar throws
+      // EBUSY, killing the dev server mid-build. Windows holds exclusive locks on files open for
+      // writing, so this is fatal there and merely wasteful on macOS/Linux.
+      ignored: ['**/src-tauri/**'],
+    },
   },
   envPrefix: ['VITE_', 'TAURI_'],
   build: {

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "apps/cockpit": {
       "name": "cockpit",
-      "version": "0.1.43",
+      "version": "0.1.63",
       "dependencies": {
         "@fontsource/cascadia-code": "^5.2.3",
         "@fontsource/fira-code": "^5.2.7",


### PR DESCRIPTION
## Summary

- **Minimize, maximize and close now work on Windows.** They had stopped responding entirely: the title bar's drag layer was painting on top of the button cluster, so every click started a window drag instead of activating the button. macOS was never affected — it renders a different, already-correctly-layered control cluster.
- **The title bar's internal layering is now explicit.** Each interactive cluster declares that it sits above the drag layer, instead of depending on the order elements happen to appear in the markup.
- **`bun run tauri dev` starts on Windows again.** Vite was watching the Rust build directory while cargo wrote into it, and the dev server crashed on a partially written `.dll`. Fatal on Windows, which locks files open for writing.
- **New Windows native-UI test harness**, mirroring the macOS one that already lives in `scripts/native-ui/`. Includes a one-command run that drives every real title-bar control and checks the actual OS window state, so this class of bug can't pass unnoticed again.

## Why the automated tests didn't catch it

The bug was purely about which element wins a click. jsdom performs no layout and no hit-testing, so every existing test passed while all three buttons were unreachable. There is now a unit test for the invariant and a native harness that drives the real window.

## What the self-review changed

The one-line positioning fix was correct but left the guarantee resting on source order — moving the drag layer further down the JSX would have silently re-broken all three buttons. Two things pointed the same way: `styles/tokens.css` states that layering must not depend on DOM position, and the drag layer was the only pointer-capturing overlay in the app that didn't declare a z-index (`Base64Tool`, `ImageTool`, `MarkdownEditor` and `Workspace` all do). The drag layer is now the explicit floor with each interactive cluster one tier above it, still below the window resize handles and the overlay tiers.

The regression test was tightened to match, and now fails on both the original bug and the weaker order-dependent version of it.

## Test plan

- [x] `verify-window-controls.ps1` — 7/7 pass against the running app: minimize, maximize, restore, double-click zoom + restore on the drag region, drag-to-move, close
- [x] Re-ran 7/7 after the layering change, to confirm dragging still works once the buttons are raised above the drag layer
- [x] Reverting the fix flips exactly the control checks to FAIL while all drag-region checks keep passing, confirming the harness detects this specific regression
- [x] Full suite: 1289 tests / 105 files passing
- [x] `bun run lint` clean, `npx tsc --noEmit` clean
- [x] Verified at 150% display scaling (the harness is DPI-aware; hard-coded pixel offsets would miss every button)
- [ ] macOS spot-check that the traffic lights and drag region are unchanged — the traffic-light cluster gains an explicit z-tier here, so it is worth a look on a real Mac

## Notes for the reviewer

- `bun.lock` shows the cockpit version field moving `0.1.43` → `0.1.63`; that's `bun install` syncing a stale entry, not a hand edit.
- **Unrelated pre-existing issue, not touched here:** `src-tauri/Cargo.toml` is pinned at `0.1.54` while `package.json` and `tauri.conf.json` are at `0.1.63` — the release bump appears to skip the Rust manifest, and it's drifted nine releases. Left alone deliberately, since versioning belongs to the release tooling.
- `documentation/NATIVE_UI_HARNESS.md` records the Windows-specific traps found while building this, including one where the harness itself produced a completely convincing false failure. Worth reading before relying on a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)