### PR TITLE
fix(cockpit): pre-load editor font to prevent Monaco cursor offset

### DIFF
--- a/apps/cockpit/src/hooks/useMonaco.ts
+++ b/apps/cockpit/src/hooks/useMonaco.ts
@@ -62,7 +62,6 @@ const LIGHT_THEME: MonacoThemeData = {
 }
 
 let themesRegistered = false
-const EMPTY_OVERRIDES: Record<string, unknown> = {}
 
 /**
  * Convert an rgb()/rgba() string returned by getComputedStyle to a Monaco-compatible hex.
@@ -401,11 +400,18 @@ export function useMonacoSettings() {
 
       monaco.editor.setTheme(resolvedTheme)
 
+      // Force-load the configured font before any editor measures character
+      // widths. The @fontsource fonts use font-display:swap, so the browser
+      // won't fetch the woff2 until text actually renders with that family.
+      // document.fonts.ready resolves instantly when nothing is loading yet,
+      // which means remeasureFonts() below would fire before the real font is
+      // available — leaving Monaco with stale fallback-font measurements and
+      // the cursor offset from click positions by several characters.
       try {
-        await document.fonts?.ready
+        await document.fonts.load(`400 1em "${editorFont}"`)
       } catch {
-        // Font readiness can reject in constrained webview environments. Monaco still
-        // falls back to its current measurements in that case.
+        // Font loading can reject in constrained webview environments. Monaco
+        // still falls back to its current measurements in that case.
       }
 
       if (!cancelled && typeof monaco.editor.remeasureFonts === 'function') {
@@ -426,15 +432,10 @@ export function useMonacoSettings() {
   }
 }
 
-export function useMonacoTheme(): string {
-  const { theme } = useMonacoSettings()
-  return theme
-}
-
-export function useMonacoOptions(overrides: Record<string, unknown> = EMPTY_OVERRIDES) {
+export function useMonaco() {
   const settings = useMonacoSettings()
 
-  return useMemo(
+  const options = useMemo(
     () => ({
       ...EDITOR_OPTIONS,
       fontSize: settings.fontSize,
@@ -442,10 +443,11 @@ export function useMonacoOptions(overrides: Record<string, unknown> = EMPTY_OVER
       lineHeight: Math.max(20, Math.ceil(settings.fontSize * 1.5)),
       tabSize: settings.tabSize,
       formatOnPaste: settings.formatOnPaste,
-      ...overrides,
     }),
-    [settings.fontSize, settings.fontFamily, settings.tabSize, settings.formatOnPaste, overrides]
+    [settings.fontSize, settings.fontFamily, settings.tabSize, settings.formatOnPaste]
   )
+
+  return { theme: settings.theme, options }
 }
 
 /**

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useMonacoSelectionToolbar } from '@/hooks/useMonacoSelectionToolbar'
 import { TabBar } from '@/components/shared/TabBar'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -234,8 +234,7 @@ function applyMethodDefaults(draft: RequestDraft, nextMethod: string): RequestDr
 
 export default function ApiClient() {
   const responsePaneId = useId()
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const init = useApiStore((s) => s.init)
   const environments = useApiStore((s) => s.environments)
   const activeEnvironmentId = useApiStore((s) => s.activeEnvironmentId)

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -10,7 +10,7 @@ import {
   SlidersHorizontalIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Alert } from '@/components/shared/Alert'
@@ -74,8 +74,7 @@ function describeStatus(status: FormatStatus): string {
 }
 
 export default function CodeFormatter() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CodeFormatterState>('code-formatter', {
     input: '',
     fileName: null,

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
@@ -317,8 +317,7 @@ function convertCssToTailwind(css: string): ConversionResult {
 }
 
 export default function CssToTailwind() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CssToTailwindState>('css-to-tailwind', {
     input: '',
   })

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -17,7 +17,7 @@ import {
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
@@ -92,8 +92,7 @@ const MAX_LISTED_SELECTORS = 100
 const MAX_LISTED_ISSUES = 200
 
 export default function CssValidator() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const setLastAction = useUiStore((s) => s.setLastAction)
   const copy = useCopyToClipboard()
   const { record } = useToolHistory({ toolId: 'css-validator' })

--- a/apps/cockpit/src/tools/csv-tools/CsvConvert.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvConvert.tsx
@@ -1,5 +1,5 @@
 import Editor from '@monaco-editor/react'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Select } from '@/components/shared/Select'
 import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
@@ -13,8 +13,7 @@ type CsvConvertProps = {
 }
 
 export default function CsvConvert({ output, format, onFormatChange }: CsvConvertProps) {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -11,7 +11,7 @@ import {
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -104,8 +104,7 @@ function outputFor(source: string, parse: CsvParse, options: OutputOptions): str
 }
 
 export default function CsvTools() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CsvToolsState>('csv-tools', {
     input: '',
     fileName: null,

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -216,8 +216,7 @@ const METHOD_COLORS: Record<string, string> = {
 // ── Component ──────────────────────────────────────────────────────
 
 export default function CurlToFetch() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CurlToFetchState>('curl-to-fetch', {
     input: '',
     outputTab: 'fetch',

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -11,7 +11,7 @@ import {
   TrashIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -223,8 +223,7 @@ function EditorPane({
 
 export default function DiffViewer() {
   const optionsId = useId()
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   // Merged once: spreading inline made a new object every render, which
   // @monaco-editor/react re-applies to both editors on every keystroke.
   const editorOptions = useMemo(

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -19,7 +19,7 @@ import {
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
@@ -97,8 +97,7 @@ const VALIDATE_DEBOUNCE_MS = 300
 const PREVIEW_DEBOUNCE_MS = 400
 
 export default function HtmlValidator() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const setLastAction = useUiStore((s) => s.setLastAction)
   const copy = useCopyToClipboard()
   const { record } = useToolHistory({ toolId: 'html-validator' })

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -15,7 +15,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -69,8 +69,7 @@ const FETCH_TIMEOUT_MS = 15_000
 // ---------------------------------------------------------------------------
 
 export default function JsonSchemaValidator() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<JsonSchemaState>('json-schema-validator', {
     data: '',
     schema: DEFAULT_TEMPLATE ? JSON.stringify(DEFAULT_TEMPLATE.schema, null, 2) : '',

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -16,7 +16,7 @@ import {
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -303,8 +303,7 @@ type ParseResult =
 // ---------------------------------------------------------------------------
 
 export default function JsonTools() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<JsonToolsState>('json-tools', {
     input: '',
     fileName: null,

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
@@ -478,8 +478,7 @@ export async function renderMarkdownContent(content: string): Promise<string> {
 
 export default function MarkdownEditor() {
   const isInstanceActive = useIsInstanceActive()
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<MarkdownEditorState>('markdown-editor', {
     content: '',
     fileName: null,

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -10,7 +10,7 @@ import {
   GraphIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { Alert } from '@/components/shared/Alert'
@@ -117,8 +117,7 @@ function removeMermaidScratchNodes(renderId: string) {
 }
 
 export default function MermaidEditor() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const appTheme = useSettingsStore((s) => s.theme)
   const mermaidTheme = isLightEffectiveTheme(getEffectiveTheme(appTheme)) ? 'default' : 'dark'
   const setLastAction = useUiStore((s) => s.setLastAction)

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -10,7 +10,7 @@ import {
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -108,8 +108,7 @@ function IndeterminateCheckbox({
 }
 
 export default function RefactoringToolkit() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const diffOptions = useMemo(
     () => ({
       ...monacoOptions,

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -29,7 +29,7 @@ import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { InlineInput } from '@/components/shared/InlineInput'
-import { useMonacoOptions, useMonacoTheme } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useIsInstanceActive } from '@/app/tool-instance'
 import { buildExportFilename, exportFile, openFileDialog } from '@/lib/file-io'
 import { useSnippetsStore } from '@/stores/snippets.store'
@@ -233,8 +233,7 @@ export default function SnippetsManager() {
   const tagSuggestionsId = useId()
   const snippetOptionsId = useId()
   const isInstanceActive = useIsInstanceActive()
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const snippets = useSnippetsStore((state) => state.snippets)
   const saving = useSnippetsStore((state) => state.saving)
   const activeFolder = useSnippetsStore((state) => state.activeFolder)

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -11,7 +11,7 @@ import {
   XCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -75,8 +75,7 @@ export function describeProblems(diagnostics: Diagnostic[]): string {
 }
 
 export default function TsPlayground() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   // Merged once: a fresh options object on every keystroke makes
   // @monaco-editor/react re-apply the whole configuration to both editors.
   const editorOptions = useMemo(

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -13,7 +13,7 @@ import {
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker, type WorkerRpc } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -110,8 +110,7 @@ function describeIssue(issue: XmlIssue): string {
 // ---------------------------------------------------------------------------
 
 export default function XmlTools() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<XmlToolsState>('xml-tools', {
     input: '',
     fileName: null,

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -11,7 +11,7 @@ import {
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
-import { useMonacoTheme, useMonacoOptions } from '@/hooks/useMonaco'
+import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -83,8 +83,7 @@ function toText(value: unknown): string {
 // ---------------------------------------------------------------------------
 
 export default function YamlTools() {
-  const monacoTheme = useMonacoTheme()
-  const monacoOptions = useMonacoOptions()
+  const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<YamlToolsState>('yaml-tools', {
     input: '',
     fileName: null,


### PR DESCRIPTION
## Summary
- Replace `document.fonts.ready` with `document.fonts.load()` in `useMonacoSettings` to explicitly trigger and await the configured editor font before `remeasureFonts()` fires — fixes cursor landing 3-4 chars left of click position on first open
- Consolidate `useMonacoTheme()` + `useMonacoOptions()` into a single `useMonaco()` hook so each tool registers the font-loading effect once instead of twice (halves the effect count across all mounted Monaco tools)

## Test plan
- [ ] Open any Monaco tool (Markdown Editor, JSON Tools, etc.) on cold start — click mid-line and verify cursor lands at click position
- [ ] Switch editor font in Settings (e.g. JetBrains Mono → Fira Code) — verify cursor alignment holds after the switch
- [ ] Open two Monaco tools in separate tabs, switch between them — verify both have correct cursor alignment
- [ ] Verify all 4 font options render correctly: JetBrains Mono, Fira Code, Cascadia Code, Source Code Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)