### PR TITLE
refactor(cockpit): tool UI consistency audit — reusable layout, chrome and shortcut primitives

### DIFF
--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -175,7 +175,8 @@ Weights: `regular` default; `bold` for emphasis and active states; `fill` for st
 
 ## Layout contract
 
-Every tool renders through `ToolLayout`. No exceptions.
+Every tool renders through `ToolLayout`, or — if it's a library tool with a list beside a detail
+pane — `MasterDetailLayout`. No exceptions.
 
 ```
 ToolLayout
@@ -185,10 +186,19 @@ ToolLayout
   body:
     fullBleed  → SplitPane / editors, each pane headed by PaneHeader
     otherwise  → maxWidth-capped stack of Panel sections
+
+MasterDetailLayout                       ← snippets, prompt-templates, api-client
+  title / subtitle / sidebarActions      ← names the collection, not the tool
+  sidebar: filters, then the list
+  children: the detail pane (may itself be a ToolLayout)
 ```
 
 **The `toolbar` slot is for chrome.** Not a form, not a `TextArea`, not an editor. If the thing you
 want to put there accepts typed input longer than a filename, it belongs in the body.
+
+**No tool renders its own title.** The tab strip already names it. `ToolLayout` has no title slot
+for this reason — one existed and reached zero consumers. The only heading a tool shows is
+`MasterDetailLayout`'s, which names the collection inside the tool.
 
 **Tools must be `flex h-full flex-col` at the root** — `ToolLayout` handles this; hand-rolled roots
 without `h-full` silently collapse.
@@ -201,15 +211,15 @@ Import from `@/components/shared/<Name>`.
 
 ### Layout
 
-| Component            | Use                                                                     |
-| -------------------- | ----------------------------------------------------------------------- |
-| `ToolLayout`         | Every tool's outer shell. `fullBleed` for editors, `maxWidth` for forms |
-| `Toolbar`            | The chrome row. `ToolbarGroup` for families, `ToolbarSpacer` to push    |
-| `DocumentToolbar`    | Wrapping variant for document tools; pairs with `DocumentIdentity`      |
-| `PaneHeader`         | Header strip for one pane of a split — title, optional status/actions   |
-| `Panel`              | Bordered section container with optional title + actions                |
-| `SplitPane`          | Resizable two-pane split; persists ratio via `storageKey`               |
-| `MasterDetailLayout` | Sidebar + detail shell for library-style tools                          |
+| Component            | Use                                                                                    |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `ToolLayout`         | Every tool's outer shell. `fullBleed` for editors, `maxWidth` for forms. No title slot |
+| `Toolbar`            | The chrome row. `ToolbarGroup` for families, `ToolbarSpacer` to push                   |
+| `DocumentToolbar`    | Wrapping variant for document tools; pairs with `DocumentIdentity`                     |
+| `PaneHeader`         | Header strip for one pane of a split — title, optional status/actions                  |
+| `Panel`              | Bordered section container with optional title + actions                               |
+| `SplitPane`          | Resizable two-pane split; persists ratio via `storageKey`                              |
+| `MasterDetailLayout` | Sidebar + detail shell for library-style tools                                         |
 
 ### Controls
 
@@ -259,9 +269,25 @@ Pick `as` for the _document structure_ you need; the visual is identical either 
 
 ### `Button` variants
 
-- `primary` — the main action. **At most one per tool.** Tools that compute live as you type
-  (`case-converter`, `regex-tester`, `hash-generator`, …) correctly have _none_; do not add one
-  just to fill the slot.
+- `primary` — the main action. The rule, in full:
+
+  > **A tool that computes live as you type has no primary action. A tool you trigger has exactly
+  > one visible at a time.**
+
+  `case-converter`, `regex-tester`, `hash-generator`, `timestamp-converter`, `color-converter`,
+  `jwt-decoder` and `refactoring-toolkit` correctly have none — there is no button to press, and
+  adding one to fill the slot invents a step the tool doesn't have.
+
+  Three things are outside the count, because they can't compete with the tool's own action:
+  - **A modal's confirm button.** It's the primary of its dialog, and the dialog is the only thing
+    focusable while it's open.
+  - **An `EmptyState` action.** It shows precisely when the chrome has nothing to act on.
+  - **A conditional swap** — `variant={originalImg ? 'secondary' : 'primary'}` in `image-tool`,
+    where opening a file is the primary until a file is open and Download takes over.
+
+  Two placements are settled: a `MasterDetailLayout` sidebar heading **never** carries the accent
+  (its create action is `secondary`), and neither does a `PaneHeader` action, however transient.
+
 - `secondary` — ordinary actions (Clear, Reset, Swap)
 - `ghost` — tertiary actions and navigation
 - `danger` — destructive only
@@ -360,3 +386,27 @@ Escape hatch: `/* design-system-ignore: <reason> */` on the preceding line. The 
 
 If you need to change a rule, change this document in the same commit. A gate that disagrees with
 its documentation teaches contributors to ignore both.
+
+---
+
+## Adding a new tool
+
+The gates catch tokens and class strings. They cannot catch structure, which is where every
+inconsistency in the 2026-08 audit actually came from. Walk this before opening the PR:
+
+- [ ] Root is `ToolLayout` (or `MasterDetailLayout` for a library tool). Nothing above it.
+- [ ] No `<h1>`/`<h2>` naming the tool — the tab strip does that.
+- [ ] The `toolbar` slot holds chrome only. A `TextArea` in there is the single most common mistake.
+- [ ] Chrome rows are `Toolbar`/`DocumentToolbar` with `aria-label`, grouped by `ToolbarGroup`,
+      spaced by `ToolbarSpacer` — never `ml-auto`.
+- [ ] Side-by-side panes use `SplitPane` with a unique `storageKey`, and `stackBelow` if the layout
+      needs to stack on a narrow window. Each pane is headed by `PaneHeader`.
+- [ ] Body sections are `Panel`. Anything nested inside one uses `bg-bg`, not `bg-surface`.
+- [ ] Every labelled control is a `Field` — no bare `<label>`. Pass `htmlFor` when the field holds
+      more than one labelable element.
+- [ ] Region labels are `SectionLabel`. Keyboard hints are `Kbd`, including inside `title=` prose.
+- [ ] Exactly one `variant="primary"` visible at a time, or none if the tool computes live.
+- [ ] Icons are `size={12}`, `{14}` or `{16}`; icon-only buttons carry `aria-label`.
+- [ ] Live results that settle are announced (`role="status"` + `aria-live="polite"`); values that
+      change on every keystroke are not.
+- [ ] All four gates green, run from `apps/cockpit`.

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -1,404 +1,362 @@
 # DESIGN SYSTEM — devdrivr cockpit
 
-> Visual language reference. Before touching any UI — colours, spacing, typography, components — read this first.
+> Visual language reference. Before touching any UI — colours, spacing, typography, components —
+> read this first.
+
+Verified against source on 2026-08-19. Where this document and the code disagree, the code is
+authoritative and this document is a bug — fix it in the same commit.
 
 ---
 
-## Core Principle
+## Core principle
 
-**All visual values come from CSS custom properties.** Never hardcode hex values, `rgb()`, or Tailwind palette utilities like `bg-zinc-900`. Using tokens means themes switch correctly at runtime; hardcoding means the app looks broken in light mode or after a theme update.
+**All visual values come from CSS custom properties.** Never hardcode a hex value, an `rgb()`, or a
+Tailwind palette utility like `bg-zinc-900`.
+
+This is not a style preference. The app ships **22 themes**. A hardcoded colour is correct under
+exactly one of them and silently wrong under the other 21 — and it will look fine to whoever wrote
+it, because they only ran the theme they were using.
+
+`bun run lint:ds` fails the build on hardcoded colours, off-scale type, off-scale icons, and
+non-standard focus rings. See § Enforcement.
 
 ---
 
-## Colour Tokens
+## Where things live
 
-Defined in `src/index.css` under `:root` (dark, default) and `.light` (overrides).
+| File                              | Contains                                                             |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `src/styles/tokens.css`           | All tokens: 22 theme palettes, z-index, spacing, radius, type, focus |
+| `src/index.css`                   | Font imports, `@theme` font families, keyframes, reduced-motion      |
+| `src/styles/highlight-themes.css` | Syntax-highlighting palettes                                         |
 
-### Background & Surface
+`index.css:21` imports `tokens.css`. Do not add tokens to `index.css`.
 
-| Token                    | Dark      | Light     | When to use                            |
-| ------------------------ | --------- | --------- | -------------------------------------- |
-| `--color-bg`             | `#0a0a0a` | `#faf8f0` | Main window / page background          |
-| `--color-surface`        | `#181818` | `#f5f3eb` | Sidebar, panels, cards, tool workspace |
-| `--color-surface-raised` | `#1e1e1e` | `#ffffff` | Modals, dropdowns, command palette     |
-| `--color-surface-hover`  | `#282828` | `#ece9e0` | Hover fill on buttons, list items      |
+---
 
-**Rule of thumb:** Nest surfaces by elevation — bg → surface → surface-raised.
+## Colour tokens
 
-### Text
+Values are **per-theme** and there are 22 themes, so this table documents each token's _role_
+rather than a value that would be wrong for 21 of them. Read the actual values from
+`src/styles/tokens.css`.
 
-| Token                | Dark      | Light     | When to use                           |
-| -------------------- | --------- | --------- | ------------------------------------- |
-| `--color-text`       | `#e0e0e0` | `#1a1a1a` | Primary body text, labels, headings   |
-| `--color-text-muted` | `#888888` | `#666666` | Placeholders, secondary labels, hints |
+### Surfaces
 
-Never use a hex value for text. Always pick one of these two.
+| Token                    | Role                                                 |
+| ------------------------ | ---------------------------------------------------- |
+| `--color-bg`             | Main window / workspace background                   |
+| `--color-surface`        | Sidebar, toolbars, panels, cards                     |
+| `--color-surface-raised` | Modals, dropdowns, command palette — above `surface` |
+| `--color-surface-sunken` | Wells and inset areas — below `surface`              |
+| `--color-surface-hover`  | Hover fill on buttons and list rows                  |
 
-### Borders
+**Rule of thumb:** nest by elevation — `sunken → bg → surface → raised`.
 
-| Token            | Dark      | Light     | When to use                           |
-| ---------------- | --------- | --------- | ------------------------------------- |
-| `--color-border` | `#333333` | `#d4d0c8` | All borders: panels, inputs, dividers |
+### Text and borders
 
-One border token. All edges in the UI use it.
+| Token                | Role                                  |
+| -------------------- | ------------------------------------- |
+| `--color-text`       | Primary body text, labels, headings   |
+| `--color-text-muted` | Placeholders, secondary labels, hints |
+| `--color-border`     | Every border in the app — one token   |
 
-### Accent (Brand)
+Never use a hex for text. There are exactly two text colours.
 
-| Token                | Dark                   | Light            | When to use                                                |
-| -------------------- | ---------------------- | ---------------- | ---------------------------------------------------------- |
-| `--color-accent`     | `#39ff14` (neon green) | `#00875a` (teal) | Active states, focused inputs, highlights, primary buttons |
-| `--color-accent-dim` | `#1a7a0a`              | `#b3e0d0`        | Hover fill backgrounds behind accent-coloured text         |
+### Accent and semantics
 
-Use `accent` sparingly — it's the single point of visual focus. Use `accent-dim` for hover/selected fill so the accent text remains readable.
+| Token                | Role                                                                |
+| -------------------- | ------------------------------------------------------------------- |
+| `--color-accent`     | Active state, focus, primary button fill, highlights                |
+| `--color-accent-dim` | Selected/hover fill _behind_ accent text, so the text stays legible |
+| `--color-error`      | Errors, destructive actions, validation failures                    |
+| `--color-warning`    | Warnings, deprecations                                              |
+| `--color-success`    | Success states, copy confirmation                                   |
+| `--color-info`       | Informational callouts, neutral status                              |
+| `--color-shadow`     | Every `box-shadow` colour                                           |
+| `--color-scrim`      | Modal backdrop dim                                                  |
 
-### Semantic Colours
+Accent is the single point of visual focus — use it sparingly. Prefer the semantic variants on
+`Alert` / `StatusBadge` over colouring text at the call site.
 
-| Token             | Dark      | Light     | When to use                                              |
-| ----------------- | --------- | --------- | -------------------------------------------------------- |
-| `--color-error`   | `#ef4444` | `#dc2626` | Error messages, destructive actions, validation failures |
-| `--color-warning` | `#f59e0b` | `#d97706` | Warnings, deprecation notices                            |
-| `--color-success` | `#22c55e` | `#16a34a` | Success states, copy confirmations                       |
-| `--color-info`    | `#3b82f6` | `#2563eb` | Informational callouts, neutral status                   |
+### Stacking
 
-### Shadows
+One documented z-index scale; same across all themes. Use `z-[var(--z-modal)]`.
 
-| Token            | Dark              | Light             | When to use         |
-| ---------------- | ----------------- | ----------------- | ------------------- |
-| `--color-shadow` | `rgba(0,0,0,0.4)` | `rgba(0,0,0,0.1)` | `box-shadow` values |
-
-Always use this token for shadows rather than hardcoding an alpha value.
-
-### Usage Examples
-
-```typescript
-// Panel background
-className="bg-[var(--color-surface)]"
-
-// Card with border
-className="bg-[var(--color-surface)] border border-[var(--color-border)]"
-
-// Active tab
-className="border-b-2 border-[var(--color-accent)] text-[var(--color-accent)]"
-
-// Destructive button text
-className="text-[var(--color-error)]"
-
-// Hover fill
-className="hover:bg-[var(--color-surface-hover)]"
-
-// Muted placeholder
-className="text-[var(--color-text-muted)] placeholder:text-[var(--color-text-muted)]"
-
-// Shadow
-style={{ boxShadow: `0 4px 16px var(--color-shadow)` }}
-```
+| Token         | Value | Layer                             |
+| ------------- | ----- | --------------------------------- |
+| `--z-scrim`   | 40    | Backdrop behind a modal/palette   |
+| `--z-modal`   | 50    | Dialogs, command palette          |
+| `--z-popover` | 60    | Context menus, dropdowns, flyouts |
+| `--z-tooltip` | 70    | Hover tooltips                    |
+| `--z-toast`   | 80    | Toasts — always topmost           |
 
 ---
 
 ## Typography
 
-### Fonts
+### Families
 
-| Token          | Value                                      | When to use                                         |
-| -------------- | ------------------------------------------ | --------------------------------------------------- |
-| `--font-mono`  | `'JetBrains Mono', 'Fira Code', monospace` | All code, input fields, output areas, Monaco editor |
-| `--font-pixel` | `'Silkscreen', monospace`                  | App logo / branding only                            |
+| Token          | Value                                            | Use                                            |
+| -------------- | ------------------------------------------------ | ---------------------------------------------- |
+| `--font-ui`    | `system-ui, -apple-system, …`                    | UI chrome: buttons, labels, toolbars, headings |
+| `--font-mono`  | `'Source Code Pro', monospace` (theme-dependent) | Code, editors, values, IDs, output             |
+| `--font-pixel` | `'Silkscreen', monospace`                        | App logo / branding only                       |
 
-The system sans-serif (default browser font) is used for all UI chrome — labels, buttons, headings.
+Use `font-ui`, `font-mono`, `font-pixel` (Tailwind `@theme` families — not
+`font-[family-name:var(--font-mono)]`).
 
-```typescript
-// Code/monospace content
-className = 'font-[family-name:var(--font-mono)] text-sm'
+**The split is semantic, not decorative:** chrome is `font-ui`, content the user typed or the tool
+produced is `font-mono`. A _label naming_ a monospace region is chrome and takes `font-ui`.
 
-// Logo
-className = 'font-[family-name:var(--font-pixel)]'
-```
+### Size scale
 
-### Text Size Scale
+Five sizes. Nothing else. `text-[13px]` and friends are a lint error.
 
-Use Tailwind's text scale. Common sizes in use:
+| Class       | rem   | px  | Use                                                       |
+| ----------- | ----- | --- | --------------------------------------------------------- |
+| `text-2xs`  | 0.625 | 10  | Section labels, status lines, metadata, keyboard hints    |
+| `text-xs`   | 0.75  | 12  | The workhorse: buttons, inputs, toolbars, list rows, body |
+| `text-sm`   | 0.875 | 14  | Tool/panel titles, modal titles                           |
+| `text-base` | 1     | 16  | Rare — large empty-state headings                         |
+| `text-lg`   | 1.125 | 18  | Rare — onboarding                                         |
 
-| Class                 | Use case                                             |
-| --------------------- | ---------------------------------------------------- |
-| `text-xs`             | Button labels, status bar, tab labels, sidebar items |
-| `text-sm`             | Body text, tool labels, form inputs                  |
-| `text-base`           | Section headings                                     |
-| `text-lg` / `text-xl` | Modal titles (rare)                                  |
+The app is dense by design; `text-xs` is the default body size, not a small variant.
 
-The Monaco editor font size follows `settings.editorFontSize` (default: 14px, range 10–20).
+Monaco's font size follows `settings.editorFontSize` (default 14, range 10–20) and is independent
+of this scale.
 
 ---
 
-## Spacing & Layout
+## Spacing, radius, elevation
 
-The app uses Tailwind's default spacing scale. No custom spacing tokens — use the scale directly.
+Tailwind's default spacing scale, on a 4px rhythm. `--space-1..8` exist in `tokens.css` for use in
+inline `style`, but in `className` prefer the Tailwind utilities.
 
-### Common Layout Patterns
+| Token           | Value    | Use                             |
+| --------------- | -------- | ------------------------------- |
+| `--radius-sm`   | 0.125rem | Buttons, inputs, small controls |
+| `--radius-md`   | 0.25rem  | Panels, cards                   |
+| `--radius-lg`   | 0.5rem   | Modals, large surfaces          |
+| `--elevation-1` | —        | Resting raised surface          |
+| `--elevation-2` | —        | Dropdowns, popovers             |
+| `--elevation-3` | —        | Modals                          |
 
-**Full-height tool workspace:**
+### Chrome padding scale
 
-```typescript
-<div className="flex h-full flex-col gap-2 p-3">
-  {/* header row */}
-  <div className="flex items-center gap-2">...</div>
-  {/* expanding content area */}
-  <div className="flex min-h-0 flex-1 flex-col">...</div>
-</div>
-```
+Chrome rows use two paddings and no others. This is what `Toolbar` and `PaneHeader` encode; if you
+are writing either by hand, you are writing a bug.
 
-**Side-by-side panels:**
-
-```typescript
-<div className="flex h-full min-h-0 gap-2">
-  <div className="flex flex-1 flex-col">Left</div>
-  <div className="flex flex-1 flex-col">Right</div>
-</div>
-```
-
-**Toolbar row:**
-
-```typescript
-<div className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
-  ...
-</div>
-```
-
-**Key layout rule:** Tools must be `flex h-full flex-col` at the root. Without `h-full`, the tool won't fill the workspace.
+| Padding       | Use                                       |
+| ------------- | ----------------------------------------- |
+| `px-4 py-2`   | Tool toolbar row (`Toolbar`, `min-h-10`)  |
+| `px-3 py-1.5` | Pane header inside a split (`PaneHeader`) |
 
 ---
 
 ## Icons
 
-All icons use **Phosphor Icons** (`@phosphor-icons/react`). No inline SVGs, no emoji, no other icon libraries.
+**Phosphor Icons** (`@phosphor-icons/react`) only. No inline SVG, no emoji, no second icon library.
 
-```typescript
-import { ArrowRight, Clipboard, Lightning, Code, Gear } from '@phosphor-icons/react'
+Three sizes. 10/11/13/15 are lint errors — they existed, they meant nothing, they are gone.
 
-// Standard sizes
-<Gear size={16} />           // toolbar / button icons
-<Code size={20} />           // sidebar group icons
-<Lightning size={14} />      // status bar
+| `size` | Use                                                        |
+| ------ | ---------------------------------------------------------- |
+| `12`   | Dense/inline: inside `text-2xs` rows, status lines, chips  |
+| `14`   | Toolbar and button icons — the default                     |
+| `16`   | Navigation and identity: sidebar groups, document identity |
 
-// Weights
-weight="regular"   // default
-weight="bold"      // emphasis, active states
-weight="fill"      // filled/active icon variant
-weight="duotone"   // decorative, two-tone
-weight="light"     // subtle, secondary icons
-weight="thin"      // very subtle
-```
+Decorative icons need `aria-hidden="true"`. Icons that _are_ the control need the `aria-label` on
+the button, not the icon.
 
-**Choosing weight by context:**
-
-- Sidebar group headers: `weight="bold"` at `size={16}`
-- Toolbar actions: `weight="regular"` at `size={14}` or `size={16}`
-- Status indicators: `weight="fill"` (solid, immediately readable at small sizes)
-- Empty state illustrations: `weight="duotone"` at larger sizes
+Weights: `regular` default; `bold` for emphasis and active states; `fill` for status indicators
+(solid reads better at 12px); `duotone` for empty-state illustrations.
 
 ---
 
-## Shared Components
+## Layout contract
 
-### `Button`
+Every tool renders through `ToolLayout`. No exceptions.
 
-```typescript
-import { Button } from '@/components/shared/Button'
-
-// Variants
-<Button variant="primary">Run</Button>        // accent background — main CTA
-<Button variant="secondary">Cancel</Button>   // border style — default
-<Button variant="ghost">Settings</Button>     // text only — minimal chrome
-<Button variant="danger">Delete</Button>      // destructive action
-<Button variant="icon" aria-label="Save">…</Button> // icon-only action
-
-// Sizes
-<Button size="md">Default</Button>            // px-4 py-2
-<Button size="sm">Compact</Button>            // px-2 py-1
-<Button size="xs">Dense toolbar</Button>       // px-1.5 py-0.5
-
-// All standard HTMLButtonElement props pass through
-<Button variant="primary" loading={loading} onClick={handleRun}>
-  Run
-</Button>
+```
+ToolLayout
+  toolbar: Toolbar | DocumentToolbar     ← chrome only
+    ToolbarGroup (+ separated)           ← action families
+    ToolbarSpacer
+  body:
+    fullBleed  → SplitPane / editors, each pane headed by PaneHeader
+    otherwise  → maxWidth-capped stack of Panel sections
 ```
 
-**When to use which variant:**
+**The `toolbar` slot is for chrome.** Not a form, not a `TextArea`, not an editor. If the thing you
+want to put there accepts typed input longer than a filename, it belongs in the body.
 
-- `primary` — one per tool, the main action (Format, Run, Generate, etc.)
-- `secondary` — secondary actions (Clear, Reset, Copy as…)
+**Tools must be `flex h-full flex-col` at the root** — `ToolLayout` handles this; hand-rolled roots
+without `h-full` silently collapse.
+
+---
+
+## Shared components
+
+Import from `@/components/shared/<Name>`.
+
+### Layout
+
+| Component            | Use                                                                     |
+| -------------------- | ----------------------------------------------------------------------- |
+| `ToolLayout`         | Every tool's outer shell. `fullBleed` for editors, `maxWidth` for forms |
+| `Toolbar`            | The chrome row. `ToolbarGroup` for families, `ToolbarSpacer` to push    |
+| `DocumentToolbar`    | Wrapping variant for document tools; pairs with `DocumentIdentity`      |
+| `PaneHeader`         | Header strip for one pane of a split — title, optional status/actions   |
+| `Panel`              | Bordered section container with optional title + actions                |
+| `SplitPane`          | Resizable two-pane split; persists ratio via `storageKey`               |
+| `MasterDetailLayout` | Sidebar + detail shell for library-style tools                          |
+
+### Controls
+
+| Component                       | Notes                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| `Button`                        | Variants `primary`/`secondary`/`ghost`/`danger`/`icon`; sizes `xs`/`sm`/`md` |
+| `CopyButton`                    | Copy + 1.5s confirmation + success toast                                     |
+| `Input` / `TextArea` / `Select` | Boxed form controls                                                          |
+| `InlineInput`                   | Chrome-less input for editable titles                                        |
+| `SearchInput`                   | Search field with clear affordance                                           |
+| `Field`                         | Label + control + hint/error. **Use this instead of a raw `<label>`**        |
+| `Toggle`                        | Boolean switch with label                                                    |
+| `SegmentedControl`              | Pick one view mode                                                           |
+| `TabBar`                        | ARIA tabs for multi-mode tools; arrow/Home/End nav                           |
+| `Kbd`                           | Keyboard hint. `<Kbd keys="mod+enter" />` — resolves `mod` per platform      |
+
+`SegmentedControl` switches a _view_ of the same thing; `TabBar` switches _what you're working on_.
+
+### Feedback
+
+| Component      | Use                                                              |
+| -------------- | ---------------------------------------------------------------- |
+| `Alert`        | A message needing attention, or an operation outcome             |
+| `StatusBadge`  | A compact state or metadata value (HTTP status, validity)        |
+| `EmptyState`   | Replaces an ambiguous blank pane; may carry one next-step action |
+| `Spinner`      | Indeterminate progress                                           |
+| `SectionLabel` | The small uppercase label naming a region                        |
+| `Dialog`       | Modal; owns focus trap, escape, and backdrop                     |
+
+Use semantic variants (`info`/`success`/`warning`/`error`) rather than styling status text at the
+call site. Do not add check marks, warning glyphs, emoji, or custom SVG — the component or a
+Phosphor icon supplies the cue.
+
+### `SectionLabel`
+
+The one label idiom. Before it existed there were seven, differing on font, weight, and tracking
+with no rule distinguishing them.
+
+```tsx
+<SectionLabel>Output</SectionLabel>                        // <span>, chrome
+<SectionLabel as="h2">Validate &amp; parse</SectionLabel>  // real heading
+<SectionLabel hint={`${count} matches`}>Results</SectionLabel>
+```
+
+Renders `font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]`.
+Pick `as` for the _document structure_ you need; the visual is identical either way.
+
+### `Button` variants
+
+- `primary` — the main action. **At most one per tool.** Tools that compute live as you type
+  (`case-converter`, `regex-tester`, `hash-generator`, …) correctly have _none_; do not add one
+  just to fill the slot.
+- `secondary` — ordinary actions (Clear, Reset, Swap)
 - `ghost` — tertiary actions and navigation
-- `danger` — destructive actions only
-- `icon` — icon-only controls; always provide `aria-label` (it also becomes the tooltip)
+- `danger` — destructive only
+- `icon` — icon-only; **always** pass `aria-label` (it also becomes the tooltip)
 
-Use `loading` for asynchronous actions. It preserves the button width, announces busy state, and
-disables repeat clicks. Use one `primary` action per action group, not one per screen.
+Use `loading` for async actions: it preserves width, announces busy, and blocks repeat clicks.
 
-### `CopyButton`
+### Toasts
 
-```typescript
-import { CopyButton } from '@/components/shared/CopyButton'
+Triggered through the UI store, never rendered directly:
 
-<CopyButton text={output} />
-<CopyButton text={output} label="Copy JSON" />
-<CopyButton text={output} className="ml-auto" />
-```
-
-Shows a check icon and "Copied" for 1.5s after click. Triggers a success toast automatically.
-
-### `TabBar`
-
-```typescript
-import { TabBar } from '@/components/shared/TabBar'
-
-const TABS = [
-  { id: 'format', label: 'Format' },
-  { id: 'minify', label: 'Minify' },
-]
-
-<TabBar
-  tabs={TABS}
-  activeTab={state.tab}
-  onTabChange={(id) => updateState({ tab: id })}
-/>
-```
-
-Active tab has a 2px bottom border in `--color-accent`. Use `TabBar` for multi-mode tools.
-It exposes the ARIA tab pattern, supports arrow/Home/End navigation, and scrolls horizontally when
-the available width is narrow. Use `SegmentedControl` for a view mode rather than document sections.
-
-### `Toolbar` and `ToolbarGroup`
-
-```typescript
-import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
-
-<Toolbar aria-label="Editor actions">
-  <ToolbarGroup label="Document actions">…</ToolbarGroup>
-  <ToolbarGroup label="Formatting" separated>…</ToolbarGroup>
-  <ToolbarSpacer />
-  <ToolbarGroup label="Export actions">…</ToolbarGroup>
-</Toolbar>
-```
-
-Place document-wide actions in the tool toolbar. Use groups and separators for different action
-families; keep actions for a specific pane in that pane's header.
-
-### `Input`, `Select`, and `TextArea`
-
-Use these primitives for native form controls instead of duplicating border, radius, focus, and
-disabled styles. Set `monospace` on `TextArea` for source/code. Full-bleed editor textareas may
-override radius and border while retaining the shared typography and focus contract.
-
-### `Alert`, `StatusBadge`, and `EmptyState`
-
-- `Alert` is for a message that needs attention or explains an operation outcome.
-- `StatusBadge` is for a compact state or metadata value, such as HTTP status or validity.
-- `EmptyState` replaces ambiguous blank panes and may include a single next-step action.
-
-Use semantic variants (`info`, `success`, `warning`, `error`) rather than styling status text at the
-call site. Do not add check marks, warning glyphs, emoji, or custom SVG; the shared component or a
-Phosphor icon supplies the visual cue.
-
-### `Toggle`
-
-```typescript
-import { Toggle } from '@/components/shared/Toggle'
-
-<Toggle
-  checked={state.wrap}
-  onChange={(v) => updateState({ wrap: v })}
-  label="Word wrap"
-/>
-```
-
-### `Toast` / Status feedback
-
-Toasts are triggered via the UI store, not rendered directly:
-
-```typescript
+```tsx
 const setLastAction = useUiStore((s) => s.setLastAction)
-
-// Success (green)
 setLastAction('Formatted successfully', 'success')
-
-// Error (red)
 setLastAction('Invalid JSON', 'error')
-
-// Info (accent)
 setLastAction('Copied to clipboard', 'info')
 ```
 
-Toasts auto-dismiss after 3 seconds and can be dismissed by click. They appear bottom-right at `fixed bottom-12 right-4`.
-
-### `SendToMenu`
-
-Allows sending text content from one tool to another:
-
-```typescript
-import { SendToMenu } from '@/components/shared/SendToMenu'
-
-<SendToMenu content={state.output} />
-```
-
-The menu lists all other tools that accept `open-file` / `send-to` actions.
+Auto-dismiss after 3s, dismissable by click, bottom-right.
 
 ---
 
-## Animations
+## Focus
 
-One animation is defined globally:
+Two treatments, both tokens. Anything else is drift and fails `lint:ds`.
 
-```css
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
+```tsx
+// Standard — control with room around it
+className = 'focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]'
+
+// Inset — control flush in a dense container (sidebar row, tab strip, list item)
+className = 'focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)]'
 ```
 
-Used for modals, toasts, and panels appearing. Apply with:
+`--focus-ring` draws 4px _outside_ the element, with a background-coloured inner layer so it stays
+visible on any surface. In a dense container that ring gets clipped or lands on the neighbouring
+row, which is what `--focus-ring-inset` is for. Reach for inset only when the standard ring is
+actually clipped.
 
-```typescript
-className = 'animate-[fade-in_150ms_ease-out]'
-```
-
-Keep all animations under 200ms. The app is a utility — it should feel instant.
+Every interactive element needs a visible focus state. Icon-only buttons need `aria-label`. Use
+semantic HTML (`<button>`, `<input>`, `<label>`) over a `<div>` with `onClick`. The app is
+keyboard-first — every core action must be reachable without a mouse (`useGlobalShortcuts`).
 
 ---
 
-## Monaco Editor
+## Animation
 
-Tools using Monaco import shared theme sync and options:
+One shared animation:
 
-```typescript
+```tsx
+className = 'animate-fade-in' // 150ms ease-out, 8px rise
+```
+
+Defined at `index.css:89`. Keep everything under 200ms — this is a utility app, it should feel
+instant. `index.css` disables animation under `prefers-reduced-motion` globally, so don't add
+per-component guards.
+
+---
+
+## Monaco editor
+
+```tsx
 import { useMonacoTheme, EDITOR_OPTIONS } from '@/hooks/useMonaco'
 
-export default function MyTool() {
-  useMonacoTheme()   // keeps Monaco in sync with app theme — must be called
+useMonacoTheme() // keeps Monaco in sync with the app theme — must be called
 
-  return (
-    <Editor
-      options={EDITOR_OPTIONS}   // shared base options (minimap off, line numbers, etc.)
-      theme="cockpit-dark"       // set by useMonacoTheme
-      language="javascript"
-      value={state.input}
-      onChange={(v) => updateState({ input: v ?? '' })}
-    />
-  )
-}
+<Editor options={EDITOR_OPTIONS} theme={monacoTheme} language="json" … />
 ```
 
-Always use `EDITOR_OPTIONS` as the base. Override individual options if needed, but don't replace the whole object.
+Always base off `EDITOR_OPTIONS`; override individual keys rather than replacing the object.
+**Always pass `theme` explicitly** — `DiffEditor` defaults to light, and `setTheme` is global.
 
 ---
 
-## Accessibility Notes
+## Enforcement
 
-- All interactive elements must have visible focus states (Tailwind's `focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]`)
-- Icon-only buttons need an `aria-label`
-- Use semantic HTML (`<button>`, `<input>`, `<label>`) over generic `<div>` with `onClick`
-- The app is keyboard-first — every core action must be reachable without a mouse (see `useGlobalShortcuts`)
+`bun run lint` runs ESLint and then `bun run lint:ds`
+(`scripts/lint-design-system.mjs`).
+
+ESLint (`eslint.config.js`) blocks raw `<button>`, `<select>`, and text `<input>` in `src/tools`,
+and raw text `<input>` in `src/components/shell`. Per-line
+`// eslint-disable-next-line no-restricted-syntax` with a stated reason is the escape hatch.
+
+`lint:ds` walks raw source — including template literals, where most of the historical drift hid —
+and blocks:
+
+| Rule                | Blocks                                 |
+| ------------------- | -------------------------------------- |
+| `off-scale-text`    | `text-[Npx]`                           |
+| `off-scale-icon`    | `size={10\|11\|13\|15}`                |
+| `legacy-focus-ring` | `focus-visible:ring-*`                 |
+| `hardcoded-colour`  | hex / `rgb()` inside a class attribute |
+| `tailwind-palette`  | `bg-zinc-900` and friends              |
+
+Escape hatch: `/* design-system-ignore: <reason> */` on the preceding line. The reason is required.
+
+If you need to change a rule, change this document in the same commit. A gate that disagrees with
+its documentation teaches contributors to ignore both.

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -364,8 +364,14 @@ deliberately.
 
 ### P5 — Behaviour and polish
 
-- [ ] **F7:** adopt `SplitPane` in the 15 fixed-50/50 tools, persisting ratio per tool via
-      `storageKey`. Prioritise `diff-viewer`, `json-tools`, `markdown-editor`, `regex-tester`.
+- [x] **F7** (`cef7a62`, `9add8b6`) — eight tools onto `SplitPane`, each with its own `storageKey`:
+      `base64`, `regex-tester`, `url-codec`, `css-to-tailwind`, `json-tools`, `markdown-editor`,
+      `mermaid-editor`, `html-validator`. `SplitPane` gained `stackBelow` first, because four of
+      those already stacked by hand at 900/1000px and an inline ratio `width` beats any Tailwind
+      breakpoint — without it, adoption would have silently deleted their responsive behaviour.
+      The tools with a toggleable pane lift each pane into a local const so the split and
+      single-pane branches share one definition. `diff-viewer` is **not** in the list: it renders
+      Monaco's `DiffEditor`, which owns its own internal split and has none to convert.
 - [ ] **F11:** write down the primary-action rule ("live-computing tools have no primary action;
       action-triggered tools have exactly one"), then fix the 5 tools with 2+.
 - [ ] **F12 follow-up:** re-verify `DESIGN_SYSTEM.md` against the post-P4 code and add a short

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -308,69 +308,38 @@ All six landed with tests, `DESIGN_SYSTEM.md` entries, and zero call sites chang
 **Acceptance:** ✅ 114 test files / 1338 tests passing (was 109/1314); `SplitPane` keyboard resize,
 clamping, and persistence all covered.
 
-### P1 — Decide the scale, fix the docs
+### P3 — Convergence sweep: labels, panes, keys ✅
 
-No code changes to tools. This phase exists so P2–P5 have something to converge _on_.
+Landed as five commits, split by finding rather than by tool so each diff stays reviewable.
 
-- [ ] Decide and record the **label scale**: one `SectionLabel` with at most two variants. Proposal:
-      `font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]`
-      (idiom A — already the plurality at 6 uses and the only one that is `font-ui`, matching the
-      chrome/mono split the design system already draws).
-- [ ] Decide the **icon scale**: proposal — `12` dense/inline, `14` toolbar, `16` navigation. Retire
-      10/11/13/15.
-- [ ] Decide the **chrome padding scale**: `px-4 py-2` for tool toolbars (the existing `Toolbar`
-      contract), `px-3 py-1.5` for pane headers. Retire `px-3 py-1`, `px-3 py-2`, `px-4 py-3` from
-      chrome rows.
-- [ ] Rewrite `DESIGN_SYSTEM.md` against reality — every item in F12. Regenerate the colour tables
-      from `src/styles/tokens.css` rather than retyping them, so they cannot drift again.
-- [ ] Add an ESLint rule or a `bun run lint:ui` grep gate rejecting: hardcoded `text-[Npx]`,
-      `focus-visible:ring-*` in `src/`, and raw hex/`rgb()` in `className`.
+- [x] **F1** (`c66a39f`) — 32 label sites across 16 files onto `SectionLabel`. `SectionLabel` gained
+      `legend`/`h5` in its `as` union and HTML-attribute passthrough, so a conversion can't silently
+      drop an `id` that an `aria-labelledby` points at. The `<label><span>` pairs were deliberately
+      left for F9 — they label controls, they don't name regions.
+- [x] **F2** (`8f54e1e`) — 11 pane headers across 10 tools. `yaml-tools` and `xml-tools` had each
+      grown a _local_ `PaneHeader` component with the same class string; both deleted. The
+      `hint`/`status` split earned its keep immediately: the schema validator's problem count had to
+      move to `hint` because the tool's summary bar already announces it, and two live regions read
+      the same number twice.
+- [x] **F6** (`3525279`) — both shell `<kbd>` copies and nine tool hint sites onto `Kbd`.
+      `ShortcutsModal`'s table rewritten from pre-rendered symbol arrays into combo notation.
+      `Kbd` gained an `inline` variant for the hint that sits _inside_ the control it describes,
+      where the boxed treatment reads as a button nested in a button.
+- [x] **F9** (`a1d1888`) — 16 fields across 7 files onto `Field`, which fixed a real a11y bug rather
+      than just a visual one: most hand-rolled sites were a bare `<label>` sibling with no `htmlFor`
+      and nothing wrapped, so the input was announced unnamed. `Field` now makes the wrapper _be_
+      the label when no `htmlFor` is given.
+- [x] **F13** (`36d4367`) — `[Recent]`/`[Pinned]`/`[ 03-PREVIEW ]` retired; HTTP method colours
+      extracted to `lib/http-method.ts`. The two maps disagreed on POST and PATCH, so the same
+      request read a different colour depending on which tool opened it.
+- [x] **F8** and **F10** were completed during P1's scale sweep.
 
-**Acceptance:** `DESIGN_SYSTEM.md` claims verified line-by-line against source; the new gate fails on
-a deliberately-introduced `text-[9px]` and passes on `main`.
+**Still open, recorded rather than half-done:** the `⌘` literals inside `title=` and `description=`
+prose strings. Those need a `modSymbol` interpolation per site rather than a component, and the
+markdown editor's toolbar table is module-level where a hook can't reach. Tracked as F6b.
 
-### P2 — Land the primitives
-
-Each with a test, a `DESIGN_SYSTEM.md` entry, and **zero call sites changed** in this phase.
-
-- [ ] `SectionLabel` — `{ children, as?: 'span' | 'h2' | 'h3', hint?: ReactNode }`. Renders the P1
-      scale. `as` exists so the visual and the heading level can be chosen independently — several
-      current call sites are `<h2>` where a `<span>` is correct, and vice versa.
-- [ ] `PaneHeader` — `{ title, actions?, status? }`. The F2 string, once, at the P1 padding.
-      `actions` is the slot the five copies currently lack, which is why `CopyButton` placement
-      varies pane to pane.
-- [ ] `Kbd` — `{ keys: string }`, e.g. `<Kbd keys="mod+enter" />`, resolving `mod` via
-      `usePlatform()`. Replaces the two disagreeing shell copies and the bare spans.
-- [ ] `SplitPane` — `{ children: [ReactNode, ReactNode], direction?, defaultRatio?, storageKey? }`.
-      Draggable divider with `role="separator"` + `aria-orientation` + arrow-key resize. Lift the
-      drag logic out of `shell/NotesDrawer.tsx:592` rather than writing it twice.
-- [ ] `MasterDetailLayout` — `{ sidebar, children, sidebarWidth?, collapsible? }`. The shell shared by
-      `snippets`, `prompt-templates`, and `api-client`.
-- [ ] `Panel` — keep as-is; add the `SectionLabel`-based header. Its API already fits the four
-      hand-rolled sites.
-
-**Acceptance:** each primitive has a unit test covering its ARIA contract; `SplitPane` has a
-keyboard-resize test; bundle size delta recorded.
-
-### P3 — Convergence sweep: labels, panes, keys
-
-The mechanical bulk. Split into 3–4 PRs by finding, not by tool, so review stays diffable.
-
-- [ ] **F1:** replace all 7 label idioms with `SectionLabel`. ~25 files. Watch for the `<h2>`/`<span>`
-      distinction — do not silently change heading structure, it is a11y-visible.
-- [ ] **F2:** replace the 5 verbatim pane headers plus the `snippets`/`prompt-templates`/`json-tools`
-      family variants with `PaneHeader`.
-- [ ] **F6:** replace the 55 `⌘` sites with `Kbd`; delete the two shell copies. Keep `title=` tooltips
-      as-is where they are the only affordance.
-- [ ] **F9:** adopt `Field` in the 16 hand-rolled `<label>` files. If `Field`'s API does not fit a
-      site, extend `Field` — do not fork.
-- [ ] **F10:** convert the ~8 `focus-visible:ring-*` sites to `--focus-ring`.
-- [ ] **F8:** normalise icon sizes to the P1 scale.
-- [ ] **F13:** delete the `[ 03-PREVIEW ]` idiom; extract HTTP-method colours into one shared map used
-      by both `curl-to-fetch` and `api-client`.
-
-**Acceptance:** grep for each retired class string returns zero hits in `src/tools`; the P1 lint gate
-passes; visual diff against the P0 screenshots shows only intended changes.
+**Acceptance:** ✅ all four gates green after each commit; retired class strings return zero hits.
+Visual diff against the P0 screenshots was **not** possible — see P0.
 
 ### P4 — Structural convergence
 
@@ -411,13 +380,13 @@ deliberately.
 
 Baseline recorded 2026-08-19 at `19af685`, all from `apps/cockpit` (never the monorepo root).
 
-| Gate       | Command                          | Baseline         | After P2         |
-| ---------- | -------------------------------- | ---------------- | ---------------- |
-| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             |
-| Tests      | `bunx vitest run`                | 109 files / 1314 | 114 files / 1338 |
-| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings |
-| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     |
-| Rust       | `cargo check` (from `src-tauri`) | Pass             | Pass (untouched) |
+| Gate       | Command                          | Baseline         | After P2         | After P3         |
+| ---------- | -------------------------------- | ---------------- | ---------------- | ---------------- |
+| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             | Pass             |
+| Tests      | `bunx vitest run`                | 109 files / 1314 | 114 files / 1338 | 114 files / 1340 |
+| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings | Pass, 0 warnings |
+| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     | 0 violations     |
+| Rust       | `cargo check` (from `src-tauri`) | Pass             | Pass (untouched) | Pass (untouched) |
 
 Re-run and update this table at the end of every phase.
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -345,22 +345,43 @@ Visual diff against the P0 screenshots was **not** possible — see P0.
 
 Higher-risk, one PR per tool group.
 
-- [ ] **F3 (chrome):** move the 16 bypassing tools onto `Toolbar`/`ToolbarGroup`. Start with
-      `api-client` — it is the closest (a hand-rolled row that is one prop from correct) and the most
-      visible.
-- [ ] **F3 (slot abuse):** move `case-converter` and `hash-generator`'s input forms out of the
-      `toolbar` slot into the body. These two will look different afterwards; that is the point.
-- [ ] **F5:** move `snippets`, `prompt-templates`, and `api-client` onto `MasterDetailLayout`
-      wrapped in `ToolLayout`. Decide at this point whether the `ToolLayout.header` slot earns its
-      keep — if `MasterDetailLayout` owns the sidebar title, delete the slot (F5 says it is dead).
-- [ ] **F4:** adopt `Panel` at the 4 hand-rolled sites, and for the section stacks in
-      `uuid-generator` and `color-converter` (currently bare `<section>` + `<h2>`).
-- [ ] **F13 (csv):** define which level owns the toolbar in `csv-tools` and collapse the stacked
-      toolbars accordingly.
+- [x] **F3 (chrome)** (`4559d08`, `6b638b5`) — `api-client`, `diff-viewer`, `curl-to-fetch`,
+      `csv-tools` and `mermaid-editor/MermaidPreview` moved onto `Toolbar`/`ToolbarGroup`. The
+      count of 16 was measured before P1–P3: the `SectionLabel`, `PaneHeader` and `Field` sweeps
+      had already converted or dissolved the rest of the list, so what remained was these five
+      plus the three master–detail tools handled under F5.
+- [x] **F3 (slot abuse)** (`a78dfb7`) — `case-converter` and `hash-generator`'s forms moved out of
+      the `toolbar` slot into the body, wrapped in `Field`. `Field.hint` widened from `string` to
+      `ReactNode` first: both hints are live read-outs (detected case, byte count, match badge),
+      not sentences. `hash-generator`'s compare row uses `htmlFor` rather than a wrapping label,
+      because the badge beside the input is labelable and would otherwise steal the click.
+- [x] **F5** (`6b638b5`) — all three master–detail tools now render `MasterDetailLayout`.
+      `api-client` is **inverted** rather than lifted: `CollectionsSidebar` takes the detail as
+      `children` and renders the layout itself, because the sidebar heading's one action (new
+      collection) drives sidebar-local collapse and rename state that has no business moving up.
+      Its context menu and confirm dialogs moved outside the layout — a collapsed sidebar is
+      `w-0 overflow-hidden`, which clips a `position: fixed` menu rendered inside it.
+      `ToolLayout.header` is **deleted**: it reached zero consumers while two tools hand-rolled the
+      heading it couldn't express, and that heading names a collection, which is
+      `MasterDetailLayout`'s job.
+- [x] **F4** (`a78dfb7`) — `Panel` adopted for the section stacks in `uuid-generator` (×4) and
+      `color-converter` (×2). Chips nested inside them flipped `bg-surface` → `bg-bg`: `Panel` is
+      itself `bg-surface`, so a surface box inside it has no edge left to read, and `bg-bg` reads
+      as inset across all 22 themes.
+- [x] **F13 (csv)** (`a78dfb7`) — `csv-tools` chrome moved to `DocumentToolbar`/`DocumentIdentity`
+      and its body to `SplitPane` (`stackBelow={900}`, preserving the hand-rolled breakpoint).
+      Note the finding overstated the problem: `csv-tools` had **one** chrome row, not stacked
+      toolbars — the sub-tools' toolbars are alternatives, never rendered together.
 
-**Acceptance:** all 30 tools render through `ToolLayout`; `grep -L ToolLayout src/tools/*/[A-Z]*.tsx`
-returns only sub-components; no tool has more than one chrome row unless it uses `Toolbar` twice
-deliberately.
+**Acceptance:** ✅ every tool renders through `ToolLayout` or `MasterDetailLayout`;
+`grep -rL "ToolLayout\|MasterDetailLayout" src/tools/*/[A-Z]*.tsx` returns only the five
+sub-components (`CsvAnalyze`, `CsvConvert`, `CsvTable`, `MarkdownPreview`, `MermaidPreview`); no
+tool has more than one chrome row unless it uses `Toolbar` twice deliberately. All four gates green.
+
+The acceptance criterion was written as "all 30 tools render through `ToolLayout`". That turned out
+to be the wrong shape: the master–detail tools render `MasterDetailLayout`, whose sidebar is a
+sibling of the detail pane, and nesting a `ToolLayout` around the pair would add a wrapper that
+positions nothing.
 
 ### P5 — Behaviour and polish
 
@@ -372,13 +393,30 @@ deliberately.
       The tools with a toggleable pane lift each pane into a local const so the split and
       single-pane branches share one definition. `diff-viewer` is **not** in the list: it renders
       Monaco's `DiffEditor`, which owns its own internal split and has none to convert.
-- [ ] **F11:** write down the primary-action rule ("live-computing tools have no primary action;
-      action-triggered tools have exactly one"), then fix the 5 tools with 2+.
-- [ ] **F12 follow-up:** re-verify `DESIGN_SYSTEM.md` against the post-P4 code and add a short
-      "adding a new tool" checklist pointing at the target contract in §4.
-- [ ] Re-shoot the P0 screenshots and diff. Attach the before/after to the final PR.
+- [x] **F11** (`93be8b9`) — the rule is now in `DESIGN_SYSTEM.md` §3 with its carve-outs, and three
+      tools were fixed: `image-tool` (Open image is primary only until an image exists, then
+      Download takes over), `uuid-generator` (bulk generate is the same operation with a count, not
+      a second headline), `yaml-tools` (Apply to YAML is a conditional row, not a rival to Format).
+      The audit said five. Two of them — a modal's confirm button and an `EmptyState` CTA — turned
+      out not to be tool chrome at all, so demoting them would have made those surfaces worse. The
+      rule as written carves them out rather than pretending the count was five.
+- [x] **F6b** (`93be8b9`) — `lib/shortcut-label.ts` exports `formatShortcut`, which `Kbd` now
+      renders through, and 40 prose literals across 17 files interpolate. Writing the shared
+      formatter exposed that `Kbd` had the same bug the literals did in milder form: it used Mac
+      glyphs on every platform, so Windows read `Ctrl+↵`. The symbol table is now split by
+      convention — glyphs for macOS, words for everywhere else.
+- [x] **F12 follow-up** (`93be8b9`) — `DESIGN_SYSTEM.md` re-verified against post-P4 code:
+      `MasterDetailLayout` documented beside `ToolLayout`, the no-title rule and the
+      primary-action rule written down, and a 13-item "adding a new tool" checklist added.
+- [ ] **Blocked — needs a human.** Re-shoot the P0 screenshots and diff, then attach the
+      before/after to the final PR. Same blocker as P0: the Tauri WebView on macOS can be
+      screenshotted and resized by script, but not clicked or typed into, so an agent can't drive a
+      tool into the state worth photographing. Every other verification route was used instead —
+      the four gates, the design-system linter, and the DOM assertions in the test suite.
 
-**Acceptance:** all four gates green; screenshot diff reviewed; `DESIGN_SYSTEM.md` re-verified.
+**Acceptance:** ✅ all four gates green (115 files / 1344 tests, 0 design-system violations);
+✅ `DESIGN_SYSTEM.md` re-verified against post-P4 code. ⬜ Screenshot diff outstanding and blocked
+on manual capture — it is the one claim in this document no automated check backs.
 
 ---
 
@@ -386,15 +424,19 @@ deliberately.
 
 Baseline recorded 2026-08-19 at `19af685`, all from `apps/cockpit` (never the monorepo root).
 
-| Gate       | Command                          | Baseline         | After P2         | After P3         |
-| ---------- | -------------------------------- | ---------------- | ---------------- | ---------------- |
-| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             | Pass             |
-| Tests      | `bunx vitest run`                | 109 files / 1314 | 114 files / 1338 | 114 files / 1340 |
-| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings | Pass, 0 warnings |
-| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     | 0 violations     |
-| Rust       | `cargo check` (from `src-tauri`) | Pass             | Pass (untouched) | Pass (untouched) |
+| Gate       | Command                          | Baseline         | After P2         | After P3         | After P4         | After P5         |
+| ---------- | -------------------------------- | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |
+| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             | Pass             | Pass             | Pass             |
+| Tests      | `bunx vitest run`                | 109 files / 1314 | 114 files / 1338 | 114 files / 1340 | 114 files / 1340 | 115 files / 1344 |
+| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings | Pass, 0 warnings | Pass, 0 warnings | Pass, 0 warnings |
+| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     | 0 violations     | 0 violations     | 0 violations     |
+| Rust       | `cargo check` (from `src-tauri`) | Pass             | Pass (untouched) | Pass (untouched) | Pass (untouched) | Pass (untouched) |
 
 Re-run and update this table at the end of every phase.
+
+P4 moved three tools onto `MasterDetailLayout` without changing what they assert, so the test count
+held at 1340; the four new tests in P5 are `shortcut-label`'s. The Rust column has read "untouched"
+since the baseline because this whole effort is frontend-only — see §8.
 
 ---
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1,759 +1,487 @@
-# TODO - Cockpit Backlog
+# TODO — Cockpit Tool UI Consistency Programme
 
-Last updated: 2026-08-14
+Last updated: 2026-08-19
+Branch: `chore/tool-ui-consistency-audit`
 
-This is the working backlog for `apps/cockpit`. Keep this document focused on actionable engineering
-work: every item should have evidence, an expected outcome, acceptance criteria, and a verification
-path.
+This file was reset on 2026-08-19. The previous backlog (July reliability work + the 2026-08-13 UI
+modernisation programme) was complete or superseded; see git history for `documentation/TODO.md` if
+you need the closure notes.
 
-The 2026-07-30/31 reliability backlog (P0 and P1 in full, and most of P2) is complete and has been
-removed from this file — see git history for `documentation/TODO.md` if you need the closure notes.
-What survives below is the four quality items that were never started, plus the UI modernisation
-programme filed on 2026-08-13.
-
-**The UI modernisation programme is now complete** (P0–P5). Note for anyone reading the history:
-four items in it — sidebar filter box, group collapse persistence, truncated-name tooltips, and
-ImageTool's `ToolLayout` pass — actually shipped in #81 but were left unchecked; they were verified
-against the running code and corrected on 2026-08-14. Trust the code over the checkbox if you find
-another one. The only open work below is the four-item quality backlog carried over from July.
-
-## Current Snapshot
-
-Frontend gates verified locally from `apps/cockpit` on 2026-08-14; the Rust and release rows were
-last verified 2026-07-31 and are unchanged by this work (no `src-tauri` changes).
-
-| Gate        | Command                                        | Result                          |
-| ----------- | ---------------------------------------------- | ------------------------------- |
-| TypeScript  | `npx tsc --noEmit`                             | Passing                         |
-| Tests       | `bunx vitest run`                              | Passing: 100 files, 939 tests   |
-| ESLint      | `bun run lint`                                 | Passing with zero warnings      |
-| Rust check  | `cargo check` from `src-tauri`                 | Passing                         |
-| Rust clippy | `cargo clippy -- -D warnings` from `src-tauri` | Passing                         |
-| Release     | `bun run tauri build`                          | Passing: builds `.app` + `.dmg` |
-
-Commands no longer need a `PATH="/opt/homebrew/bin:$PATH"` prefix; older entries in this file still
-show one. See the PATH section in `CLAUDE.md` for what changed.
-
-## How To Use This Backlog
-
-- Work P0 before P1, and P1 before P2 unless a lower-priority item is blocking current release work.
-- Convert broad TODOs into small PRs with one clear risk area per PR.
-- Keep completed items in this file until the next release branch is cut, then move notable outcomes
-  into release notes or the relevant documentation.
-- For each PR, update the item with links to tests, manual smoke notes, or follow-up issues.
+**Scope of this document:** an audit of every tool's chrome — title, toolbar, pane headers, buttons,
+labels, empty/error states — and a phased plan to converge them on a small set of reusable,
+maintainable primitives.
 
 ---
 
-## UI Modernisation Programme
+## 1. Method
 
-Filed 2026-08-13 after a hands-on audit of the running app. Reference screenshots are in
-`/screenshots/ui-audit-*.png` at the repo root.
+Static audit of `src/tools/**` (36 non-test `.tsx` files across 30 tools) plus
+`src/components/shared/**` and `src/styles/tokens.css`, on 2026-08-19 at commit `19af685`.
 
-Scope: the shell (sidebar, tab strip, status bar, palette, settings) and the visual language shared
-across the 30 tools. Not a rewrite — no new UI framework, no component library, no design-system
-package. Tailwind 4 plus CSS custom properties stay.
-
-## How the audit was run
-
-The app hard-fails outside Tauri: `getCurrentWindow()` throws at `src/app/providers.tsx:30` and the
-UI renders the "Failed to initialize" retry screen. Stubbing `window.__TAURI_INTERNALS__` before page
-load — `metadata.currentWindow`, `plugin:sql|load` / `|select` / `|execute` returning empty results,
-`plugin:event|listen` returning an id — boots the entire shell against an empty database in a normal
-browser, which is what made a Playwright review possible. See the Phase 5 item on keeping that
-harness.
-
-## Measured baseline
-
-From `apps/cockpit/src`, excluding tests, on 2026-08-13:
-
-| Signal                                              | Count   |
-| --------------------------------------------------- | ------- |
-| Arbitrary Tailwind values in tools + components     | 1149    |
-| Hardcoded `text-xs`                                 | 332     |
-| Raw `<button>` in `src/tools`                       | 130     |
-| Files importing `shared/Button`                     | 29      |
-| Raw `<input>` vs files importing `shared/Input`     | 53 / 18 |
-| Unstyled native `<select>`                          | 7       |
-| `prefers-reduced-motion` handling anywhere in `src` | 0       |
-
-## P0 - Broken behaviour
-
-### [x] Unmount the inactive sidebar variant instead of fading it to `opacity: 0`
-
-Area: shell / accessibility / hit-testing
-
-Problem: `src/components/shell/Sidebar.tsx` renders the expanded and collapsed trees at the same time
-and cross-fades between them with `opacity`. The hidden tree keeps real geometry, real focus order,
-and real hit-testing.
-
-Evidence: with the sidebar expanded, `document.querySelectorAll('button[aria-label="Open settings"]')`
-returns two buttons — the visible one at `(44, 836)` and an invisible one at `(94.5, 796)` whose
-ancestor has `opacity: 0`. `elementFromPoint` over the invisible one returns a "Prompt Templates"
-button from the collapsed tree. Playwright could not click the sidebar footer at all: every attempt
-reported the collapsed tree intercepting pointer events. Screen readers see all 30 tools twice, and
-Tab walks through a tree the user cannot see.
-
-Expected outcome: exactly one sidebar tree is present, focusable, and hit-testable at any time.
-
-Acceptance criteria:
-
-- The inactive variant is either conditionally rendered or marked `hidden` + `inert`; a CSS-only
-  `pointer-events-none` is not sufficient because it leaves the tab order and accessibility tree
-  intact.
-- The collapse/expand transition still reads as a transition rather than a snap.
-- A test asserts exactly one `[aria-label="Open settings"]` and exactly one node per tool id in the
-  DOM, in both collapsed and expanded states. Confirm it fails against the current code first.
-
-Verification:
-
-```bash
-cd apps/cockpit
-bunx vitest run src/components/shell
-npx tsc --noEmit
-```
-
-Done in `9f04c4d` — only one variant is rendered at a time, keyed so the fade still reads as a
-transition. `sidebar.test.tsx` pins one `Open settings` button and one node per tool id in both
-states. Re-confirmed in the running app on 2026-08-14: one match when expanded (x=44) and one when
-collapsed (x=6), with no `opacity: 0` ancestor and no duplicate tool buttons in either state.
-
-### [x] Make overlay scrims actually visible, and give overlays one stacking order
-
-Area: shell / modals
-
-Problem: overlays _do_ have scrims — the first version of this item said they did not, which was
-wrong. The scrims are simply invisible in half the themes. `Dialog.tsx` and `CommandPalette.tsx` both
-paint their backdrop with `color-mix(in srgb, var(--color-shadow) 50%, transparent)`, and
-`--color-shadow` is a **box-shadow** colour, not a scrim colour. Light themes set it faint by design:
-`soft-focus` uses `rgba(0, 0, 0, 0.05)`, so after the 50% mix the scrim computes to
-`color(srgb 0 0 0 / 0.0254902)` — 2.5% black, measured in the running app. `catppuccin-latte`,
-`github-light`, `solarized-light`, and `tokyo-night-light` are in the same range (0.05-0.1 before the
-mix). Dark themes land at 20-30%, which reads correctly. So the layer disappears in exactly the
-themes where a scrim matters most, which is why `ui-audit-08-settings.png` looks like a rendering
-fault.
-
-Positioning is fine and should not be changed: the palette is `fixed left-1/2 top-[15%]` with
-`-translate-x-1/2` (measured centred at x=720 in a 1440px viewport) and `Dialog` centres both axes.
-
-Secondary problem: stacking is ad-hoc. Values in use are `z-40` (palette backdrop, file-drop
-overlay), `z-50` (Dialog, Toast, SendToMenu, 4 markdown modals, 2 prompt-template modals, HTML
-validator preview), `z-[70]` (SelectionContextToolbar), `z-[9999]` (tab-strip context menu, sidebar
-flyout and tooltip), and inline `zIndex: 100` / `101` (API client context menu and submenu). Nothing
-documents which should sit above which.
-
-Expected outcome: overlays read as a layer above the app in every theme, and there is one documented
-stacking order.
-
-Acceptance criteria:
-
-- A dedicated `--color-scrim` token per theme, independent of `--color-shadow`, tuned so the scrim is
-  visibly dimming in all 22 themes (target roughly 30-50% effective alpha; verify in at least one
-  light and one dark theme by measuring the computed value, not by eye).
-- `Dialog.tsx` and `CommandPalette.tsx` consume it; the 4 markdown-editor modals and the 2
-  prompt-templates modals — which hand-roll `bg-black/50` and `bg-[var(--color-bg)]/80` — use the
-  same token. Migrating those six onto `Dialog` outright is preferred if it does not regress their
-  focus traps; if it does, just unify the scrim and say so.
-- A documented z-index scale (tokens or a short comment block listing the layers) replacing the
-  ad-hoc values above. The `zIndex: 100/101` inline styles in `CollectionsSidebar.tsx` join it.
-- Existing focus-trap, Esc-to-close, and click-outside behaviour is preserved, and the scrim does not
-  swallow the events those depend on.
-- The scrim respects the reduced-motion item below (no fade when reduced motion is requested).
-
-Verification:
-
-```bash
-cd apps/cockpit
-bunx vitest run src/components
-npx tsc --noEmit
-```
-
-### [x] Give the 12 cockpit-native themes real Monaco token rules
-
-Area: editors / theming
-
-Problem: `src/hooks/useMonaco.ts` builds themes for the 12 cockpit-native app themes from CSS custom
-properties via `buildCockpitTheme()`, which returns `rules: []`. Monaco falls back to the bare `vs` /
-`vs-dark` base, so code in those themes renders with little to no syntax differentiation. Only the 10
-imported `monaco-themes` JSONs (dracula, monokai, nord, night-owl, github-\_, solarized-\_,
-tomorrow-night, oceanic-next) highlight properly. The default theme is one of the good ones, which is
-why this is easy to miss.
-
-Expected outcome: every app theme highlights code.
-
-Acceptance criteria:
-
-- `buildCockpitTheme()` emits a token rule set covering at least comment, string, number, keyword,
-  type, function, and operator, derived from the theme's existing `--color-accent`, `--color-info`,
-  `--color-success`, `--color-warning`, and `--color-text-muted` variables.
-- Contrast against `--color-surface` is checked for each derived colour; nothing lands below ~3:1.
-- A test asserts the built theme has a non-empty `rules` array for a cockpit-native theme.
-- No new dependency: the derivation uses the existing `getCssColor` helper.
-
-Verification:
-
-```bash
-cd apps/cockpit
-bunx vitest run src/hooks
-npx tsc --noEmit
-```
-
-### [x] Honour `prefers-reduced-motion`
-
-Area: accessibility
-
-Problem: `src` contains no `prefers-reduced-motion` handling at all, while the shell animates sidebar
-collapse, tab transitions, toasts, the status-bar fade, and a spinner.
-
-Expected outcome: users who ask the OS for reduced motion get a still interface.
-
-Acceptance criteria:
-
-- One `@media (prefers-reduced-motion: reduce)` block neutralising transition and animation duration
-  app-wide, with any genuinely necessary exception documented inline.
-- Spinners degrade to a static or opacity-only indicator rather than disappearing.
-
-Verification:
-
-```bash
-cd apps/cockpit
-bun run lint
-```
-
-## P1 - Design tokens
-
-### [x] Split `index.css` and add the missing scales
-
-Area: theming / CSS architecture
-
-Problem: `src/index.css` is 869 lines mixing font imports, theme custom properties for 22 themes, and
-highlight.js token colours for those same 22 themes. There are no tokens for spacing, radius, type
-scale, or elevation, which is why tools hardcode `p-1.5`, `text-xs`, and `rounded` inline 1149 times.
-`--color-surface-hover` and `--color-surface-raised` are also identical in most themes, so hover
-states have nowhere to go.
-
-Expected outcome: a token layer worth building components against.
-
-Acceptance criteria:
-
-- Highlight.js blocks move to `src/styles/highlight-themes.css`; theme variables move to
-  `src/styles/tokens.css`; `index.css` imports both and keeps only global element styles.
-- New tokens: `--space-1..8`, `--radius-sm/md/lg`, `--text-xs/sm/base/lg`, `--elevation-1/2/3`,
-  `--focus-ring`, `--color-surface-sunken`, and a `--color-surface-hover` that differs from
-  `--color-surface-raised` in every theme.
-- No visual regression: the 22 themes still resolve every variable they resolved before. A test or
-  script asserting every theme class defines the full token set is preferred over eyeballing.
-
-### [x] Introduce a UI font distinct from the code font
-
-Area: typography
-
-Problem: every label, button, settings row, and menu item renders in Source Code Pro. Monospace for
-chrome costs horizontal space and legibility, and it is why sidebar labels truncate at ~14 characters
-("TypeScript Playgr…", "JSON Schema Valid…").
-
-Acceptance criteria:
-
-- A `--font-ui` token, defaulting to a system UI stack, applied to shell chrome and form labels.
-- `--font-mono` stays on values, editors, code output, and anything the user might diff by eye.
-- Themes can opt back into full-mono by pointing `--font-ui` at `--font-mono`; at least one theme
-  keeps the all-mono look so the aesthetic is still available.
-
-## P2 - Shared primitives
-
-### [x] Extend the primitive set
-
-Area: `src/components/shared`
-
-Problem: `Button.tsx` offers 3 variants and 2 sizes that both render `text-xs`. There is no `Select`,
-no `Field`, no `EmptyState`, no `Toolbar`, and no segmented control — so Match/Replace,
-Edit/Split/Preview, and Formats/Shades/Harmony are three separate hand-rolled implementations of the
-same control.
-
-Acceptance criteria:
-
-- `Button` gains `danger` and `icon` variants, an `xs` size, a `loading` state, and a focus-visible
-  ring drawn from `--focus-ring`.
-- New primitives: `Select` (replacing all 7 native selects), `Field`, `EmptyState`, `Panel`,
-  `Toolbar`, `SegmentedControl`.
-- Every primitive consumes the Phase 1 tokens; no raw pixel values.
-- Each primitive has a focused test in `src/components/shared/__tests__/`.
-
-### [ ] Add a `ToolLayout` and migrate tools onto it
-
-Area: cross-tool consistency
-
-Problem: no layout contract exists between tools. Color Converter pads its content 34px, Regex Tester
-is edge-to-edge at 0px, JSON Tools puts its tab row flush at the top while Regex Tester puts one
-under a control bar, and nothing constrains content width — a 7-character hex value gets a 1200px row
-with its Copy button roughly 1100px away from the value it copies.
-
-Acceptance criteria:
-
-- `ToolLayout` provides an optional header (title, description, actions), an optional toolbar slot, a
-  body with consistent padding, a `max-w` for form-style tools, and a full-bleed opt-out for
-  editor-style tools.
-- Tools migrate one group per PR, starting with CONVERT (9 tools, simplest markup).
-  - [x] CONVERT (9 tools) — `ToolLayout` itself is built and tested.
-  - [x] CODE (4), DATA (5), WEB (4), TEST (2), NETWORK (2), WRITE (4).
-
-Migration complete. Two structural exemptions, both deliberate:
-
-- **Snippets and Prompt Templates** keep their own grid roots. Both are three-column layouts with a
-  command bar spanning all columns; `ToolLayout`'s single-column header/toolbar/body contract cannot
-  express that without redesigning them. They did adopt the shared `Button`/`Select`.
-- **Tree views** (JSON/YAML/XML) keep raw `<button>` for leaves and chevrons — the content is custom
-  inline JSX that no `Button` variant fits.
-
-### Ratchet — corrected
-
-The arbitrary-value figure previously recorded here (1551, later re-measured as 1635) was an artifact
-of a bad command: `grep -o "\[[^]]*\]"` counts every bracket pair in the file, so JS dependency
-arrays (`[state, updateState]`), regex character classes (`[0-9a-f]`) and empty arrays (`[]`) were
-all being counted as Tailwind. Use this instead, which matches a utility with an arbitrary value and
-ignores `var()` token references:
-
-```bash
-grep -rhoP '[a-zA-Z][a-zA-Z0-9:_-]_-\[(?!var\()[^\]]+\]' --include='_.tsx' src/tools | wc -l
-```
-
-| Metric                        | Target | Before migration | After #81 | Now (2026-08-14) |
-| ----------------------------- | ------ | ---------------- | --------- | ---------------- |
-| raw `<button>` in `src/tools` | < 30   | 125              | 20        | 20               |
-| arbitrary Tailwind values     | < 400  | 202              | 202       | 60               |
-
-Count raw buttons with `grep -rc '<button' src/tools --include='*.tsx'` minus the four in
-`src/tools/__tests__/` (lint-ignored) and the one in `HtmlValidator.tsx`, which is HTML sample data
-inside a template string, not JSX. All 20 that remain carry an `eslint-disable-next-line` with a
-stated reason — the rule below now holds the line.
-
-Raw buttons met the target. Arbitrary values were already under it once measured correctly.
-
-**The `text-[10px]` decision is now resolved (2026-08-14): a `--text-2xs` token was added and swept.**
-142 of the 202 remaining arbitrary values were `text-[10px]`, because the smallest `--text-*` token
-was `--text-xs` at 12px. The options were to add a `--text-2xs: 0.625rem` token and sweep, or to
-decide 10px chrome text should become 12px. **We took the token route**, because it is provably a
-no-op visually: `0.625rem × 16px root = 10px` exactly, confirmed live in Chromium
-(`getComputedStyle` on a `.text-2xs` probe returns `10px`, root returns `16px`). Rounding up to
-`text-xs` was rejected for the reason originally recorded here — it silently enlarges dense toolbars.
-
-Mechanism: `--text-2xs: 0.625rem` was added to the `@theme` block in `src/index.css`, which is how
-this project generates real Tailwind 4 utilities (the `--text-*` entries in `tokens.css` only
-document Tailwind's built-in scale; they do not generate anything). It was mirrored into
-`tokens.css` for scale consistency. All 173 occurrences swept — 142 in `src/tools`, 31 in
-`src/components` — taking tools from 202 arbitrary values to 60.
-
-### [x] Remaining: Image Tool
-
-`src/tools/image-tool/ImageTool.tsx` was missed in the CONVERT sweep. Its Reset and aspect-lock
-controls are now shared `Button`s (verified live: lock flips `aria-pressed`/title and stops height
-tracking width; Reset restores 64 × 64).
-
-Done in #81 — the `ToolLayout` pass landed (`ImageTool.tsx:567`, `fullBleed` with a `toolbar` slot)
-but this item was left unchecked. The four raw buttons left are exempted by category, not oversight:
-two 10px underlabels, the 10px preset chip grid, and the crop switch.
-
-## P3 - Shell UX
-
-### [x] Sidebar filter box
-
-All 30 tools sit in 8 always-expanded groups, so at 900px height the bottom third is permanently
-below the fold. Add a filter input at the top of the sidebar, focused by `/`, reusing the Fuse.js
-scoring already implemented in `CommandPalette.tsx` rather than a second search implementation.
-Filtering collapses groups with no matches.
-
-Done in #81 — this item was left unchecked by mistake and is being corrected on 2026-08-14. The
-filter lives in `Sidebar.tsx` and shares scoring through the `useFuseSearch` hook, so there is one
-search implementation, not two. `/` focuses it (expanding the sidebar first if collapsed), ArrowDown
-drops into the filtered results, and Escape clears. Covered by `sidebar.test.tsx` "Filter Box".
-
-### [x] Persist group collapse state
-
-Default to collapsing groups the user has never opened a tool from, and remember explicit
-collapse/expand choices across launches.
-
-Done in #81 — also left unchecked by mistake. State lives in `openedSidebarGroups` on the settings
-store. Covered by `sidebar.test.tsx` "Group Collapse Defaults", including the first-run freeze gate.
-
-### [x] Tool icons in tabs
-
-Every tool has an icon in `src/app/tool-registry.ts`, but `WorkspaceTabStrip` renders text only, so a
-six-tab strip has no shape to scan by. The strip's overflow scrolling and fade affordances already
-work and should not be disturbed.
-
-Done. The icon is decorative (`aria-hidden`), so tab accessible names are unchanged. Verified at
-eight open tabs: overflow still engages (1133px of tabs in a 950px strip) and both edge fades still
-flip with scroll position.
-
-### [x] Theme picker with swatches
-
-23 themes in a native `<select>` with no preview. Replace with a grid of preview chips (bg, surface,
-accent, text) grouped Dark / Light, live-previewing on hover and reverting if the user cancels.
-
-Done — `src/components/shell/ThemePicker.tsx`. Each swatch applies the theme's own class to a scoped
-wrapper, so its colours resolve from `tokens.css` rather than from a duplicated JS palette. The
-Dark/Light split derives from `isLightEffectiveTheme` in `src/lib/theme.ts`; `useMonaco.ts` no longer
-keeps its own light-theme list.
-
-`role="listbox"` with manual activation, not `radiogroup`: radio semantics imply selection follows
-focus, which is the opposite of preview-then-commit. Arrow keys move a roving tabindex and preview;
-`aria-selected` only moves on Enter/Space/click. Preview swaps the `<html>` class only — it never
-touches the `theme-cache` localStorage key that `index.html` reads at boot, so quitting mid-hover
-can't change the theme on next launch. Verified live: hovering previews and reverts on leave,
-ArrowDown from System previews Midnight without moving the selection, Enter commits and writes
-`theme-cache`, and closing the panel mid-hover reverts to the committed theme.
-
-### [x] Better empty states
-
-The workspace placeholder ("Select a tool to get started") should surface recent and pinned tools as
-clickable chips. Per-tool empty panes should offer a "Load sample" action.
-
-Done. `src/components/shell/WorkspaceEmptyState.tsx` renders pinned and recent chips through the
-existing `EmptyState` primitive (no changes to the primitive were needed — its `action` slot already
-takes arbitrary nodes). Recency came from `recentToolIds` in `ui.store.ts`, which already existed and
-already feeds `SidebarRecent`; no new persisted list was added. Recent chips exclude anything already
-pinned.
-
-Samples live in `src/lib/tool-samples.ts` and cover JSON, XML and YAML Tools, the JWT decoder and the
-Diff Viewer. Loading a sample calls the same `updateState` setter the editors' `onChange` uses, so
-validation, history and undo behave exactly as they do for typed input — confirmed live: the JSON
-sample loads and immediately reports "✓ Valid · 11 keys · depth 3", the diff sample computes
-"+2 / −2", and the (obviously fake, unsigned) JWT sample decodes into header/payload. The button
-disappears once the input is non-empty.
-
-Correction to this item as originally written: `apps/cockpit/samples/` is snippet-library markdown
-for the Snippets importer, not per-tool sample inputs, so it was not a usable source. There is also
-no cron parser tool in the registry, so it was skipped rather than invented.
-
-### [x] Tooltip or wrap for truncated tool names
-
-At the current 218px sidebar width, several tool names truncate mid-word with no way to read them.
-
-Done in #81 — also left unchecked by mistake. `SidebarItem` compares `scrollWidth` against
-`clientWidth` and only sets `title` when the label is actually clipped, so tools whose names fit
-don't get a redundant tooltip. Covered by `sidebar.test.tsx` "Truncation Tooltip".
-
-## P4 - Guardrails
-
-### [x] Keep the browser harness
-
-Check in the Playwright init script that stubs `__TAURI_INTERNALS__` (see "How the audit was run"
-above) plus a small script that boots the dev server and captures the shell. This is the basis for
-screenshot review and, later, visual regression. It must not ship in the app bundle.
-
-Done — `scripts/tauri-browser-stub.js` exports `installTauriStub()`, documented in
-`documentation/BROWSER_HARNESS.md` alongside `bun run dev` (port 1420) usage. It stubs
-`metadata.currentWindow`/`currentWebview`, and returns array/tuple shapes the callers destructure
-(`plugin:sql|select` → `[]`, `plugin:sql|execute` → `[0, 0]`, `plugin:sql|load` → an id). It also
-sets `window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} }`, which
-`@tauri-apps/api/event`'s `_unlisten()` reads directly (`node_modules/@tauri-apps/api/event.js`) —
-without it, every listener teardown (`useFileDropZone`'s 4 drag-event listeners included) throws
-`Cannot read properties of undefined (reading 'unregisterListener')`. Verified live in Chromium via
-the Playwright MCP tool: with the field stubbed out, switching between an open-file tool and a
-non-open-file tool (retriggering `useFileDropZone`'s effect) throws 20 of those errors across 5
-switches; with the checked-in stub, the same sequence plus several more tool switches produces zero
-console errors. Not reachable from the production bundle — nothing under `src/` imports it, and it
-lives outside `index.html`'s module graph.
-
-### [x] Lint rule against raw form elements in `src/tools`
-
-Landed as a flat-config `no-restricted-syntax` block in `eslint.config.js` scoped to
-`src/tools/**/*.tsx`, with `JSXOpeningElement[name.name="button"]` and `…="select"` selectors.
-`react/forbid-elements` was not used: `eslint-plugin-react` is not a dependency of this project (it
-appears in `bun.lock` only transitively via `eslint-config-next` for the legacy `apps/next`, and is
-not resolvable from `apps/cockpit`), and `AGENTS.md` says to reach for what's already available
-before adding one. `no-restricted-syntax` is built into ESLint and needs nothing new.
-
-`input` was originally left out because there was no shared primitive to point violators at. There
-is now — boxed `Input` and chrome-less `InlineInput` — so a third selector covers it. It matches
-text-entry inputs only: `checkbox`, `radio`, `file`, `color` and `range` are native controls with no
-shared equivalent, and are exempted by `type` in the selector rather than by fourteen per-line
-disable comments that would all give the same reason.
-
-Escape hatch: a per-line `// eslint-disable-next-line no-restricted-syntax -- <reason>` immediately
-above the element. **The directive must be the last line of the comment** — with stacked `//` lines
-ESLint applies it to the following comment line, not to the JSX, so it silently no-ops and reports
-an unused-directive warning. Keep the reason on that one line, or use a `{/_ … _/}` block comment.
-
-The 25 sites the rule first flagged resolved as: 3 migrated (`ImageTool`'s Reset and aspect-lock to
-`Button`, `CurlToFetch`'s "Test in API Client" to `Button`), 2 replaced by `SegmentedControl`
-(`YamlTools`' YAML→JSON / JSON→YAML direction toggle), and 20 exempted in five categories —
-tree disclosure rows, inline click-to-copy tokens inside syntax-highlighted output, accordion panel
-headers, 10px chips and underlabels with no token below `text-xs`, and controls whose colour is
-state (`--color-warning`/`--color-success` borders, the crop switch, the decorative colour-mockup
-button).
-
-The crop switch is no longer among them: its exemption claimed no equivalent existed, but the shared
-`Toggle` is exactly that control, and moving to it also corrected the semantics from a button with
-`aria-pressed` to a `role="switch"` with `aria-checked`.
-
-### [x] Contrast pass across all 22 themes
-
-**Fixed 2026-08-14** — see Outcome below. The ratios in this section are the _original_, pre-fix
-measurements, kept for the record. They are `--color-text-muted` composited over `--color-surface`
-and over `--color-bg`, taken live in Chromium by applying each theme class to `<html>` and reading
-computed values (the alpha in most tokens has to be flattened against the backdrop first — comparing
-the raw `rgba` against the surface overstates every dark theme).
-
-Five themes fail WCAG AA for normal text (4.5:1) on surface:
-
-| Theme               | muted token             | on surface | on bg |
-| ------------------- | ----------------------- | ---------- | ----- |
-| `solarized-light`   | `rgb(88,110,117)` α0.6  | **2.23**   | 2.37  |
-| `solarized-dark`    | `rgb(131,148,150)` α0.6 | **2.59**   | 2.79  |
-| `tokyo-night-light` | `rgb(108,110,117)`      | **3.48**   | 4.13  |
-| `soft-focus`        | `rgb(45,52,54)` α0.6    | **3.49**   | 3.65  |
-| `github-light`      | `rgb(36,41,46)` α0.6    | **3.96**   | 4.05  |
-
-Borderline (AA for large text only, and `--color-text-muted` is used at 10–12px throughout):
-`catppuccin-latte` 4.06, `earth-code` 4.07, `tomorrow-night` 4.41, `nord` 4.42, `oceanic-next` 4.48.
-The remaining 12 clear 5:1.
-
-Both Solarized themes are the real problem — their muted token is Solarized's own base01/base1
-comment colour at 60% opacity, which halves an already low-contrast pairing. `soft-focus` is the
-default light theme, so its 3.49 is the one users hit first. Fix by raising the alpha (or dropping
-it entirely, as `tokyo-night` and the Catppuccin variants already do) rather than by shifting hue,
-so each theme keeps its palette identity.
-
-Re-measure with the snippet in `documentation/BROWSER_HARNESS.md` after any token change; the
-in-app WCAG checker in Color Converter can confirm individual pairs by hand.
-
-**Outcome.** All 10 sub-4.5 themes now clear AA on _both_ surface and bg. Worth noting: every one of
-the 10 was failing on bg as well, which the table above did not capture — it only recorded the
-surface ratio. Alpha was raised (or dropped to opaque) in preference to shifting hue, exactly as
-this item specified; only `solarized-light`, `tokyo-night-light`, and `catppuccin-latte` needed a
-lightness shift along their existing hue, because alpha alone could not reach 4.5.
-
-| Theme             | surface before → after | change                            |
-| ----------------- | ---------------------- | --------------------------------- |
-| solarized-light   | 2.23 → 4.85            | `rgba(88,110,117,.6)` → `#53676e` |
-| solarized-dark    | 2.59 → 4.75            | alpha dropped, hue kept           |
-| tokyo-night-light | 3.48 → 4.84            | `#6c6e75` → `#57585e`             |
-| soft-focus        | 3.49 → 5.23            | alpha 0.6 → 0.75                  |
-| github-light      | 3.96 → 5.35            | alpha 0.6 → 0.7                   |
-| catppuccin-latte  | 4.06 → 4.85            | `#6c6f85` → `#616377`             |
-| earth-code        | 4.07 → 4.92            | alpha 0.6 → 0.7                   |
-| tomorrow-night    | 4.41 → 5.04            | alpha 0.6 → 0.66                  |
-| nord              | 4.42 → 5.00            | alpha 0.6 → 0.66                  |
-| oceanic-next      | 4.48 → 4.99            | alpha 0.6 → 0.65                  |
-
-Worst case across all 22 themes is now **4.75:1** (`solarized-dark` on surface). Values were kept in
-a ~4.6–6:1 band deliberately: muted text still has to read as muted, so overshooting into
-full-contrast text would have been its own regression. Confirmed by eye in `soft-focus` (the default
-light theme, and the one users hit first) — secondary text is legible without competing with primary.
-
-Regression guard: `src/styles/__tests__/contrast.test.ts` parses `tokens.css`, flattens alpha against
-the backdrop, and asserts every theme clears 4.5:1 on both surface and bg. It asserts the parsed
-theme count is 22, so a parser regression cannot make it pass vacuously. Node-side numbers match
-live Chromium measurements to 2dp.
-
-## P5 - Polish pass (filed and completed 2026-08-14)
-
-Found by re-auditing the app after #81 landed, rather than from the original audit.
-
-### [x] One focus treatment everywhere
-
-Area: accessibility / shared primitives
-
-Problem: a `--focus-ring` token existed but only 13 files used `focus-visible`. `Toggle` and
-`CopyButton` had no focus styling at all, `TabBar` buttons had none, and several places used
-`focus:` — which also fires on mouse click, so clicking a control left a ring stuck on it.
-
-Done. Canonical treatment is `focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]`,
-matching what `Button`/`Select`/`SegmentedControl` already did. Applied across `src/components/**`:
-`Toggle`, `CopyButton`, `TabBar`, `Dialog`'s close button, `SelectionContextToolbar`, `SendToMenu`,
-`ErrorBoundary`, and every previously-unstyled interactive element in the shell (tab strip, sidebar,
-footer, status bar, update notification, notes drawer, settings panel).
-
-Deliberate exceptions, each for a reason rather than by oversight:
-
-- **`Input.tsx` keeps its `focus:border` accent** and gained the ring on top. An always-on active-field
-  border is correct UX for text inputs — users want to see which field is live whether they clicked
-  or tabbed. Removing it to satisfy a lint-shaped rule would have been a regression.
-- **`SidebarGroup`, `SidebarItem`, and the tab-row** keep their existing `focus-visible:ring-1
-ring-inset` treatment. They already satisfy keyboard-only visibility; the canonical token draws an
-  _outward_ 2px+4px glow that would clip inside those overflow-hidden scroll containers.
-- **`CommandPalette` and `SendToMenu` filter inputs** get no ring — they are focused programmatically
-  the instant the surface opens, so "you tabbed here" is never meaningful.
-- **`CommandPalette` result buttons** are `tabIndex={-1}` under the ARIA combobox pattern
-  (AGENTS.md rule 23); they never take DOM focus, so `focus-visible` could never fire.
-
-### [x] One spinner, and loading states only where they earn their place
-
-Area: shared primitives / perceived performance
-
-`Button` had an inline spinner and nothing else did. Extracted it into
-`src/components/shared/Spinner.tsx`; `Button` now consumes it, so there is exactly one spinner in the
-codebase. It inherits reduced-motion handling for free from the existing global
-`.animate-spin { animation: none !important; opacity: 1 }` rule — it degrades to a static ring rather
-than vanishing, which the P0 reduced-motion item requires.
-
-`useDelayedLoading(active, delay = 150)` ships alongside it: a single anti-flash implementation that
-only reports `true` once a load has held for 150ms, and drops to `false` immediately on completion.
-Tools import it rather than each re-implementing a timer.
-
-Instrumented: `TsPlayground` (worker compilation), `RefactoringToolkit` (AST transform preview),
-`XmlTools` (five worker round-trips, wired through `Button`'s existing `loading` prop).
-
-**Deliberately skipped, which is the more important half of this item** — a spinner that flashes for
-20ms is worse than no spinner:
-
-- `JsonSchemaValidator` — Ajv runs synchronously inside the debounce callback, so React cannot paint
-  a spinner mid-block. It would either never render or always render for the whole block.
-- `CodeFormatter` — `handleFormat` already had `Button loading`; `handleAutoDetect` is a handful of
-  cheap regex tests, never realistically >200ms.
-- `YamlTools` — format/convert already had `Button loading`; minify and sort-keys are synchronous on
-  already-parsed data.
-- `DiffViewer` — already had `Button loading={isComparing}`.
-
-### [x] Unify error presentation
-
-Area: accessibility / cross-tool consistency
-
-A shared `Alert` (`role="alert"`, `aria-live`) existed and 9 tools used it; four hand-rolled errors
-as bare colour-coded text with no role, so a screen reader never announced a validation failure.
-
-Migrated to `Alert`: `ApiClient` request errors, `RegexTester`'s `matchError` and `replaceError`.
-
-Exempted, because forcing the component would have been worse than the problem:
-
-- **`CssValidator`** renders a _list_ of diagnostics, potentially hundreds. Wrapping each in a banner
-  would be far worse than the status quo. Gave the list container `role="status"` /
-  `aria-live="polite"` instead, so it announces as one region.
-- **`MarkdownEditor`** bakes its render error into an HTML _string_ injected via
-  `dangerouslySetInnerHTML`, so there is no JSX pass to drop a React component into. Put
-  `role="alert"` / `aria-live="assertive"` directly on the generated tag for equivalent semantics.
+Every finding below carries a count and at least one file reference. Counts came from grep over
+`src/tools` excluding `__tests__`. No runtime/visual inspection was performed — Phase 0 includes a
+screenshot pass to catch anything static analysis cannot see.
 
 ---
 
-## Remaining quality backlog
+## 2. Where we actually are
 
-Carried over from the 2026-07-30 reliability audit; these four were never started.
+The good news first, because it shapes the plan: **the primitive layer is already broadly adopted.**
+This is a convergence job, not a rewrite.
 
-### [ ] Add a no-regression audit for cockpit non-negotiables
+| Primitive          | Tool files importing it | Verdict                       |
+| ------------------ | ----------------------- | ----------------------------- |
+| `Button`           | 33 / 36                 | Near-universal                |
+| `CopyButton`       | 26 / 36                 | Near-universal                |
+| `ToolLayout`       | 27 / 36                 | Strong                        |
+| `Alert`            | 22 / 36                 | Strong                        |
+| `EmptyState`       | 18 / 36                 | Partial                       |
+| `Toolbar`          | 20 / 36                 | Partial — the main gap        |
+| `SegmentedControl` | 13 / 36                 | Fine (view-mode tools only)   |
+| `TabBar`           | 4 / 36                  | Fine (multi-mode tools only)  |
+| `Field`            | 1 / 36                  | **Effectively unadopted**     |
+| `Panel`            | 0 / 36                  | **Dead — tested, never used** |
 
-Area: contributor safety / architecture guardrails
+There are **zero** raw `<input>`, `<textarea>`, or `<select>` elements in the tool layer, and only 12
+raw `<button>` elements across 5 files. Form controls and buttons are solved. What is _not_ solved is
+everything **around** them: the container, the section label, the pane header, and the scale.
 
-Problem: `AGENTS.md` lists critical rules that prevent known failures: DB singleton access, no
-StrictMode, no new Tauri windows, DPI conversion, worker imports, theme timing, CSS variables, and
-Phosphor icons. Some are checked by hooks, but the coverage should be explicit and easy to run.
+---
 
-Expected outcome: New PRs get fast, deterministic feedback for cockpit-specific architecture rules.
+## 3. Findings
 
-Acceptance criteria:
+### F1 — Section labels have ~7 competing visual idioms (highest impact)
 
-- Add or document a single audit command that checks the non-negotiables.
-- Audit covers `Database.load()` outside `src/lib/db.ts`, `React.StrictMode`,
-  `new WebviewWindow`, Comlink `expose`, module worker construction, module-level `applyTheme`,
-  missing DPI conversion near window APIs, hardcoded colors, npm/yarn commands, and non-Phosphor
-  icons.
-- The audit runs in CI or is explicitly required in the PR checklist.
+The same semantic thing — "a small label naming a region" — is styled seven different ways. Grep for
+`uppercase` in `src/tools` returns 21 distinct class strings.
 
-Verification:
+| Idiom                                                       | Uses | Example                                    |
+| ----------------------------------------------------------- | ---- | ------------------------------------------ |
+| A. `font-ui text-2xs font-semibold uppercase tracking-wide` | 6    | `json-tools/JsonTools.tsx:731`             |
+| B. `text-2xs font-semibold uppercase tracking-wider`        | 5    | `image-tool/ImageTool.tsx:896`             |
+| C. `font-mono text-2xs uppercase tracking-widest`           | 6    | `prompt-templates/PromptTemplates.tsx:628` |
+| D. `font-mono text-xs text-muted` (sentence case)           | 3    | `hash-generator/HashGenerator.tsx:114`     |
+| E. `text-2xs font-bold uppercase tracking-wide` (as `<h2>`) | 3    | `css-validator/CssValidator.tsx:611`       |
+| F. `font-mono text-sm` (as `<h2>`)                          | 6    | `uuid-generator/UuidGenerator.tsx:241`     |
+| G. `text-[9px] uppercase tracking-wide` (off-scale)         | 2    | `color-converter/ColorConverter.tsx`       |
 
-```bash
-cd apps/cockpit
-bun run lint
-npx tsc --noEmit
+Three axes vary independently and meaninglessly: font (`font-ui` vs `font-mono`), weight
+(`medium`/`semibold`/`bold`), and tracking (`wide`/`wider`/`widest`). Idiom G escapes the type scale
+entirely with a hardcoded `text-[9px]`.
+
+**This is the single biggest source of "these tools feel like different apps."**
+
+### F2 — Pane headers are copy-pasted, not shared
+
+Five tools carry this string **verbatim**:
+
+```
+border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]
 ```
 
-### [ ] Improve updater behavior coverage
+`regex-tester/RegexTester.tsx:306`, `css-specificity/CssSpecificity.tsx:246`,
+`url-codec/UrlCodec.tsx:197`, `curl-to-fetch/CurlToFetch.tsx:323`,
+`css-to-tailwind/CssToTailwind.tsx:335`.
 
-Area: updater / release channel reliability
+Meanwhile `snippets` and `prompt-templates` use `px-3 py-1.5 text-2xs` for the same role, and
+`json-tools`/`yaml-tools`/`xml-tools` use idiom A in a differently-padded row. Same element, three
+paddings, three type sizes. There is no `PaneHeader` component.
 
-Problem: The updater depends on GitHub release assets and `latest.json`. Release workflow verifies
-asset presence, but UI behavior around network errors, manual checks, automatic checks, and silent
-downloads needs focused coverage.
+### F3 — 16 tools bypass the `Toolbar` primitive
 
-Expected outcome: Update checks are reliable, non-blocking, and clear when offline or when the
-manifest is incomplete.
+These import no `Toolbar`/`ToolbarGroup` and hand-roll their top row:
 
-Acceptance criteria:
+`api-client`, `case-converter`, `color-converter`, `css-to-tailwind`, `csv-tools` (+`CsvAnalyze`),
+`curl-to-fetch`, `diff-viewer`, `hash-generator`, `jwt-decoder`, `prompt-templates`, `snippets`,
+`uuid-generator`, `markdown-editor/MarkdownPreview`, `mermaid-editor/MermaidPreview`, `placeholder`.
 
-- Tests cover available update, no update, network failure, malformed manifest, missing platform,
-  dismissed notifications, and manual retry.
-- Manual smoke confirms automatic checks do not block startup.
-- Release workflow still fails when expected platform assets or `latest.json` are missing.
+The consequence is measurable padding drift. Horizontal padding across tool chrome rows:
 
-Verification:
+| Padding       | Occurrences                 |
+| ------------- | --------------------------- |
+| `px-4 py-2`   | 20 (the `Toolbar` contract) |
+| `px-3 py-2`   | 19                          |
+| `px-3 py-1.5` | 19                          |
+| `px-3 py-1`   | 15                          |
+| `px-4 py-3`   | 4                           |
+| `px-2 py-*`   | 18                          |
 
-```bash
-cd apps/cockpit
-bunx vitest run src/stores src/components
+`api-client/ApiClient.tsx:843` is the clearest case: it renders a hand-rolled
+`flex flex-wrap items-center gap-2 border-b … px-3 py-2` inside `ToolLayout`'s `toolbar` slot —
+`Toolbar` with `px-4`, one prop away, but 1 unit narrower than every neighbouring tool.
+
+`case-converter` and `hash-generator` go further and put a **whole input form** (`p-4` + `TextArea`)
+in the `toolbar` slot, which is a layout slot, not a content slot.
+
+### F4 — `Panel` is dead code; 4 tools hand-roll its exact styling
+
+`Panel.tsx` exists, has a test (`shared/__tests__/Panel.test.tsx`), and has **zero** consumers in
+`src/tools` or `src/components/shell`. Its comment claims it replaces "the repeated
+`rounded border border-[var(--color-border)] bg-[var(--color-surface)]` wrapper hand-rolled
+throughout the tools" — which is still hand-rolled in `csv-tools/CsvAnalyze.tsx` (×2),
+`prompt-templates/PromptTemplates.tsx`, and `api-client/components/CollectionsSidebar.tsx`.
+
+Either adopt it or delete it. Shipping a tested component nobody uses is worse than either.
+
+### F5 — `ToolLayout`'s `header` slot is dead; two tools reinvent it anyway
+
+`header={...}` is used **zero** times. The tab strip supplies the tool name, which is the right call.
+But `snippets/SnippetsManager.tsx:606` and `prompt-templates/PromptTemplates.tsx:1020` both render
+their own `<h1 className="font-ui text-sm font-semibold">` inside a hand-rolled `<aside>` — so the
+app _does_ have tools that show their own title, just not through the slot built for it, and not
+through `ToolLayout` at all (neither tool uses it).
+
+`api-client` is the third master–detail tool and takes yet a third approach: `ToolLayout fullBleed`
+with the sidebar rendered as a sibling. Three master–detail tools, three shells.
+
+### F6 — No keyboard-hint primitive
+
+`⌘` appears in 55 places across 17 tool files. It is rendered three ways:
+
+- Bare span: `<span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>`
+  (`base64/Base64Tool.tsx:358`, `url-codec/UrlCodec.tsx:165`)
+- Inside `title=` tooltips (most tools)
+- A real `<kbd>` with border + surface + `font-mono` — but only in the shell, and duplicated between
+  `shell/CommandPalette.tsx:546` (`text-[10px]`) and `shell/ShortcutsModal.tsx:54` (`text-[11px]`),
+  which disagree with each other and both sit off the type scale.
+
+### F7 — No shared split-pane; every split is a fixed 50/50
+
+15 tools render side-by-side panes via `w-1/2` or `grid-cols-2`. **None** is resizable. The only
+draggable divider in the app is `shell/NotesDrawer.tsx:592`. For a tool like `diff-viewer` or
+`json-tools`, where one side is routinely much denser than the other, a fixed 50/50 is a real usability
+cost, not just a consistency one.
+
+### F8 — Icon size scale has drifted from the documented one
+
+| `size=` | Uses |
+| ------- | ---- |
+| 12      | 65   |
+| 13      | 54   |
+| 14      | 29   |
+| 15      | 22   |
+| 11      | 10   |
+| 10      | 9    |
+| 16      | 5    |
+
+`DESIGN_SYSTEM.md` documents 14/16 for toolbar icons and 20 for sidebar. Actual practice is 12/13,
+with 10/11/15 sprinkled in. Six sizes for what should be two or three. The docs are wrong, not the
+code — but nothing tells a contributor which of the six to pick.
+
+### F9 — `Field` unadopted; 16 files hand-roll `<label>`
+
+`Field` (label + control + hint/error) is imported by exactly one file
+(`api-client/components/AuthTab.tsx`). Sixteen other files hand-roll `<label>` wrappers —
+`prompt-templates` alone has 10, `image-tool` 6, `color-converter` 3. Label styling therefore
+inherits all of F1's variance.
+
+### F10 — Focus-ring convention has a minority dialect
+
+The standard is `focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]` (56 uses).
+A minority use `focus-visible:ring-1` / `focus-visible:ring-[var(--color-accent)]/60` /
+`focus-visible:ring-inset` (~8 uses). These render differently — a ring, not the two-layer offset
+shadow — so focus is visibly inconsistent between neighbouring controls.
+
+### F11 — Primary-action discipline is uneven
+
+`variant="primary"` per tool: 15 tools have exactly 1 (correct), **13 tools have 0**, and 5 have 2–4
+(`prompt-templates` 4, `image-tool`/`snippets`/`uuid-generator`/`yaml-tools` 2).
+
+Tools with zero primary action include `case-converter`, `color-converter`, `hash-generator`,
+`jwt-decoder`, `regex-tester`, `timestamp-converter`, `refactoring-toolkit` — all live-computing
+tools where "no button to press" is arguably correct. That should be a **stated rule**, not an
+accident, so reviewers stop adding one.
+
+### F12 — `DESIGN_SYSTEM.md` is materially stale
+
+It is the document contributors are told to read first, and it currently misinforms them:
+
+- Says tokens live in `src/index.css`; they live in `src/styles/tokens.css` (imported at `index.css:21`).
+- Every colour value in its tables is wrong (`--color-bg` documented `#0a0a0a`, actual `#0a0f1c`).
+- Prescribes `focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]`; the codebase uses
+  `--focus-ring` (F10). The doc actively teaches the minority dialect.
+- Documents `animate-[fade-in_150ms_ease-out]` — **zero** uses. Actual class is `animate-fade-in` (7 uses).
+- No mention of `ToolLayout`, `DocumentToolbar`, `DocumentIdentity`, `Panel`, `Field`, `InlineInput`,
+  `SearchInput`, `Dialog`, `Spinner`, `SegmentedControl` — i.e. most of the layer this plan is about.
+- No mention of `text-2xs` (45 files use it) or the `--radius-*` / `--elevation-*` tokens.
+
+### F13 — Assorted one-offs
+
+- `prompt-templates/PromptTemplates.tsx:189` renders a `[ 03-PREVIEW ]` bracketed mono label — an
+  idiom that exists nowhere else in the app.
+- `curl-to-fetch/CurlToFetch.tsx:285` computes HTTP-method chip colours inline with `color-mix()` and
+  a local `METHOD_COLORS` map; `api-client` has its own method-colour treatment. Two sources of truth
+  for the same visual vocabulary.
+- `csv-tools/CsvTools.tsx` renders sub-tools (`CsvTable`, `CsvAnalyze`, `CsvConvert`) that each carry
+  their own `Toolbar`, producing stacked toolbars with no shared rule about which level owns what.
+
+---
+
+## 4. Target contract
+
+The rule we are converging on, stated once so it can be reviewed against:
+
+```
+ToolLayout                        ← every tool, no exceptions
+  toolbar: Toolbar | DocumentToolbar   ← chrome only. Never a form, never an editor.
+    ToolbarGroup (+ separated)         ← action families
+    ToolbarSpacer
+  body:
+    fullBleed  → SplitPane / editor panes, each with PaneHeader
+    otherwise  → maxWidth-capped stack of Panel sections
 ```
 
-### [ ] Add performance budgets for large inputs
+Five new or revived primitives close every finding above:
 
-Area: tool responsiveness / desktop UX
+| Primitive            | Status | Closes |
+| -------------------- | ------ | ------ |
+| `SectionLabel`       | new    | F1, F9 |
+| `PaneHeader`         | new    | F2     |
+| `Panel`              | revive | F4     |
+| `Kbd`                | new    | F6     |
+| `SplitPane`          | new    | F7     |
+| `MasterDetailLayout` | new    | F5     |
 
-Problem: Several tools can process large text, CSV, XML, images, or generated history. Regressions
-may show up as UI stalls rather than test failures.
+Plus one non-component deliverable: a **scale decision** (F8, F10) recorded in `DESIGN_SYSTEM.md`
+and enforced by lint where possible.
 
-Expected outcome: Large-input handling has practical budgets and protects the main thread where
-possible.
+---
 
-Acceptance criteria:
+## 5. Plan
 
-- Define representative large-input fixtures for JSON, XML, CSV, Markdown, Diff Viewer, Regex
-  Tester, and Image Tool.
-- Measure parse/format/render behavior with repeatable local scripts or Vitest performance checks.
-- Add debouncing, workers, chunking, or limits where a tool blocks interaction beyond the agreed
-  budget.
-- Document any intentional input-size limits in tool UI or troubleshooting docs.
+Phases are ordered so that each one is independently shippable and reviewable. Do not batch them into
+one PR — F1 alone touches ~25 files.
 
-Verification:
+### P0 — Baseline and guardrails ✅
 
-```bash
-cd apps/cockpit
-bunx vitest run src/tools/__tests__
-```
+- [x] Record the current gate results in §6. All four green at `19af685`.
+- [ ] ~~Screenshot every tool at 1280×800 and 900×700 via the native harness.~~ **Not done — blocked.**
+      Capturing 30 tools requires navigating between them, and clicks/typing into the WebView are
+      not scriptable on macOS (`documentation/NATIVE_UI_HARNESS.md`); only screenshot and resize
+      are. A screenshot of whichever tool happens to be open is not a baseline. This is a real gap
+      in the plan's verification story and it is not closed by anything below — the mitigation is
+      that P3's sweeps are pure substitutions with unchanged DOM structure, and that P4/P5 are
+      per-tool commits reviewable in isolation.
+- [ ] ~~Append visual-only findings as F14+.~~ Superseded by the above.
 
-### [ ] Keep quality docs synchronized
+**Acceptance:** all four gates green and recorded ✅; screenshot baseline **not achieved** — see above.
 
-Area: documentation / contributor onboarding
+### P1 — Decide the scale, fix the docs ✅
 
-Problem: `README.md`, `PRODUCT_MAP.md`, `TESTING.md`, `RELEASE_SMOKE_TESTS.md`, `AGENTS.md`, and
-this backlog can drift as quality work lands.
+- [x] **Label scale** decided: idiom A —
+      `font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]`.
+- [x] **Icon scale** decided: `12` dense/inline, `14` toolbar, `16` navigation. 10/11/13/15 retired.
+      Applied app-wide: 10,11→12; 13→14; 15→16.
+- [x] **Chrome padding** decided: `px-4 py-2` tool toolbar, `px-3 py-1.5` pane header.
+- [x] **Off-scale type** retired: `text-[9px]`/`text-[10px]`→`text-2xs`, `text-[11px]`→`text-xs`.
+- [x] **Focus** resolved. The four `focus-visible:ring-*` sites turned out not to be drift — they
+      are _inset_ rings in dense containers (sidebar rows, tab strip) where the outer ring clips.
+      Added `--focus-ring-inset` to `tokens.css` and moved them onto it, rather than forcing them
+      onto a treatment that would render wrong. Also fixed `SnippetsManager`'s
+      `shadow-[inset_var(--focus-ring)]`, which only inset the _first_ of the token's two shadow
+      layers — a real bug the audit surfaced by accident.
+- [x] `DESIGN_SYSTEM.md` rewritten against source. The per-theme colour tables are gone: the app
+      ships 22 themes, so a two-column dark/light table was wrong 20 ways and encouraged
+      contributors to copy literal values. Documents roles instead.
+- [x] `scripts/lint-design-system.mjs` + `bun run lint:ds`, chained into `bun run lint`.
 
-Expected outcome: Contributors can find the current source of truth without stale test counts,
-commands, or status claims.
+**Scope note:** the scale sweep deliberately extended past `src/tools` into `src/components/shell`
+(49 of the 153 violations). A design scale the shell is exempt from is not a scale. Structural work
+in §5 P4/P5 remains tool-only per §8.
 
-Acceptance criteria:
+**Acceptance:** ✅ gate fails on a deliberate `text-[9px]`, passes on the swept tree; every
+`DESIGN_SYSTEM.md` claim re-derived from source.
 
-- Update test counts in docs when the suite changes materially.
-- Move completed release-smoke or testing improvements into `TESTING.md` and
-  `RELEASE_SMOKE_TESTS.md`.
-- Keep `AGENTS.md` command guidance aligned with CI and package scripts.
-- Link new quality artifacts from the README documentation table when they become permanent.
+### P2 — Land the primitives ✅
 
-Verification:
+All six landed with tests, `DESIGN_SYSTEM.md` entries, and zero call sites changed.
 
-```bash
-cd apps/cockpit
-bunx vitest run
-bun run lint
-```
+- [x] `SectionLabel` — `{ children, as, hint }`. `as` decouples heading level from visual.
+- [x] `PaneHeader` — `{ title, hint, status, actions }`. `actions` is the slot all five
+      hand-rolled copies lacked, which is why `CopyButton` placement wandered.
+- [x] `Kbd` — `{ keys }`, `mod` resolved per platform via `usePlatform()`.
+- [x] `SplitPane` — draggable + **keyboard-resizable** (arrows/Home/End/Enter-to-reset),
+      `role="separator"` with `aria-valuenow`, ratio persisted under `cockpit.split.<key>`.
+- [x] `MasterDetailLayout` — `{ sidebar, title, subtitle, sidebarActions, sidebarOpen, onToggleSidebar }`.
+- [x] `Panel` — kept as-is (its existing API already fits the four hand-rolled sites).
 
-## Release Readiness Checklist
+**Acceptance:** ✅ 114 test files / 1338 tests passing (was 109/1314); `SplitPane` keyboard resize,
+clamping, and persistence all covered.
 
-Before cutting or promoting a cockpit release, confirm:
+### P1 — Decide the scale, fix the docs
 
-- [ ] Cockpit CI is green for the release commit.
-- [ ] Frontend typecheck, lint, and Vitest pass locally.
-- [ ] Rust `cargo check` and `cargo clippy -- -D warnings` pass locally or have a documented,
-      environment-specific exception.
-- [ ] Release workflow produced all expected platform artifacts.
-- [ ] `latest.json` exists and maps `darwin-aarch64`, `darwin-x86_64`, `windows-x86_64`, and
-      `linux-x86_64`.
-- [ ] Cross-platform smoke results are recorded against downloaded release artifacts.
-- [ ] Any platform-specific defect is documented before the release leaves internal validation.
+No code changes to tools. This phase exists so P2–P5 have something to converge _on_.
 
-## Maintenance Notes
+- [ ] Decide and record the **label scale**: one `SectionLabel` with at most two variants. Proposal:
+      `font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]`
+      (idiom A — already the plurality at 6 uses and the only one that is `font-ui`, matching the
+      chrome/mono split the design system already draws).
+- [ ] Decide the **icon scale**: proposal — `12` dense/inline, `14` toolbar, `16` navigation. Retire
+      10/11/13/15.
+- [ ] Decide the **chrome padding scale**: `px-4 py-2` for tool toolbars (the existing `Toolbar`
+      contract), `px-3 py-1.5` for pane headers. Retire `px-3 py-1`, `px-3 py-2`, `px-4 py-3` from
+      chrome rows.
+- [ ] Rewrite `DESIGN_SYSTEM.md` against reality — every item in F12. Regenerate the colour tables
+      from `src/styles/tokens.css` rather than retyping them, so they cannot drift again.
+- [ ] Add an ESLint rule or a `bun run lint:ui` grep gate rejecting: hardcoded `text-[Npx]`,
+      `focus-visible:ring-*` in `src/`, and raw hex/`rgb()` in `className`.
 
-- Prefer small PRs that improve one risk area at a time.
-- Do not add new npm packages for quality work unless platform APIs and existing tools are
-  insufficient.
-- New tests should follow established locations: tool tests in `src/tools/__tests__/`, library tests
-  in `src/lib/__tests__/`, store tests in `src/stores/__tests__/`, and component tests colocated per
-  subdirectory in `src/components/<subdir>/__tests__/` (e.g. `src/components/shell/__tests__/`,
-  `src/components/shared/__tests__/`) — there is no single flat `src/components/__tests__/`.
-- Keep commands Bun-first and run cockpit commands from `apps/cockpit`.
+**Acceptance:** `DESIGN_SYSTEM.md` claims verified line-by-line against source; the new gate fails on
+a deliberately-introduced `text-[9px]` and passes on `main`.
+
+### P2 — Land the primitives
+
+Each with a test, a `DESIGN_SYSTEM.md` entry, and **zero call sites changed** in this phase.
+
+- [ ] `SectionLabel` — `{ children, as?: 'span' | 'h2' | 'h3', hint?: ReactNode }`. Renders the P1
+      scale. `as` exists so the visual and the heading level can be chosen independently — several
+      current call sites are `<h2>` where a `<span>` is correct, and vice versa.
+- [ ] `PaneHeader` — `{ title, actions?, status? }`. The F2 string, once, at the P1 padding.
+      `actions` is the slot the five copies currently lack, which is why `CopyButton` placement
+      varies pane to pane.
+- [ ] `Kbd` — `{ keys: string }`, e.g. `<Kbd keys="mod+enter" />`, resolving `mod` via
+      `usePlatform()`. Replaces the two disagreeing shell copies and the bare spans.
+- [ ] `SplitPane` — `{ children: [ReactNode, ReactNode], direction?, defaultRatio?, storageKey? }`.
+      Draggable divider with `role="separator"` + `aria-orientation` + arrow-key resize. Lift the
+      drag logic out of `shell/NotesDrawer.tsx:592` rather than writing it twice.
+- [ ] `MasterDetailLayout` — `{ sidebar, children, sidebarWidth?, collapsible? }`. The shell shared by
+      `snippets`, `prompt-templates`, and `api-client`.
+- [ ] `Panel` — keep as-is; add the `SectionLabel`-based header. Its API already fits the four
+      hand-rolled sites.
+
+**Acceptance:** each primitive has a unit test covering its ARIA contract; `SplitPane` has a
+keyboard-resize test; bundle size delta recorded.
+
+### P3 — Convergence sweep: labels, panes, keys
+
+The mechanical bulk. Split into 3–4 PRs by finding, not by tool, so review stays diffable.
+
+- [ ] **F1:** replace all 7 label idioms with `SectionLabel`. ~25 files. Watch for the `<h2>`/`<span>`
+      distinction — do not silently change heading structure, it is a11y-visible.
+- [ ] **F2:** replace the 5 verbatim pane headers plus the `snippets`/`prompt-templates`/`json-tools`
+      family variants with `PaneHeader`.
+- [ ] **F6:** replace the 55 `⌘` sites with `Kbd`; delete the two shell copies. Keep `title=` tooltips
+      as-is where they are the only affordance.
+- [ ] **F9:** adopt `Field` in the 16 hand-rolled `<label>` files. If `Field`'s API does not fit a
+      site, extend `Field` — do not fork.
+- [ ] **F10:** convert the ~8 `focus-visible:ring-*` sites to `--focus-ring`.
+- [ ] **F8:** normalise icon sizes to the P1 scale.
+- [ ] **F13:** delete the `[ 03-PREVIEW ]` idiom; extract HTTP-method colours into one shared map used
+      by both `curl-to-fetch` and `api-client`.
+
+**Acceptance:** grep for each retired class string returns zero hits in `src/tools`; the P1 lint gate
+passes; visual diff against the P0 screenshots shows only intended changes.
+
+### P4 — Structural convergence
+
+Higher-risk, one PR per tool group.
+
+- [ ] **F3 (chrome):** move the 16 bypassing tools onto `Toolbar`/`ToolbarGroup`. Start with
+      `api-client` — it is the closest (a hand-rolled row that is one prop from correct) and the most
+      visible.
+- [ ] **F3 (slot abuse):** move `case-converter` and `hash-generator`'s input forms out of the
+      `toolbar` slot into the body. These two will look different afterwards; that is the point.
+- [ ] **F5:** move `snippets`, `prompt-templates`, and `api-client` onto `MasterDetailLayout`
+      wrapped in `ToolLayout`. Decide at this point whether the `ToolLayout.header` slot earns its
+      keep — if `MasterDetailLayout` owns the sidebar title, delete the slot (F5 says it is dead).
+- [ ] **F4:** adopt `Panel` at the 4 hand-rolled sites, and for the section stacks in
+      `uuid-generator` and `color-converter` (currently bare `<section>` + `<h2>`).
+- [ ] **F13 (csv):** define which level owns the toolbar in `csv-tools` and collapse the stacked
+      toolbars accordingly.
+
+**Acceptance:** all 30 tools render through `ToolLayout`; `grep -L ToolLayout src/tools/*/[A-Z]*.tsx`
+returns only sub-components; no tool has more than one chrome row unless it uses `Toolbar` twice
+deliberately.
+
+### P5 — Behaviour and polish
+
+- [ ] **F7:** adopt `SplitPane` in the 15 fixed-50/50 tools, persisting ratio per tool via
+      `storageKey`. Prioritise `diff-viewer`, `json-tools`, `markdown-editor`, `regex-tester`.
+- [ ] **F11:** write down the primary-action rule ("live-computing tools have no primary action;
+      action-triggered tools have exactly one"), then fix the 5 tools with 2+.
+- [ ] **F12 follow-up:** re-verify `DESIGN_SYSTEM.md` against the post-P4 code and add a short
+      "adding a new tool" checklist pointing at the target contract in §4.
+- [ ] Re-shoot the P0 screenshots and diff. Attach the before/after to the final PR.
+
+**Acceptance:** all four gates green; screenshot diff reviewed; `DESIGN_SYSTEM.md` re-verified.
+
+---
+
+## 6. Current snapshot
+
+Baseline recorded 2026-08-19 at `19af685`, all from `apps/cockpit` (never the monorepo root).
+
+| Gate       | Command                          | Baseline         | After P2         |
+| ---------- | -------------------------------- | ---------------- | ---------------- |
+| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             |
+| Tests      | `bunx vitest run`                | 109 files / 1314 | 114 files / 1338 |
+| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings |
+| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     |
+| Rust       | `cargo check` (from `src-tauri`) | Pass             | Pass (untouched) |
+
+Re-run and update this table at the end of every phase.
+
+---
+
+## 7. Per-tool worklist
+
+`T` = `Toolbar` adoption (F3) · `L` = `SectionLabel` (F1) · `P` = `PaneHeader` (F2) ·
+`S` = `SplitPane` (F7) · `K` = `Kbd` (F6) · `F` = `Field` (F9) · `N` = `Panel` (F4) ·
+`M` = `MasterDetailLayout` (F5)
+
+| Tool                  | Work        | Notes                                                    |
+| --------------------- | ----------- | -------------------------------------------------------- |
+| api-client            | T L P S K M | Hand-rolled `px-3 py-2` row; third master–detail shell   |
+| base64                | K S         | Already exemplary — use as the reference implementation  |
+| case-converter        | T L S       | Input form lives in the `toolbar` slot                   |
+| code-formatter        | K           | `DocumentToolbar` user; near-clean                       |
+| color-converter       | T L N F     | `text-[9px]` off-scale; `font-mono` `<h2>` sections      |
+| css-specificity       | P L         | Verbatim pane-header copy                                |
+| css-to-tailwind       | T P S       | Verbatim pane-header copy; no `Toolbar`                  |
+| css-validator         | L K         | `<h2>` label idiom E                                     |
+| csv-tools (+3 subs)   | T L N       | Stacked sub-tool toolbars; 2 hand-rolled panels          |
+| curl-to-fetch         | T P S       | Inline `color-mix` method chip → shared map              |
+| diff-viewer           | T S K       | Highest-value `SplitPane` target                         |
+| docs-browser          | —           | Clean                                                    |
+| hash-generator        | T L S       | Input form in the `toolbar` slot                         |
+| html-validator        | L K         | Label idioms A + E in one file                           |
+| image-tool            | L F         | 5× idiom B; 6 hand-rolled labels; 3 raw `<button>`       |
+| json-schema-validator | L S K       | 2× idiom A                                               |
+| json-tools            | L S K       | 3 raw `<button>`; prime `SplitPane` target               |
+| jwt-decoder           | T L S       | No `ToolLayout` toolbar at all                           |
+| markdown-editor       | S K         | `SelectionContextToolbar` user; otherwise clean          |
+| mermaid-editor        | S K         | Clean chrome                                             |
+| placeholder           | —           | Trivial                                                  |
+| prompt-templates      | T L P S M F | Worst offender: `[ 03-PREVIEW ]`, 10 labels, 4 primaries |
+| refactoring-toolkit   | L K         | Clean chrome                                             |
+| regex-tester          | P S         | Verbatim pane-header copy                                |
+| snippets              | T L P S M K | Own `<h1>`; no `ToolLayout`                              |
+| timestamp-converter   | L           | Second chrome row hand-rolled at `px-4 py-3`             |
+| ts-playground         | L K         | —                                                        |
+| url-codec             | T P S K     | Verbatim pane-header copy; bare `⌘↵` span                |
+| uuid-generator        | T L N       | 4× `font-mono text-sm` `<h2>`; 2 primaries               |
+| xml-tools             | L K         | 1 raw `<button>`                                         |
+| yaml-tools            | L K         | 3 raw `<button>`; 2 primaries                            |
+
+---
+
+## 8. Out of scope
+
+- Shell chrome (`Sidebar`, `TitleBar`, `StatusBar`, `CommandPalette`, `SettingsPanel`,
+  `NotesDrawer`) — except where P2 lifts code _out_ of it (`SplitPane` from `NotesDrawer`, `Kbd` from
+  `CommandPalette`/`ShortcutsModal`).
+- Theming and the token set itself. Tokens are sound; this programme changes how tools _consume_
+  them, not what they are.
+- Any change to tool behaviour, parsing, or output. This is chrome only.
+- New tools. The Cron Parser gap tracked previously is still open and unaffected by this work.
+
+## 9. Risks
+
+- **P3 is a wide mechanical diff.** ~25 files of class-string replacement is exactly the shape of
+  change where a subtle regression hides. Mitigation: the P0 screenshots, and splitting P3 by
+  finding rather than by tool so each diff is one substitution repeated.
+- **Tests assert on class strings in places.** Expect breakage in `src/components/shared/__tests__`
+  and in tool tests that query by styled text. Prefer fixing the test to assert on role/text over
+  re-asserting the new class string.
+- **`SplitPane` (P5) changes layout maths in 15 tools** and is the only phase touching behaviour.
+  It is last for that reason and can be dropped without invalidating P1–P4.

--- a/apps/cockpit/eslint.config.js
+++ b/apps/cockpit/eslint.config.js
@@ -82,8 +82,10 @@ export default [
     // for what's already available before adding one.
     //
     // Exemptions are per-line `eslint-disable-next-line no-restricted-syntax`
-    // comments with a stated reason — see the P2 section of documentation/TODO.md
-    // for the categories that legitimately survive.
+    // comments with a stated reason. The class-string half of the same contract
+    // (type scale, icon scale, focus rings, colour tokens) is enforced by
+    // scripts/lint-design-system.mjs, which `bun run lint` chains after ESLint —
+    // see documentation/DESIGN_SYSTEM.md § Enforcement.
     files: ['src/tools/**/*.tsx'],
     rules: {
       'no-restricted-syntax': [

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -10,7 +10,8 @@
     "tauri": "tauri",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src --ext .ts,.tsx,.js,.jsx --max-warnings 0",
+    "lint": "eslint src --ext .ts,.tsx,.js,.jsx --max-warnings 0 && bun run lint:ds",
+    "lint:ds": "bun scripts/lint-design-system.mjs",
     "smoke:report": "bun scripts/create-smoke-report.mjs",
     "clean": "rm -rf node_modules dist src-tauri/target",
     "clean-js": "bun scripts/clean-js.mjs"

--- a/apps/cockpit/scripts/lint-design-system.mjs
+++ b/apps/cockpit/scripts/lint-design-system.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+/**
+ * Design-system lint gate.
+ *
+ * ESLint can only see `className="literal"`; roughly a third of the styling in this app is built
+ * in template literals or ternaries, which is exactly where the drift documented in
+ * documentation/TODO.md § F1/F8/F10/F12 accumulated. This walks the raw source text instead, so a
+ * violation cannot hide inside an interpolation.
+ *
+ * Every rule here encodes a decision recorded in documentation/DESIGN_SYSTEM.md. If you need to
+ * change a rule, change the doc in the same commit — a gate that disagrees with the doc teaches
+ * contributors to ignore both.
+ *
+ * Escape hatch: `/* design-system-ignore: <reason> *​/` on the line above. Reason is mandatory.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const ROOT = new URL('..', import.meta.url).pathname
+const SRC = join(ROOT, 'src')
+
+const RULES = [
+  {
+    id: 'off-scale-text',
+    // `text-[9px]` / `text-[11px]` bypass the --text-* scale, so they don't move when the scale
+    // does and they read as a different size on every theme's font stack.
+    pattern: /text-\[\d+px\]/g,
+    message: 'Off-scale font size. Use text-2xs / text-xs / text-sm from the documented scale.',
+  },
+  {
+    id: 'legacy-focus-ring',
+    // Two focus treatments render visibly differently side by side. --focus-ring is the one with
+    // the background-coloured offset layer that stays visible on any surface.
+    pattern: /focus-visible:ring(?!-offset\b)[-\[]/g,
+    message:
+      'Use focus-visible:shadow-[var(--focus-ring)] rather than a ring utility (see DESIGN_SYSTEM.md § Focus).',
+  },
+  {
+    id: 'hardcoded-colour',
+    // Hardcoding any colour breaks 22 themes at once, and does it silently — the app only looks
+    // wrong under the themes nobody ran locally.
+    pattern: /(?:className|class)=(?:"[^"]*|'[^']*|\{`[^`]*)(#[0-9a-fA-F]{3,8}\b|rgba?\()/g,
+    message: 'Hardcoded colour in a class. Use a --color-* token.',
+  },
+  {
+    id: 'tailwind-palette',
+    // Same failure as above, one step less obvious.
+    pattern:
+      /\b(?:bg|text|border|ring|fill|stroke)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}\b/g,
+    message: 'Tailwind palette colour. Use a --color-* token.',
+  },
+  {
+    id: 'off-scale-icon',
+    // The audit found six icon sizes doing the work of three. 10/11/13/15 are the strays.
+    pattern: /\bsize=\{(?:10|11|13|15)\}/g,
+    message:
+      'Off-scale icon size. Use 12 (dense/inline), 14 (toolbar) or 16 (navigation) — DESIGN_SYSTEM.md § Icons.',
+    files: /\.tsx$/,
+  },
+]
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === '__mocks__') continue
+      walk(full, out)
+    } else if (/\.tsx?$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const violations = []
+
+for (const file of walk(SRC)) {
+  const text = readFileSync(file, 'utf8')
+  const lines = text.split('\n')
+
+  for (const rule of RULES) {
+    if (rule.files && !rule.files.test(file)) continue
+    lines.forEach((line, i) => {
+      rule.pattern.lastIndex = 0
+      const match = rule.pattern.exec(line)
+      if (!match) return
+      // An ignore comment on the preceding line, with a reason after the colon.
+      const previous = lines[i - 1] ?? ''
+      if (/design-system-ignore:\s*\S/.test(previous)) return
+      violations.push({
+        file: relative(ROOT, file),
+        line: i + 1,
+        rule: rule.id,
+        match: match[0].trim(),
+        message: rule.message,
+      })
+    })
+  }
+}
+
+if (violations.length === 0) {
+  console.log('design-system: no violations')
+  process.exit(0)
+}
+
+for (const v of violations) {
+  console.error(`${v.file}:${v.line}  [${v.rule}]  ${v.match}\n    ${v.message}`)
+}
+console.error(`\ndesign-system: ${violations.length} violation(s)`)
+process.exit(1)

--- a/apps/cockpit/src/components/shared/Field.tsx
+++ b/apps/cockpit/src/components/shared/Field.tsx
@@ -2,6 +2,14 @@ import type { ReactNode } from 'react'
 
 type FieldProps = {
   label: string
+  /**
+   * The id of the control this labels. Pass it when the field holds more than one interactive
+   * element — a text input next to a button, say — because a wrapping label forwards clicks to
+   * whichever labelable descendant comes first, which in that layout is the wrong one.
+   *
+   * Omit it for the ordinary one-control field and the wrapper becomes the `<label>` itself, so
+   * the association is structural and there's no id to keep in sync.
+   */
   htmlFor?: string
   hint?: string
   error?: string
@@ -10,9 +18,15 @@ type FieldProps = {
   className?: string
 }
 
-// Vertical label-above-control wrapper — matches the `<label>` + control
-// pattern already hand-rolled across tools/modals (e.g. SaveRequestModal's
-// "Request Name" field, AuthTab's field rows).
+/**
+ * Vertical label-above-control field.
+ *
+ * The audit found this hand-rolled in sixteen files, and in most of them the `<label>` was a bare
+ * sibling of the control with no `htmlFor` and nothing wrapped — markup that renders identically
+ * and labels nothing at all. Clicking the text did nothing and a screen reader announced the input
+ * unnamed. That's the failure this primitive exists to make unrepeatable, which is why the default
+ * path needs no id from the caller.
+ */
 export function Field({
   label,
   htmlFor,
@@ -22,12 +36,22 @@ export function Field({
   children,
   className = '',
 }: FieldProps) {
+  const Wrapper = htmlFor ? 'div' : 'label'
+
   return (
-    <div className={`flex flex-col gap-1 ${className}`}>
-      <label htmlFor={htmlFor} className="font-mono text-xs text-[var(--color-text-muted)]">
-        {label}
-        {required && <span className="text-[var(--color-error)]"> *</span>}
-      </label>
+    <Wrapper className={`flex flex-col gap-1 ${className}`}>
+      {/* font-ui, not font-mono: a field name is chrome naming the control, not content. */}
+      {htmlFor ? (
+        <label htmlFor={htmlFor} className="font-ui text-xs text-[var(--color-text-muted)]">
+          {label}
+          {required && <span className="text-[var(--color-error)]"> *</span>}
+        </label>
+      ) : (
+        <span className="font-ui text-xs text-[var(--color-text-muted)]">
+          {label}
+          {required && <span className="text-[var(--color-error)]"> *</span>}
+        </span>
+      )}
       {children}
       {error ? (
         <span role="alert" className="text-2xs text-[var(--color-error)]">
@@ -36,6 +60,6 @@ export function Field({
       ) : (
         hint && <span className="text-2xs text-[var(--color-text-muted)]">{hint}</span>
       )}
-    </div>
+    </Wrapper>
   )
 }

--- a/apps/cockpit/src/components/shared/Field.tsx
+++ b/apps/cockpit/src/components/shared/Field.tsx
@@ -11,7 +11,11 @@ type FieldProps = {
    * the association is structural and there's no id to keep in sync.
    */
   htmlFor?: string
-  hint?: string
+  /**
+   * `ReactNode` rather than `string` because a hint is often a live read-out of the control above
+   * it — a detected case, a byte count, a match badge — not a static sentence.
+   */
+  hint?: ReactNode
   error?: string
   required?: boolean
   children: ReactNode

--- a/apps/cockpit/src/components/shared/Kbd.tsx
+++ b/apps/cockpit/src/components/shared/Kbd.tsx
@@ -7,6 +7,14 @@ type KbdProps = {
    * describes the way a hardcoded "⌘↵" string does on Windows.
    */
   keys: string
+  /**
+   * `boxed` is the standalone hint — a shortcut listed beside the thing it triggers.
+   *
+   * `inline` is the hint *inside* the control itself ("Format ⌘↵"), where a border and a surface
+   * fill read as a second button nested in the first. It keeps the platform mapping and drops
+   * only the chrome, which is the whole reason these sites hardcoded ⌘ and lied on Windows.
+   */
+  variant?: 'boxed' | 'inline'
   className?: string
 }
 
@@ -40,7 +48,7 @@ const KEY_SYMBOLS: Record<string, string> = {
  * Replaces three competing treatments: bare muted spans in the tools, and two `<kbd>` copies in
  * the shell that disagreed on font size (10px vs 11px, both off the type scale).
  */
-export function Kbd({ keys, className = '' }: KbdProps) {
+export function Kbd({ keys, variant = 'boxed', className = '' }: KbdProps) {
   const { isMac } = usePlatform()
 
   const label = keys
@@ -56,10 +64,13 @@ export function Kbd({ keys, className = '' }: KbdProps) {
     // separator elsewhere, where they aren't (Ctrl+Shift+P).
     .join(isMac ? '' : '+')
 
+  const chrome =
+    variant === 'inline'
+      ? 'opacity-70'
+      : 'rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 text-[var(--color-text-muted)]'
+
   return (
-    <kbd
-      className={`font-mono inline-flex shrink-0 items-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 text-2xs text-[var(--color-text-muted)] ${className}`}
-    >
+    <kbd className={`font-mono inline-flex shrink-0 items-center text-2xs ${chrome} ${className}`}>
       {label}
     </kbd>
   )

--- a/apps/cockpit/src/components/shared/Kbd.tsx
+++ b/apps/cockpit/src/components/shared/Kbd.tsx
@@ -1,4 +1,5 @@
 import { usePlatform } from '@/hooks/usePlatform'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type KbdProps = {
   /**
@@ -18,30 +19,6 @@ type KbdProps = {
   className?: string
 }
 
-// Symbols only where they're unambiguous and universally read. "Enter" beats ↵ for a modifier-less
-// hint, but ⌘↵ is the idiom every Mac user already knows, so the symbol wins inside a combo.
-const KEY_SYMBOLS: Record<string, string> = {
-  enter: '↵',
-  return: '↵',
-  escape: 'Esc',
-  esc: 'Esc',
-  shift: '⇧',
-  alt: '⌥',
-  option: '⌥',
-  ctrl: '⌃',
-  control: '⌃',
-  cmd: '⌘',
-  meta: '⌘',
-  backspace: '⌫',
-  delete: '⌦',
-  tab: '⇥',
-  space: 'Space',
-  up: '↑',
-  down: '↓',
-  left: '←',
-  right: '→',
-}
-
 /**
  * A keyboard hint.
  *
@@ -51,18 +28,7 @@ const KEY_SYMBOLS: Record<string, string> = {
 export function Kbd({ keys, variant = 'boxed', className = '' }: KbdProps) {
   const { isMac } = usePlatform()
 
-  const label = keys
-    .split('+')
-    .map((raw) => {
-      const key = raw.trim().toLowerCase()
-      if (key === 'mod') return isMac ? '⌘' : 'Ctrl'
-      const symbol = KEY_SYMBOLS[key]
-      if (symbol) return symbol
-      return key.length === 1 ? key.toUpperCase() : raw.trim()
-    })
-    // No separator on macOS, where modifiers are conventionally run together (⌘⇧P), but a
-    // separator elsewhere, where they aren't (Ctrl+Shift+P).
-    .join(isMac ? '' : '+')
+  const label = formatShortcut(keys, isMac)
 
   const chrome =
     variant === 'inline'

--- a/apps/cockpit/src/components/shared/Kbd.tsx
+++ b/apps/cockpit/src/components/shared/Kbd.tsx
@@ -1,0 +1,66 @@
+import { usePlatform } from '@/hooks/usePlatform'
+
+type KbdProps = {
+  /**
+   * Combo in the same notation as `useKeyboardShortcut`: `mod+enter`, `shift+alt+f`, `escape`.
+   * `mod` renders ⌘ on macOS and Ctrl elsewhere, so a hint can't drift from the binding it
+   * describes the way a hardcoded "⌘↵" string does on Windows.
+   */
+  keys: string
+  className?: string
+}
+
+// Symbols only where they're unambiguous and universally read. "Enter" beats ↵ for a modifier-less
+// hint, but ⌘↵ is the idiom every Mac user already knows, so the symbol wins inside a combo.
+const KEY_SYMBOLS: Record<string, string> = {
+  enter: '↵',
+  return: '↵',
+  escape: 'Esc',
+  esc: 'Esc',
+  shift: '⇧',
+  alt: '⌥',
+  option: '⌥',
+  ctrl: '⌃',
+  control: '⌃',
+  cmd: '⌘',
+  meta: '⌘',
+  backspace: '⌫',
+  delete: '⌦',
+  tab: '⇥',
+  space: 'Space',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+}
+
+/**
+ * A keyboard hint.
+ *
+ * Replaces three competing treatments: bare muted spans in the tools, and two `<kbd>` copies in
+ * the shell that disagreed on font size (10px vs 11px, both off the type scale).
+ */
+export function Kbd({ keys, className = '' }: KbdProps) {
+  const { isMac } = usePlatform()
+
+  const label = keys
+    .split('+')
+    .map((raw) => {
+      const key = raw.trim().toLowerCase()
+      if (key === 'mod') return isMac ? '⌘' : 'Ctrl'
+      const symbol = KEY_SYMBOLS[key]
+      if (symbol) return symbol
+      return key.length === 1 ? key.toUpperCase() : raw.trim()
+    })
+    // No separator on macOS, where modifiers are conventionally run together (⌘⇧P), but a
+    // separator elsewhere, where they aren't (Ctrl+Shift+P).
+    .join(isMac ? '' : '+')
+
+  return (
+    <kbd
+      className={`font-mono inline-flex shrink-0 items-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 text-2xs text-[var(--color-text-muted)] ${className}`}
+    >
+      {label}
+    </kbd>
+  )
+}

--- a/apps/cockpit/src/components/shared/MasterDetailLayout.tsx
+++ b/apps/cockpit/src/components/shared/MasterDetailLayout.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+import { Button } from './Button'
+import { SidebarSimpleIcon } from '@phosphor-icons/react'
+
+type MasterDetailLayoutProps = {
+  /** Library/list side. Rendered inside an `<aside>` — don't add your own. */
+  sidebar: ReactNode
+  /** Sidebar heading. Library tools legitimately show their own title; the tab strip names the
+   *  tool, this names the collection inside it. */
+  title: string
+  /** Muted subtitle under the title — usually a count. */
+  subtitle?: ReactNode
+  /** Primary action for the collection, e.g. a "New" button. */
+  sidebarActions?: ReactNode
+  children: ReactNode
+  /** Controlled collapse. Omit both to render a permanently visible sidebar. */
+  sidebarOpen?: boolean
+  onToggleSidebar?: () => void
+  className?: string
+}
+
+/**
+ * Sidebar-plus-detail shell for library-style tools (snippets, prompt templates, saved requests).
+ *
+ * Those three tools each hand-rolled this and arrived somewhere different: two bypassed
+ * `ToolLayout` entirely with their own `<h1>`, the third nested a sidebar beside a `fullBleed`
+ * body. Same shape, three implementations, three sets of breakpoints.
+ *
+ * The sidebar is a fixed-width column rather than a `SplitPane` on purpose — a list of names has
+ * a right width, and making it draggable adds a decision without adding a capability.
+ */
+export function MasterDetailLayout({
+  sidebar,
+  title,
+  subtitle,
+  sidebarActions,
+  children,
+  sidebarOpen = true,
+  onToggleSidebar,
+  className = '',
+}: MasterDetailLayoutProps) {
+  return (
+    <div className={`flex h-full min-h-0 bg-[var(--color-bg)] ${className}`}>
+      <aside
+        aria-label={title}
+        // Narrows below 1100px viewport, matching the breakpoint SnippetsManager already used.
+        // It's a viewport query rather than a container query because the workspace isn't a
+        // `@container` — worth revisiting if one is ever introduced, since the app sidebar and
+        // notes drawer both steal width this query can't see.
+        className={`flex min-h-0 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-[width,opacity] duration-200 ease-in-out ${
+          sidebarOpen
+            ? 'w-64 opacity-100 max-[1100px]:w-52'
+            : 'pointer-events-none w-0 overflow-hidden border-r-0 opacity-0'
+        }`}
+      >
+        <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-[var(--color-border)] px-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="font-ui truncate text-sm font-semibold text-[var(--color-text)]">
+              {title}
+            </h2>
+            {subtitle && (
+              <p className="truncate text-2xs text-[var(--color-text-muted)]">{subtitle}</p>
+            )}
+          </div>
+          {sidebarActions}
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col">{sidebar}</div>
+      </aside>
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {onToggleSidebar && (
+          <div className="flex shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1">
+            <Button
+              variant="icon"
+              size="sm"
+              onClick={onToggleSidebar}
+              aria-expanded={sidebarOpen}
+              aria-label={sidebarOpen ? `Hide ${title}` : `Show ${title}`}
+              className={sidebarOpen ? 'text-[var(--color-accent)]' : undefined}
+            >
+              <SidebarSimpleIcon size={14} aria-hidden="true" />
+            </Button>
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/cockpit/src/components/shared/PaneHeader.tsx
+++ b/apps/cockpit/src/components/shared/PaneHeader.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+import { SectionLabel } from './SectionLabel'
+
+type PaneHeaderProps = {
+  title: ReactNode
+  /** Muted detail beside the title — a line count, a byte size, a language. */
+  hint?: ReactNode
+  /**
+   * Live outcome for this pane specifically (parse state, match count). Announced politely.
+   * Static context that never settles belongs in `hint`, which isn't announced.
+   */
+  status?: ReactNode
+  /** Trailing controls — usually a `CopyButton` or a one-icon action. */
+  actions?: ReactNode
+  className?: string
+}
+
+/**
+ * The header strip above one pane of a split.
+ *
+ * This existed as a copy-pasted class string in five tools and as three differently-padded
+ * variants in five more. None of the copies had an actions slot, which is why `CopyButton`
+ * placement wandered pane to pane — some tools put it in the tool toolbar, some floated it over
+ * the pane, some left it out.
+ */
+export function PaneHeader({ title, hint, status, actions, className = '' }: PaneHeaderProps) {
+  return (
+    <div
+      className={`flex min-h-8 shrink-0 items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 ${className}`}
+    >
+      <SectionLabel className="min-w-0 flex-1" hint={hint}>
+        <span className="truncate">{title}</span>
+      </SectionLabel>
+      {status && (
+        <span
+          role="status"
+          aria-live="polite"
+          className="min-w-0 truncate text-2xs text-[var(--color-text-muted)]"
+        >
+          {status}
+        </span>
+      )}
+      {actions && <div className="flex shrink-0 items-center gap-1">{actions}</div>}
+    </div>
+  )
+}

--- a/apps/cockpit/src/components/shared/SectionLabel.tsx
+++ b/apps/cockpit/src/components/shared/SectionLabel.tsx
@@ -1,6 +1,6 @@
-import type { ElementType, ReactNode } from 'react'
+import type { ElementType, HTMLAttributes, ReactNode } from 'react'
 
-type SectionLabelProps = {
+type SectionLabelProps = HTMLAttributes<HTMLElement> & {
   children: ReactNode
   /**
    * Document structure, chosen independently of the visual — which is identical either way.
@@ -10,7 +10,7 @@ type SectionLabelProps = {
    * Pick `span` for a label that names a region of the current view, and a heading level for
    * something that belongs in the document outline.
    */
-  as?: Extract<ElementType, 'span' | 'div' | 'h2' | 'h3' | 'h4'>
+  as?: Extract<ElementType, 'span' | 'div' | 'legend' | 'h2' | 'h3' | 'h4' | 'h5'>
   /** Trailing muted detail on the same line — a count, a size, a state. Not uppercased. */
   hint?: ReactNode
   className?: string
@@ -29,9 +29,11 @@ export function SectionLabel({
   as: Tag = 'span',
   hint,
   className = '',
+  ...rest
 }: SectionLabelProps) {
   return (
     <Tag
+      {...rest}
       className={`font-ui flex items-center gap-2 text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)] ${className}`}
     >
       {children}

--- a/apps/cockpit/src/components/shared/SectionLabel.tsx
+++ b/apps/cockpit/src/components/shared/SectionLabel.tsx
@@ -1,0 +1,41 @@
+import type { ElementType, ReactNode } from 'react'
+
+type SectionLabelProps = {
+  children: ReactNode
+  /**
+   * Document structure, chosen independently of the visual — which is identical either way.
+   *
+   * The audit found `<h2>` used for pane labels that aren't headings and `<span>` used for
+   * genuine section headings, because the two decisions were welded together by copy-paste.
+   * Pick `span` for a label that names a region of the current view, and a heading level for
+   * something that belongs in the document outline.
+   */
+  as?: Extract<ElementType, 'span' | 'div' | 'h2' | 'h3' | 'h4'>
+  /** Trailing muted detail on the same line — a count, a size, a state. Not uppercased. */
+  hint?: ReactNode
+  className?: string
+}
+
+/**
+ * The small uppercase label that names a region.
+ *
+ * Before this existed there were seven idioms for it, varying on font (`font-ui` vs `font-mono`),
+ * weight (`medium`/`semibold`/`bold`) and tracking (`wide`/`wider`/`widest`) with no rule
+ * distinguishing them — which is most of why the tools read as different apps. It's `font-ui`
+ * because a label naming a monospace region is chrome, not content.
+ */
+export function SectionLabel({
+  children,
+  as: Tag = 'span',
+  hint,
+  className = '',
+}: SectionLabelProps) {
+  return (
+    <Tag
+      className={`font-ui flex items-center gap-2 text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)] ${className}`}
+    >
+      {children}
+      {hint && <span className="font-normal normal-case tracking-normal opacity-80">{hint}</span>}
+    </Tag>
+  )
+}

--- a/apps/cockpit/src/components/shared/SplitPane.tsx
+++ b/apps/cockpit/src/components/shared/SplitPane.tsx
@@ -167,59 +167,60 @@ export function SplitPane({
   const [first, second] = children
   const percent = `${(ratio * 100).toFixed(2)}%`
 
-  if (stacked) {
-    return (
-      <div className={`flex min-h-0 min-w-0 flex-1 flex-col ${className}`}>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{first}</div>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-[var(--color-border)]">
-          {second}
-        </div>
-      </div>
-    )
-  }
-
+  // One JSX shape for both states, deliberately. Stacking used to be a second `return` with two
+  // children instead of three, which moved `second` from index 2 to index 1 — React reconciles
+  // positionally, so crossing the breakpoint unmounted that pane and mounted a fresh one. In a tool
+  // whose pane holds a Monaco editor, that silently discards cursor, scroll and undo history every
+  // time the window is dragged past the width. Stacked, the divider stays in the tree and degrades
+  // to a plain rule: not focusable, not a `separator`, nothing to drag, but still child index 1.
   return (
     <div
       ref={containerRef}
       className={`flex min-h-0 min-w-0 flex-1 ${isHorizontal ? 'flex-row' : 'flex-col'} ${className}`}
     >
       <div
-        className="flex min-h-0 min-w-0 flex-col overflow-hidden"
-        style={isHorizontal ? { width: percent } : { height: percent }}
+        className={`flex min-h-0 min-w-0 flex-col overflow-hidden ${stacked ? 'flex-1' : ''}`}
+        // No inline size when stacked: the panes share the height evenly and there's no ratio to
+        // apply. An inline width here is also what makes `max-[900px]:flex-col` unusable.
+        style={stacked ? undefined : isHorizontal ? { width: percent } : { height: percent }}
       >
         {first}
       </div>
 
-      <div
-        role="separator"
-        tabIndex={0}
-        aria-label={ariaLabel ?? 'Resize panes'}
-        aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
-        aria-valuenow={Math.round(ratio * 100)}
-        aria-valuemin={Math.round(minRatio * 100)}
-        aria-valuemax={Math.round((1 - minRatio) * 100)}
-        aria-controls={labelId}
-        onMouseDown={(event) => {
-          event.preventDefault()
-          setDragging(true)
-        }}
-        onDoubleClick={() => commit(defaultRatio)}
-        onKeyDown={handleKeyDown}
-        title="Drag to resize — double-click or Enter to reset"
-        className={`group relative shrink-0 border-[var(--color-border)] bg-[var(--color-border)] transition-colors focus-visible:outline-none focus-visible:bg-[var(--color-accent)] ${
-          isHorizontal ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize'
-        } ${dragging ? 'bg-[var(--color-accent)]' : 'hover:bg-[var(--color-accent)]/60'}`}
-      >
-        {/* The visible divider is 1px so it reads as a border rather than a widget; this
-            invisible overlay gives the pointer a 9px target without that showing up in the
-            layout. Below ~8px a divider is measurably annoying to grab. */}
-        <span
-          aria-hidden="true"
-          className={`absolute ${
-            isHorizontal ? '-left-1 top-0 h-full w-[9px]' : '-top-1 left-0 h-[9px] w-full'
-          }`}
-        />
-      </div>
+      {stacked ? (
+        <div aria-hidden="true" className="h-px shrink-0 bg-[var(--color-border)]" />
+      ) : (
+        <div
+          role="separator"
+          tabIndex={0}
+          aria-label={ariaLabel ?? 'Resize panes'}
+          aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
+          aria-valuenow={Math.round(ratio * 100)}
+          aria-valuemin={Math.round(minRatio * 100)}
+          aria-valuemax={Math.round((1 - minRatio) * 100)}
+          aria-controls={labelId}
+          onMouseDown={(event) => {
+            event.preventDefault()
+            setDragging(true)
+          }}
+          onDoubleClick={() => commit(defaultRatio)}
+          onKeyDown={handleKeyDown}
+          title="Drag to resize — double-click or Enter to reset"
+          className={`group relative shrink-0 border-[var(--color-border)] bg-[var(--color-border)] transition-colors focus-visible:outline-none focus-visible:bg-[var(--color-accent)] ${
+            isHorizontal ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize'
+          } ${dragging ? 'bg-[var(--color-accent)]' : 'hover:bg-[var(--color-accent)]/60'}`}
+        >
+          {/* The visible divider is 1px so it reads as a border rather than a widget; this
+              invisible overlay gives the pointer a 9px target without that showing up in the
+              layout. Below ~8px a divider is measurably annoying to grab. */}
+          <span
+            aria-hidden="true"
+            className={`absolute ${
+              isHorizontal ? '-left-1 top-0 h-full w-[9px]' : '-top-1 left-0 h-[9px] w-full'
+            }`}
+          />
+        </div>
+      )}
 
       <div id={labelId} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {second}

--- a/apps/cockpit/src/components/shared/SplitPane.tsx
+++ b/apps/cockpit/src/components/shared/SplitPane.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from 'react'
+
+type SplitPaneProps = {
+  /** Exactly two panes. A three-way split is a nested `SplitPane`, not a third child. */
+  children: [ReactNode, ReactNode]
+  direction?: 'horizontal' | 'vertical'
+  /** First pane's share of the container, 0–1. Used when nothing is persisted. */
+  defaultRatio?: number
+  /**
+   * Persists the ratio under `cockpit.split.<key>`. Omit for a split whose sizing shouldn't
+   * outlive the view. Tools should pass one — re-dragging the same divider every session is
+   * exactly the kind of small tax this app exists to remove.
+   */
+  storageKey?: string
+  /** Smallest share either pane can be dragged to, 0–0.5. Keeps a pane from vanishing. */
+  minRatio?: number
+  'aria-label'?: string
+  className?: string
+}
+
+const STORAGE_PREFIX = 'cockpit.split.'
+const KEYBOARD_STEP = 0.02
+
+function readStoredRatio(storageKey: string | undefined, fallback: number): number {
+  if (!storageKey) return fallback
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + storageKey)
+    if (!raw) return fallback
+    const parsed = Number.parseFloat(raw)
+    return Number.isFinite(parsed) ? parsed : fallback
+  } catch {
+    // Private mode / disabled storage — a split that can't remember still has to render.
+    return fallback
+  }
+}
+
+/**
+ * Two panes with a draggable divider.
+ *
+ * Fifteen tools rendered a hard-coded 50/50 (`w-1/2` or `grid-cols-2`) before this existed. For
+ * something like the diff viewer or a JSON tree next to its output, the two sides are rarely
+ * equally dense, and a fixed split makes the app feel rigid in a way that's easy to stop noticing.
+ *
+ * The divider is a real `separator` with `aria-valuenow`, and resizes with arrow keys — a
+ * mouse-only divider is a keyboard-first app quietly excluding its own users.
+ */
+export function SplitPane({
+  children,
+  direction = 'horizontal',
+  defaultRatio = 0.5,
+  storageKey,
+  minRatio = 0.15,
+  'aria-label': ariaLabel,
+  className = '',
+}: SplitPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [ratio, setRatio] = useState(() => readStoredRatio(storageKey, defaultRatio))
+  const [dragging, setDragging] = useState(false)
+  const isHorizontal = direction === 'horizontal'
+  const labelId = useId()
+
+  const clamp = useCallback(
+    (value: number) => Math.min(1 - minRatio, Math.max(minRatio, value)),
+    [minRatio]
+  )
+
+  const commit = useCallback(
+    (next: number) => {
+      const clamped = clamp(next)
+      setRatio(clamped)
+      if (!storageKey) return
+      try {
+        window.localStorage.setItem(STORAGE_PREFIX + storageKey, clamped.toFixed(4))
+      } catch {
+        // Ratio still applies for this session; persistence is a nicety, not a requirement.
+      }
+    },
+    [clamp, storageKey]
+  )
+
+  // Listeners go on window, not the divider: the pointer routinely outruns a 4px target mid-drag,
+  // and a divider-scoped listener drops the drag the moment that happens.
+  useEffect(() => {
+    if (!dragging) return
+
+    const handleMove = (event: MouseEvent) => {
+      const container = containerRef.current
+      if (!container) return
+      const rect = container.getBoundingClientRect()
+      const size = isHorizontal ? rect.width : rect.height
+      if (size === 0) return
+      const offset = isHorizontal ? event.clientX - rect.left : event.clientY - rect.top
+      commit(offset / size)
+    }
+    const handleUp = () => setDragging(false)
+
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+    // Text selection across both panes while dragging looks broken and blocks the cursor change.
+    const previousSelect = document.body.style.userSelect
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = isHorizontal ? 'col-resize' : 'row-resize'
+
+    return () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+      document.body.style.userSelect = previousSelect
+      document.body.style.cursor = ''
+    }
+  }, [dragging, isHorizontal, commit])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const decrease = isHorizontal ? 'ArrowLeft' : 'ArrowUp'
+      const increase = isHorizontal ? 'ArrowRight' : 'ArrowDown'
+      if (event.key === decrease) {
+        event.preventDefault()
+        commit(ratio - KEYBOARD_STEP)
+      } else if (event.key === increase) {
+        event.preventDefault()
+        commit(ratio + KEYBOARD_STEP)
+      } else if (event.key === 'Home') {
+        event.preventDefault()
+        commit(minRatio)
+      } else if (event.key === 'End') {
+        event.preventDefault()
+        commit(1 - minRatio)
+      } else if (event.key === 'Enter') {
+        // Reset — the cheapest way back from a split dragged somewhere useless.
+        event.preventDefault()
+        commit(defaultRatio)
+      }
+    },
+    [commit, defaultRatio, isHorizontal, minRatio, ratio]
+  )
+
+  const [first, second] = children
+  const percent = `${(ratio * 100).toFixed(2)}%`
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex min-h-0 min-w-0 flex-1 ${isHorizontal ? 'flex-row' : 'flex-col'} ${className}`}
+    >
+      <div
+        className="flex min-h-0 min-w-0 flex-col overflow-hidden"
+        style={isHorizontal ? { width: percent } : { height: percent }}
+      >
+        {first}
+      </div>
+
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-label={ariaLabel ?? 'Resize panes'}
+        aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
+        aria-valuenow={Math.round(ratio * 100)}
+        aria-valuemin={Math.round(minRatio * 100)}
+        aria-valuemax={Math.round((1 - minRatio) * 100)}
+        aria-controls={labelId}
+        onMouseDown={(event) => {
+          event.preventDefault()
+          setDragging(true)
+        }}
+        onDoubleClick={() => commit(defaultRatio)}
+        onKeyDown={handleKeyDown}
+        title="Drag to resize — double-click or Enter to reset"
+        className={`group relative shrink-0 border-[var(--color-border)] bg-[var(--color-border)] transition-colors focus-visible:outline-none focus-visible:bg-[var(--color-accent)] ${
+          isHorizontal ? 'w-px cursor-col-resize' : 'h-px cursor-row-resize'
+        } ${dragging ? 'bg-[var(--color-accent)]' : 'hover:bg-[var(--color-accent)]/60'}`}
+      >
+        {/* The visible divider is 1px so it reads as a border rather than a widget; this
+            invisible overlay gives the pointer a 9px target without that showing up in the
+            layout. Below ~8px a divider is measurably annoying to grab. */}
+        <span
+          aria-hidden="true"
+          className={`absolute ${
+            isHorizontal ? '-left-1 top-0 h-full w-[9px]' : '-top-1 left-0 h-[9px] w-full'
+          }`}
+        />
+      </div>
+
+      <div id={labelId} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {second}
+      </div>
+    </div>
+  )
+}

--- a/apps/cockpit/src/components/shared/SplitPane.tsx
+++ b/apps/cockpit/src/components/shared/SplitPane.tsx
@@ -14,12 +14,40 @@ type SplitPaneProps = {
   storageKey?: string
   /** Smallest share either pane can be dragged to, 0–0.5. Keeps a pane from vanishing. */
   minRatio?: number
+  /**
+   * Viewport width (px) below which the panes stack and the divider disappears.
+   *
+   * Several tools already did this by hand with `max-[900px]:flex-col`, and without it here they
+   * couldn't adopt `SplitPane` at all — a ratio applied as an inline `width` beats any Tailwind
+   * breakpoint, so the responsive behaviour would silently stop working. Below the breakpoint
+   * there's no useful ratio to drag anyway: the panes want the full width and share the height.
+   */
+  stackBelow?: number
   'aria-label'?: string
   className?: string
 }
 
 const STORAGE_PREFIX = 'cockpit.split.'
 const KEYBOARD_STEP = 0.02
+
+/** `null` disables the query entirely, so `stackBelow` stays optional without a conditional hook. */
+function useMediaQuery(query: string | null): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    if (!query) {
+      setMatches(false)
+      return
+    }
+    const list = window.matchMedia(query)
+    setMatches(list.matches)
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches)
+    list.addEventListener('change', onChange)
+    return () => list.removeEventListener('change', onChange)
+  }, [query])
+
+  return matches
+}
 
 function readStoredRatio(storageKey: string | undefined, fallback: number): number {
   if (!storageKey) return fallback
@@ -50,13 +78,15 @@ export function SplitPane({
   defaultRatio = 0.5,
   storageKey,
   minRatio = 0.15,
+  stackBelow,
   'aria-label': ariaLabel,
   className = '',
 }: SplitPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [ratio, setRatio] = useState(() => readStoredRatio(storageKey, defaultRatio))
   const [dragging, setDragging] = useState(false)
-  const isHorizontal = direction === 'horizontal'
+  const stacked = useMediaQuery(stackBelow ? `(max-width: ${stackBelow - 1}px)` : null)
+  const isHorizontal = direction === 'horizontal' && !stacked
   const labelId = useId()
 
   const clamp = useCallback(
@@ -136,6 +166,17 @@ export function SplitPane({
 
   const [first, second] = children
   const percent = `${(ratio * 100).toFixed(2)}%`
+
+  if (stacked) {
+    return (
+      <div className={`flex min-h-0 min-w-0 flex-1 flex-col ${className}`}>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{first}</div>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-[var(--color-border)]">
+          {second}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/apps/cockpit/src/components/shared/ToolLayout.tsx
+++ b/apps/cockpit/src/components/shared/ToolLayout.tsx
@@ -1,16 +1,7 @@
 import type { ReactNode } from 'react'
 
-type ToolLayoutHeader = {
-  title: string
-  description?: string
-  actions?: ReactNode
-}
-
 type ToolLayoutProps = {
-  /** Optional title/description/actions row. Most tools skip this — the tool name already
-   *  lives in the sidebar/tab strip — but it's here for tools whose body needs its own heading. */
-  header?: ToolLayoutHeader
-  /** Rendered as-is above the body, below the header. Tools own their toolbar's internal
+  /** Rendered as-is above the body. Tools own their toolbar's internal
    *  layout (single row, wrapped rows, stacked rows) — ToolLayout only positions the slot. */
   toolbar?: ReactNode
   children: ReactNode
@@ -23,10 +14,16 @@ type ToolLayoutProps = {
   className?: string
 }
 
-// Layout contract shared by every tool: an optional header, an optional toolbar, and a body
-// that's either padded + width-capped (form-style tools) or edge-to-edge (editor-style tools).
+/**
+ * Layout contract shared by every tool: an optional toolbar and a body that's either padded +
+ * width-capped (form-style tools) or edge-to-edge (editor-style tools).
+ *
+ * There is deliberately no title slot. The tab strip names the tool, and the one family that
+ * legitimately shows a heading of its own — the library tools — names a *collection*, not the
+ * tool, which is `MasterDetailLayout`'s job. A `header` prop existed here for a while and reached
+ * zero consumers, while two tools hand-rolled the sidebar heading it couldn't express.
+ */
 export function ToolLayout({
-  header,
   toolbar,
   children,
   fullBleed = false,
@@ -35,21 +32,6 @@ export function ToolLayout({
 }: ToolLayoutProps) {
   return (
     <div className={`flex h-full flex-col ${className}`}>
-      {header && (
-        <div className="flex items-start justify-between gap-3 border-b border-[var(--color-border)] px-4 py-3">
-          <div className="min-w-0">
-            <h2 className="font-ui text-sm font-semibold text-[var(--color-text)]">
-              {header.title}
-            </h2>
-            {header.description && (
-              <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">{header.description}</p>
-            )}
-          </div>
-          {header.actions && (
-            <div className="flex shrink-0 items-center gap-2">{header.actions}</div>
-          )}
-        </div>
-      )}
       {toolbar && <div className="shrink-0 bg-[var(--color-surface)]">{toolbar}</div>}
       {fullBleed ? (
         <div className="flex flex-1 flex-col overflow-hidden">{children}</div>

--- a/apps/cockpit/src/components/shared/Toolbar.tsx
+++ b/apps/cockpit/src/components/shared/Toolbar.tsx
@@ -9,6 +9,8 @@ type ToolbarProps = {
   'aria-label'?: string
   /** Disable wrapping for horizontally scrollable editor toolbars. */
   wrap?: boolean
+  /** For a collapsible secondary row that a disclosure button's `aria-controls` points at. */
+  id?: string
 }
 
 // Horizontal control bar — codifies the
@@ -19,10 +21,12 @@ export function Toolbar({
   className = '',
   border = true,
   wrap = true,
+  id,
   'aria-label': ariaLabel,
 }: ToolbarProps) {
   return (
     <div
+      id={id}
       role="toolbar"
       aria-label={ariaLabel}
       className={`flex min-h-10 items-center gap-2 bg-[var(--color-surface)] px-4 py-2 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}

--- a/apps/cockpit/src/components/shared/__tests__/Field.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Field.test.tsx
@@ -12,6 +12,18 @@ describe('Field', () => {
     expect(screen.getByLabelText('Request Name')).toBeInTheDocument()
   })
 
+  it('wraps the control when no htmlFor is given, so the caller needs no id', () => {
+    // The hand-rolled version this replaces was a bare <label> sibling with no `for` — it
+    // rendered identically and labelled nothing, which is invisible until a screen reader
+    // reads the input unnamed.
+    render(
+      <Field label="Alt Text">
+        <input />
+      </Field>
+    )
+    expect(screen.getByLabelText('Alt Text')).toBeInTheDocument()
+  })
+
   it('shows a hint when there is no error', () => {
     render(
       <Field label="URL" hint="Must include protocol">

--- a/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Kbd } from '@/components/shared/Kbd'
+import { _resetPlatformCache } from '@/lib/platform'
+
+function setUserAgent(value: string) {
+  Object.defineProperty(navigator, 'userAgent', { value, configurable: true })
+  _resetPlatformCache()
+}
+
+const originalUserAgent = navigator.userAgent
+
+describe('Kbd', () => {
+  beforeEach(() => _resetPlatformCache())
+  afterEach(() => setUserAgent(originalUserAgent))
+
+  it('renders mod as the command symbol on macOS', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    render(<Kbd keys="mod+enter" />)
+    expect(screen.getByText('⌘↵')).toBeInTheDocument()
+  })
+
+  it('renders mod as Ctrl with a separator off macOS', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+    render(<Kbd keys="mod+enter" />)
+    // The whole point of the component: the same hint can't claim ⌘ on a Windows machine.
+    expect(screen.getByText('Ctrl+↵')).toBeInTheDocument()
+  })
+
+  it('uppercases single letters', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+    render(<Kbd keys="mod+shift+p" />)
+    expect(screen.getByText('⌘⇧P')).toBeInTheDocument()
+  })
+
+  it('renders a kbd element', () => {
+    render(<Kbd keys="escape" />)
+    expect(screen.getByText('Esc').tagName).toBe('KBD')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
@@ -23,8 +23,9 @@ describe('Kbd', () => {
   it('renders mod as Ctrl with a separator off macOS', () => {
     setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
     render(<Kbd keys="mod+enter" />)
-    // The whole point of the component: the same hint can't claim ⌘ on a Windows machine.
-    expect(screen.getByText('Ctrl+↵')).toBeInTheDocument()
+    // The whole point of the component: the same hint can't claim ⌘ on a Windows machine. The key
+    // names go with it — ↵ and ⇧ aren't printed on a PC keyboard either.
+    expect(screen.getByText('Ctrl+Enter')).toBeInTheDocument()
   })
 
   it('uppercases single letters', () => {

--- a/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Kbd.test.tsx
@@ -37,4 +37,12 @@ describe('Kbd', () => {
     render(<Kbd keys="escape" />)
     expect(screen.getByText('Esc').tagName).toBe('KBD')
   })
+
+  it('drops the border and fill for the inline variant', () => {
+    // Inline hints live inside the button they describe; a box there reads as a nested button.
+    const { rerender } = render(<Kbd keys="escape" />)
+    expect(screen.getByText('Esc').className).toContain('border')
+    rerender(<Kbd keys="escape" variant="inline" />)
+    expect(screen.getByText('Esc').className).not.toContain('border')
+  })
 })

--- a/apps/cockpit/src/components/shared/__tests__/MasterDetailLayout.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/MasterDetailLayout.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MasterDetailLayout } from '@/components/shared/MasterDetailLayout'
+
+describe('MasterDetailLayout', () => {
+  it('renders the sidebar title as a heading and labels the aside with it', () => {
+    render(
+      <MasterDetailLayout title="Snippets" sidebar={<p>List</p>}>
+        <p>Detail</p>
+      </MasterDetailLayout>
+    )
+    expect(screen.getByRole('heading', { name: 'Snippets' })).toBeInTheDocument()
+    expect(screen.getByRole('complementary', { name: 'Snippets' })).toBeInTheDocument()
+  })
+
+  it('renders sidebar, subtitle, actions, and detail content', () => {
+    render(
+      <MasterDetailLayout
+        title="Templates"
+        subtitle="4 saved"
+        sidebarActions={<button>New</button>}
+        sidebar={<p>List</p>}
+      >
+        <p>Detail</p>
+      </MasterDetailLayout>
+    )
+    expect(screen.getByText('4 saved')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New' })).toBeInTheDocument()
+    expect(screen.getByText('List')).toBeInTheDocument()
+    expect(screen.getByText('Detail')).toBeInTheDocument()
+  })
+
+  it('renders no toggle when the sidebar is not collapsible', () => {
+    render(
+      <MasterDetailLayout title="Snippets" sidebar={<p>List</p>}>
+        <p>Detail</p>
+      </MasterDetailLayout>
+    )
+    expect(screen.queryByRole('button', { name: /Hide|Show/ })).not.toBeInTheDocument()
+  })
+
+  it('toggles via the collapse control and reflects state in aria-expanded', () => {
+    const onToggle = vi.fn()
+    render(
+      <MasterDetailLayout
+        title="Snippets"
+        sidebar={<p>List</p>}
+        sidebarOpen={false}
+        onToggleSidebar={onToggle}
+      >
+        <p>Detail</p>
+      </MasterDetailLayout>
+    )
+    const toggle = screen.getByRole('button', { name: 'Show Snippets' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(toggle)
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/PaneHeader.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/PaneHeader.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PaneHeader } from '@/components/shared/PaneHeader'
+
+describe('PaneHeader', () => {
+  it('renders the title', () => {
+    render(<PaneHeader title="CSS Input" />)
+    expect(screen.getByText('CSS Input')).toBeInTheDocument()
+  })
+
+  it('announces status politely but leaves hints silent', () => {
+    render(<PaneHeader title="Output" hint="240 B" status="Formatted" />)
+    const status = screen.getByRole('status')
+    expect(status).toHaveTextContent('Formatted')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText('240 B')).not.toHaveAttribute('aria-live')
+  })
+
+  it('renders actions, the slot the hand-rolled copies lacked', () => {
+    render(<PaneHeader title="Output" actions={<button>Copy</button>} />)
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument()
+  })
+
+  it('uses the documented pane-header padding', () => {
+    const { container } = render(<PaneHeader title="Output" />)
+    expect(container.firstElementChild?.className).toContain('px-3 py-1.5')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/SectionLabel.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SectionLabel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SectionLabel } from '@/components/shared/SectionLabel'
+
+describe('SectionLabel', () => {
+  it('renders as a span by default, not a heading', () => {
+    render(<SectionLabel>Output</SectionLabel>)
+    expect(screen.getByText('Output').tagName).toBe('SPAN')
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
+
+  it('renders a real heading when asked, so the outline is a separate decision from the visual', () => {
+    render(<SectionLabel as="h2">Validate</SectionLabel>)
+    expect(screen.getByRole('heading', { level: 2, name: 'Validate' })).toBeInTheDocument()
+  })
+
+  it('applies the single documented label idiom', () => {
+    render(<SectionLabel>Input</SectionLabel>)
+    const className = screen.getByText('Input').className
+    expect(className).toContain('font-ui')
+    expect(className).toContain('text-2xs')
+    expect(className).toContain('font-semibold')
+    expect(className).toContain('uppercase')
+    expect(className).toContain('tracking-wide')
+  })
+
+  it('renders a hint without uppercasing it', () => {
+    render(<SectionLabel hint="12 matches">Results</SectionLabel>)
+    const hint = screen.getByText('12 matches')
+    expect(hint).toBeInTheDocument()
+    expect(hint.className).toContain('normal-case')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
@@ -69,6 +69,29 @@ describe('SplitPane', () => {
     expect(window.localStorage.length).toBe(0)
   })
 
+  it('stacks with no divider below stackBelow', () => {
+    // A ratio applied as an inline width beats any Tailwind breakpoint, so without this the tools
+    // that stack at 900px could not adopt SplitPane without losing their responsive behaviour.
+    const original = window.matchMedia
+    window.matchMedia = ((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia
+
+    renderSplit({ stackBelow: 900 })
+    expect(screen.getByText('Left pane')).toBeInTheDocument()
+    expect(screen.getByText('Right pane')).toBeInTheDocument()
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+
+    window.matchMedia = original
+  })
+
   it('uses row orientation when vertical', () => {
     renderSplit({ direction: 'vertical' })
     expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal')

--- a/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from 'react'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { SplitPane } from '@/components/shared/SplitPane'
 
 function renderSplit(props: Partial<React.ComponentProps<typeof SplitPane>> = {}) {
@@ -89,6 +90,64 @@ describe('SplitPane', () => {
     expect(screen.getByText('Right pane')).toBeInTheDocument()
     expect(screen.queryByRole('separator')).not.toBeInTheDocument()
 
+    window.matchMedia = original
+  })
+
+  // The regression this pins: stacking used to be a separate `return` with two children instead of
+  // three, so `second` moved from child index 2 to index 1 and React — which reconciles
+  // positionally — unmounted it. Six of the tools that stack put a Monaco editor in a pane, where a
+  // remount silently discards cursor, scroll and undo history. Dragging a window across 900px did
+  // it every time. The static stacked-render test above passes either way, so it caught nothing.
+  it('keeps both panes mounted when the viewport crosses stackBelow', () => {
+    const original = window.matchMedia
+    const listeners = new Set<(event: MediaQueryListEvent) => void>()
+    let matches = false
+
+    window.matchMedia = ((query: string) => ({
+      get matches() {
+        return matches
+      },
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: (_: string, fn: (event: MediaQueryListEvent) => void) => listeners.add(fn),
+      removeEventListener: (_: string, fn: (event: MediaQueryListEvent) => void) =>
+        listeners.delete(fn),
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia
+
+    const mounts: string[] = []
+    // A probe that records every mount. Two mounts of the same name means it was torn down and
+    // rebuilt — exactly the state loss a stateful pane would suffer.
+    function Probe({ name }: { name: string }) {
+      useEffect(() => {
+        mounts.push(name)
+      }, [name])
+      return <div>{name}</div>
+    }
+
+    render(
+      <SplitPane stackBelow={900}>
+        {[<Probe key="a" name="first" />, <Probe key="b" name="second" />]}
+      </SplitPane>
+    )
+    expect(mounts).toEqual(['first', 'second'])
+
+    // Narrow past the breakpoint, then back out again.
+    act(() => {
+      matches = true
+      listeners.forEach((fn) => fn({ matches: true } as MediaQueryListEvent))
+    })
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+
+    act(() => {
+      matches = false
+      listeners.forEach((fn) => fn({ matches: false } as MediaQueryListEvent))
+    })
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+
+    expect(mounts).toEqual(['first', 'second'])
     window.matchMedia = original
   })
 

--- a/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SplitPane } from '@/components/shared/SplitPane'
+
+function renderSplit(props: Partial<React.ComponentProps<typeof SplitPane>> = {}) {
+  return render(
+    <SplitPane {...props}>
+      {[<div key="a">Left pane</div>, <div key="b">Right pane</div>]}
+    </SplitPane>
+  )
+}
+
+describe('SplitPane', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('renders both panes', () => {
+    renderSplit()
+    expect(screen.getByText('Left pane')).toBeInTheDocument()
+    expect(screen.getByText('Right pane')).toBeInTheDocument()
+  })
+
+  it('exposes the divider as a separator with a value', () => {
+    renderSplit({ defaultRatio: 0.5 })
+    const separator = screen.getByRole('separator')
+    expect(separator).toHaveAttribute('aria-orientation', 'vertical')
+    expect(separator).toHaveAttribute('aria-valuenow', '50')
+  })
+
+  it('resizes with arrow keys — a mouse-only divider excludes keyboard users', () => {
+    renderSplit({ defaultRatio: 0.5 })
+    const separator = screen.getByRole('separator')
+    fireEvent.keyDown(separator, { key: 'ArrowRight' })
+    expect(separator).toHaveAttribute('aria-valuenow', '52')
+    fireEvent.keyDown(separator, { key: 'ArrowLeft' })
+    expect(separator).toHaveAttribute('aria-valuenow', '50')
+  })
+
+  it('clamps at minRatio so a pane cannot be collapsed to nothing', () => {
+    renderSplit({ defaultRatio: 0.5, minRatio: 0.2 })
+    const separator = screen.getByRole('separator')
+    fireEvent.keyDown(separator, { key: 'Home' })
+    expect(separator).toHaveAttribute('aria-valuenow', '20')
+    fireEvent.keyDown(separator, { key: 'ArrowLeft' })
+    expect(separator).toHaveAttribute('aria-valuenow', '20')
+  })
+
+  it('resets to the default ratio on Enter', () => {
+    renderSplit({ defaultRatio: 0.6 })
+    const separator = screen.getByRole('separator')
+    fireEvent.keyDown(separator, { key: 'End' })
+    expect(separator).not.toHaveAttribute('aria-valuenow', '60')
+    fireEvent.keyDown(separator, { key: 'Enter' })
+    expect(separator).toHaveAttribute('aria-valuenow', '60')
+  })
+
+  it('persists the ratio under the storage key and restores it', () => {
+    const { unmount } = renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+    expect(window.localStorage.getItem('cockpit.split.demo')).toBe('0.5200')
+    unmount()
+
+    renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '52')
+  })
+
+  it('does not persist without a storage key', () => {
+    renderSplit({ defaultRatio: 0.5 })
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+    expect(window.localStorage.length).toBe(0)
+  })
+
+  it('uses row orientation when vertical', () => {
+    renderSplit({ direction: 'vertical' })
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/ToolLayout.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/ToolLayout.test.tsx
@@ -12,26 +12,11 @@ describe('ToolLayout', () => {
     expect(screen.getByText('Body content')).toBeInTheDocument()
   })
 
-  it('omits the header row when no header is given', () => {
+  // The tab strip names the tool, so a tool body never repeats it. Library tools that show a
+  // heading are naming a collection, which is MasterDetailLayout's job, not this one's.
+  it('renders no heading of its own', () => {
     const { container } = render(<ToolLayout>content</ToolLayout>)
-    expect(container.querySelector('h2')).not.toBeInTheDocument()
-  })
-
-  it('renders title, description, and actions when a header is given', () => {
-    render(
-      <ToolLayout
-        header={{
-          title: 'My Tool',
-          description: 'Does a thing',
-          actions: <button>Reset</button>,
-        }}
-      >
-        content
-      </ToolLayout>
-    )
-    expect(screen.getByRole('heading', { name: 'My Tool' })).toBeInTheDocument()
-    expect(screen.getByText('Does a thing')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument()
+    expect(container.querySelector('h1, h2')).not.toBeInTheDocument()
   })
 
   it('renders the toolbar slot above the body', () => {

--- a/apps/cockpit/src/components/shell/CommandPalette.tsx
+++ b/apps/cockpit/src/components/shell/CommandPalette.tsx
@@ -27,6 +27,7 @@ import {
   type Icon,
 } from '@phosphor-icons/react'
 import { SectionLabel } from '@/components/shared/SectionLabel'
+import { Kbd } from '@/components/shared/Kbd'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -544,9 +545,7 @@ export function CommandPalette() {
             Actions
           </span>
         ) : (
-          <kbd className="shrink-0 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-2xs text-[var(--color-text-muted)]">
-            {modSymbol}K
-          </kbd>
+          <Kbd keys="mod+k" />
         )}
       </div>
 

--- a/apps/cockpit/src/components/shell/CommandPalette.tsx
+++ b/apps/cockpit/src/components/shell/CommandPalette.tsx
@@ -26,6 +26,7 @@ import {
   SidebarIcon,
   type Icon,
 } from '@phosphor-icons/react'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -576,13 +577,14 @@ export function CommandPalette() {
               {sections.map((section) => {
                 if (section.type === 'header') {
                   return (
-                    <div
+                    <SectionLabel
+                      as="div"
                       key={`header-${section.label}`}
                       role="presentation"
-                      className="px-3 pb-0.5 pt-2 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
+                      className="px-3 pb-0.5 pt-2"
                     >
                       {section.label}
-                    </div>
+                    </SectionLabel>
                   )
                 }
 

--- a/apps/cockpit/src/components/shell/CommandPalette.tsx
+++ b/apps/cockpit/src/components/shell/CommandPalette.tsx
@@ -543,7 +543,7 @@ export function CommandPalette() {
             Actions
           </span>
         ) : (
-          <kbd className="shrink-0 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--color-text-muted)]">
+          <kbd className="shrink-0 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-2xs text-[var(--color-text-muted)]">
             {modSymbol}K
           </kbd>
         )}
@@ -579,7 +579,7 @@ export function CommandPalette() {
                     <div
                       key={`header-${section.label}`}
                       role="presentation"
-                      className="px-3 pb-0.5 pt-2 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
+                      className="px-3 pb-0.5 pt-2 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
                     >
                       {section.label}
                     </div>

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -229,7 +229,7 @@ function NoteEditor({
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
         <Button variant="icon" size="sm" onClick={handleBack} aria-label="Back to all notes">
-          <ArrowLeftIcon size={15} aria-hidden="true" />
+          <ArrowLeftIcon size={16} aria-hidden="true" />
         </Button>
         <div className="min-w-0 flex-1">
           <p className="truncate text-xs font-semibold text-[var(--color-text)]">
@@ -251,7 +251,7 @@ function NoteEditor({
           title={note.pinned ? 'Unpin' : 'Pin'}
           className={note.pinned ? 'text-[var(--color-accent)]' : ''}
         >
-          <PushPinIcon size={15} weight={note.pinned ? 'fill' : 'regular'} aria-hidden="true" />
+          <PushPinIcon size={16} weight={note.pinned ? 'fill' : 'regular'} aria-hidden="true" />
         </Button>
         <Button
           variant="icon"
@@ -259,10 +259,10 @@ function NoteEditor({
           onClick={() => onCopy(draftRef.current.content)}
           aria-label="Copy note content"
         >
-          <CopyIcon size={15} aria-hidden="true" />
+          <CopyIcon size={16} aria-hidden="true" />
         </Button>
         <Button variant="icon" size="sm" onClick={handleDeleteRequest} aria-label="Delete note">
-          <TrashIcon size={15} aria-hidden="true" />
+          <TrashIcon size={16} aria-hidden="true" />
         </Button>
       </div>
 
@@ -309,7 +309,7 @@ function NoteEditor({
                   aria-label={`Remove ${tag} tag`}
                   className="rounded-full focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
                 >
-                  <XIcon size={10} aria-hidden="true" />
+                  <XIcon size={12} aria-hidden="true" />
                 </button>
               </span>
             ))}
@@ -368,7 +368,7 @@ function NoteEditor({
           onClick={() => onUseAsInput(draftRef.current.content)}
           disabled={!draft.content}
         >
-          <PaperPlaneTiltIcon size={13} aria-hidden="true" className="mr-1.5" />
+          <PaperPlaneTiltIcon size={14} aria-hidden="true" className="mr-1.5" />
           Use as input
         </Button>
       </div>
@@ -624,7 +624,7 @@ export function NotesDrawer() {
               className="min-w-0 flex-1"
             />
             <Button variant="primary" size="sm" onClick={() => void handleAddNote()}>
-              <PlusIcon size={13} className="mr-1" aria-hidden="true" /> New
+              <PlusIcon size={14} className="mr-1" aria-hidden="true" /> New
             </Button>
           </div>
 
@@ -651,7 +651,7 @@ export function NotesDrawer() {
                 action={
                   !search ? (
                     <Button variant="primary" size="sm" onClick={() => void handleAddNote()}>
-                      <PlusIcon size={13} className="mr-1" aria-hidden="true" /> New note
+                      <PlusIcon size={14} className="mr-1" aria-hidden="true" /> New note
                     </Button>
                   ) : undefined
                 }
@@ -694,7 +694,7 @@ export function NotesDrawer() {
                               aria-label={`Drag ${note.title || 'untitled note'} to reorder`}
                               className="mt-0.5 inline-flex min-h-6 min-w-5 cursor-grab items-center justify-center rounded text-[var(--color-text-muted)] opacity-60 focus-visible:opacity-100 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] group-hover:opacity-100"
                             >
-                              <DotsSixVerticalIcon size={13} aria-hidden="true" />
+                              <DotsSixVerticalIcon size={14} aria-hidden="true" />
                             </button>
                           )}
                           <button
@@ -706,7 +706,7 @@ export function NotesDrawer() {
                             <span className="flex items-center gap-1.5">
                               {note.pinned && (
                                 <PushPinIcon
-                                  size={11}
+                                  size={12}
                                   weight="fill"
                                   className="shrink-0 text-[var(--color-accent)]"
                                   aria-hidden="true"

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -16,6 +16,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Select } from '@/components/shared/Select'
@@ -291,9 +292,9 @@ function NoteEditor({
         />
 
         <div className="mt-5 border-t border-[var(--color-border)] pt-4">
-          <div className="mb-2 flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <SectionLabel as="div" className="mb-2">
             <TagIcon size={12} aria-hidden="true" /> Tags
-          </div>
+          </SectionLabel>
           <div className="flex flex-wrap items-center gap-1.5">
             {note.tags.map((tag) => (
               <span
@@ -332,9 +333,9 @@ function NoteEditor({
         </div>
 
         <fieldset className="mt-5 border-t border-[var(--color-border)] pt-4">
-          <legend className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <SectionLabel as="legend" className="mb-2">
             Color
-          </legend>
+          </SectionLabel>
           <div className="flex flex-wrap gap-2">
             {NOTE_COLORS.map((color) => (
               <button
@@ -659,10 +660,10 @@ export function NotesDrawer() {
             )}
             {noteSections.map((section) => (
               <section key={section.id} className="mb-4">
-                <div className="mb-1.5 flex items-center justify-between px-1 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                <SectionLabel as="div" className="mb-1.5 justify-between px-1">
                   <span>{section.label}</span>
                   <span>{section.notes.length}</span>
-                </div>
+                </SectionLabel>
                 <div className="space-y-2">
                   {section.notes.map((note, noteIndex) => {
                     const previousNote = section.notes[noteIndex - 1]

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -34,6 +34,7 @@ import {
   ShieldCheckIcon,
 } from '@phosphor-icons/react'
 import { Dialog } from '@/components/shared/Dialog'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Toggle } from '@/components/shared/Toggle'
 import { Select } from '@/components/shared/Select'
 import { ThemePicker } from '@/components/shell/ThemePicker'
@@ -293,10 +294,10 @@ function GeneralTab() {
 
       {/* Updates */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <ArrowCircleUpIcon size={12} />
           Updates
-        </h4>
+        </SectionLabel>
         <div className="space-y-1">
           <SettingRow label="Check for updates automatically" hint="Check on every app launch">
             <Toggle
@@ -613,10 +614,10 @@ function DataTab() {
 
       {/* Storage Stats */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <InfoIcon size={12} />
           Storage
-        </h4>
+        </SectionLabel>
         <div className="grid grid-cols-3 gap-2">
           <StatCard label="Notes" count={noteCount} />
           <StatCard label="Snippets" count={snippetCount} />
@@ -626,10 +627,10 @@ function DataTab() {
 
       {/* Data Management */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <TrashIcon size={12} />
           Clear Data
-        </h4>
+        </SectionLabel>
         <div className="flex flex-wrap gap-2">
           <DangerButton
             label={`Clear Notes (${noteCount})`}
@@ -660,10 +661,10 @@ function DataTab() {
 
       {/* Export / Import / Reset */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <ExportIcon size={12} />
           Settings Transfer
-        </h4>
+        </SectionLabel>
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
@@ -915,10 +916,10 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <KeyIcon size={12} />
           Authentication
-        </h4>
+        </SectionLabel>
         <div className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2">
           <div className="flex items-center gap-2">
             <code className="min-w-0 flex-1 truncate rounded bg-[var(--color-surface)] px-2 py-1 font-mono text-xs text-[var(--color-text)]">
@@ -953,10 +954,10 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <ShieldCheckIcon size={12} />
           Permissions
-        </h4>
+        </SectionLabel>
         <div className="overflow-hidden rounded border border-[var(--color-border)]">
           <div className="grid grid-cols-[1.4fr_repeat(4,0.7fr)] border-b border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1.5 text-2xs uppercase tracking-wider text-[var(--color-text-muted)]">
             <span>Resource</span>
@@ -1007,10 +1008,10 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="h4" className="mb-2">
           <PlugsConnectedIcon size={12} />
           Client Setup
-        </h4>
+        </SectionLabel>
         <div className="space-y-2">
           {(
             [

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -293,8 +293,8 @@ function GeneralTab() {
 
       {/* Updates */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <ArrowCircleUpIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <ArrowCircleUpIcon size={12} />
           Updates
         </h4>
         <div className="space-y-1">
@@ -613,8 +613,8 @@ function DataTab() {
 
       {/* Storage Stats */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <InfoIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <InfoIcon size={12} />
           Storage
         </h4>
         <div className="grid grid-cols-3 gap-2">
@@ -626,8 +626,8 @@ function DataTab() {
 
       {/* Data Management */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <TrashIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <TrashIcon size={12} />
           Clear Data
         </h4>
         <div className="flex flex-wrap gap-2">
@@ -660,8 +660,8 @@ function DataTab() {
 
       {/* Export / Import / Reset */}
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <ExportIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <ExportIcon size={12} />
           Settings Transfer
         </h4>
         <div className="flex flex-wrap gap-2">
@@ -703,7 +703,7 @@ function StatCard({ label, count }: { label: string; count: number }) {
   return (
     <div className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-center">
       <div className="font-mono text-sm font-bold text-[var(--color-text)]">{count}</div>
-      <div className="text-[11px] text-[var(--color-text-muted)]">{label}</div>
+      <div className="text-xs text-[var(--color-text-muted)]">{label}</div>
     </div>
   )
 }
@@ -848,7 +848,7 @@ function McpTab() {
             <button
               type="button"
               onClick={() => void copyText(status.url, 'MCP URL copied')}
-              className="mt-1 font-mono text-[11px] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
+              className="mt-1 font-mono text-xs text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
             >
               {status.url}
             </button>
@@ -875,7 +875,7 @@ function McpTab() {
           </div>
         </div>
         {status.lastError && (
-          <div className="mt-2 rounded border border-[var(--color-error)]/40 bg-[var(--color-error)]/10 px-2 py-1 text-[11px] text-[var(--color-error)]">
+          <div className="mt-2 rounded border border-[var(--color-error)]/40 bg-[var(--color-error)]/10 px-2 py-1 text-xs text-[var(--color-error)]">
             {status.lastError}
           </div>
         )}
@@ -915,13 +915,13 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <KeyIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <KeyIcon size={12} />
           Authentication
         </h4>
         <div className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2">
           <div className="flex items-center gap-2">
-            <code className="min-w-0 flex-1 truncate rounded bg-[var(--color-surface)] px-2 py-1 font-mono text-[11px] text-[var(--color-text)]">
+            <code className="min-w-0 flex-1 truncate rounded bg-[var(--color-surface)] px-2 py-1 font-mono text-xs text-[var(--color-text)]">
               {keyVisible ? settings.apiKey : '•'.repeat(Math.min(32, settings.apiKey.length))}
             </code>
             <button
@@ -930,7 +930,7 @@ function McpTab() {
               className="rounded border border-[var(--color-border)] p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
               aria-label={keyVisible ? 'Hide MCP key' : 'Show MCP key'}
             >
-              {keyVisible ? <EyeSlashIcon size={13} /> : <EyeIcon size={13} />}
+              {keyVisible ? <EyeSlashIcon size={14} /> : <EyeIcon size={14} />}
             </button>
             <button
               type="button"
@@ -938,7 +938,7 @@ function McpTab() {
               className="rounded border border-[var(--color-border)] p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
               aria-label="Copy MCP key"
             >
-              <CopyIcon size={13} />
+              <CopyIcon size={14} />
             </button>
             <button
               type="button"
@@ -953,8 +953,8 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <ShieldCheckIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <ShieldCheckIcon size={12} />
           Permissions
         </h4>
         <div className="overflow-hidden rounded border border-[var(--color-border)]">
@@ -1007,8 +1007,8 @@ function McpTab() {
       </div>
 
       <div>
-        <h4 className="mb-2 flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
-          <PlugsConnectedIcon size={10} />
+        <h4 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+          <PlugsConnectedIcon size={12} />
           Client Setup
         </h4>
         <div className="space-y-2">
@@ -1026,8 +1026,8 @@ function McpTab() {
               onClick={() => void copyText(command, `${label} setup copied`)}
               className="flex w-full items-start gap-2 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-2 text-left transition-colors hover:border-[var(--color-accent)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
             >
-              <CopyIcon size={13} className="mt-0.5 shrink-0 text-[var(--color-text-muted)]" />
-              <span className="min-w-24 text-[11px] font-semibold text-[var(--color-text)]">
+              <CopyIcon size={14} className="mt-0.5 shrink-0 text-[var(--color-text-muted)]" />
+              <span className="min-w-24 text-xs font-semibold text-[var(--color-text)]">
                 {label}
               </span>
               <code className="min-w-0 flex-1 whitespace-pre-wrap break-all font-mono text-2xs text-[var(--color-text-muted)]">

--- a/apps/cockpit/src/components/shell/ShortcutsModal.tsx
+++ b/apps/cockpit/src/components/shell/ShortcutsModal.tsx
@@ -51,7 +51,7 @@ function getCategories(mod: string): ShortcutCategory[] {
 
 function Kbd({ children }: { children: string }) {
   return (
-    <kbd className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-[11px] text-[var(--color-text)]">
+    <kbd className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-text)]">
       {children}
     </kbd>
   )

--- a/apps/cockpit/src/components/shell/ShortcutsModal.tsx
+++ b/apps/cockpit/src/components/shell/ShortcutsModal.tsx
@@ -1,10 +1,11 @@
 import { Dialog } from '@/components/shared/Dialog'
+import { Kbd } from '@/components/shared/Kbd'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { useUiStore } from '@/stores/ui.store'
-import { usePlatform } from '@/hooks/usePlatform'
 
 type ShortcutEntry = {
-  keys: string[]
+  /** Combo notation, as `useKeyboardShortcut` and `Kbd` both read it. */
+  keys: string
   action: string
 }
 
@@ -13,59 +14,48 @@ type ShortcutCategory = {
   shortcuts: ShortcutEntry[]
 }
 
-function getCategories(mod: string): ShortcutCategory[] {
-  return [
-    {
-      label: 'Navigation',
-      shortcuts: [
-        { keys: [mod, 'K'], action: 'Command palette' },
-        { keys: [mod, 'B'], action: 'Toggle sidebar' },
-        { keys: [mod, ']'], action: 'Next tool' },
-        { keys: [mod, '['], action: 'Previous tool' },
-      ],
-    },
-    {
-      label: 'Notes',
-      shortcuts: [{ keys: [mod, 'Shift', 'N'], action: 'Toggle notes drawer' }],
-    },
-    {
-      label: 'Editor',
-      shortcuts: [
-        { keys: [mod, 'Enter'], action: 'Execute / Run' },
-        { keys: [mod, 'Shift', 'C'], action: 'Copy output' },
-        { keys: [mod, '1 / 2 / 3'], action: 'Switch tab' },
-        { keys: [mod, 'O'], action: 'Open file' },
-        { keys: [mod, 'S'], action: 'Save file' },
-      ],
-    },
-    {
-      label: 'Window',
-      shortcuts: [
-        { keys: [mod, ','], action: 'Settings' },
-        { keys: [mod, 'Shift', 'T'], action: 'Toggle theme' },
-        { keys: [mod, 'Shift', 'P'], action: 'Toggle always-on-top' },
-        { keys: [mod, '/'], action: 'Keyboard shortcuts' },
-      ],
-    },
-  ]
-}
-
-function Kbd({ children }: { children: string }) {
-  return (
-    <kbd className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-text)]">
-      {children}
-    </kbd>
-  )
-}
+// Written as combos rather than pre-rendered symbols: `Kbd` resolves `mod` per platform, so this
+// table can't say ⌘ to a Windows user the way the old `getCategories(modSymbol)` shape invited.
+const CATEGORIES: ShortcutCategory[] = [
+  {
+    label: 'Navigation',
+    shortcuts: [
+      { keys: 'mod+k', action: 'Command palette' },
+      { keys: 'mod+b', action: 'Toggle sidebar' },
+      { keys: 'mod+]', action: 'Next tool' },
+      { keys: 'mod+[', action: 'Previous tool' },
+    ],
+  },
+  {
+    label: 'Notes',
+    shortcuts: [{ keys: 'mod+shift+n', action: 'Toggle notes drawer' }],
+  },
+  {
+    label: 'Editor',
+    shortcuts: [
+      { keys: 'mod+enter', action: 'Execute / Run' },
+      { keys: 'mod+shift+c', action: 'Copy output' },
+      { keys: 'mod+1 / 2 / 3', action: 'Switch tab' },
+      { keys: 'mod+o', action: 'Open file' },
+      { keys: 'mod+s', action: 'Save file' },
+    ],
+  },
+  {
+    label: 'Window',
+    shortcuts: [
+      { keys: 'mod+,', action: 'Settings' },
+      { keys: 'mod+shift+t', action: 'Toggle theme' },
+      { keys: 'mod+shift+p', action: 'Toggle always-on-top' },
+      { keys: 'mod+/', action: 'Keyboard shortcuts' },
+    ],
+  },
+]
 
 export function ShortcutsModal() {
   const open = useUiStore((s) => s.shortcutsModalOpen)
   const setOpen = useUiStore((s) => s.setShortcutsModalOpen)
-  const { modSymbol } = usePlatform()
 
   if (!open) return null
-
-  const categories = getCategories(modSymbol)
 
   return (
     <Dialog
@@ -76,7 +66,7 @@ export function ShortcutsModal() {
       bodyClassName="max-h-[70vh] px-4 py-3"
       titleClassName="text-[var(--color-accent)]"
     >
-      {categories.map((cat) => (
+      {CATEGORIES.map((cat) => (
         <div key={cat.label} className="mb-4 last:mb-0">
           <SectionLabel as="h3" className="mb-2">
             {cat.label}
@@ -85,11 +75,7 @@ export function ShortcutsModal() {
             {cat.shortcuts.map((s) => (
               <div key={s.action} className="flex items-center justify-between py-1.5">
                 <span className="text-xs text-[var(--color-text)]">{s.action}</span>
-                <div className="flex items-center gap-1">
-                  {s.keys.map((k, i) => (
-                    <Kbd key={i}>{k}</Kbd>
-                  ))}
-                </div>
+                <Kbd keys={s.keys} />
               </div>
             ))}
           </div>

--- a/apps/cockpit/src/components/shell/ShortcutsModal.tsx
+++ b/apps/cockpit/src/components/shell/ShortcutsModal.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from '@/components/shared/Dialog'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { useUiStore } from '@/stores/ui.store'
 import { usePlatform } from '@/hooks/usePlatform'
 
@@ -77,9 +78,9 @@ export function ShortcutsModal() {
     >
       {categories.map((cat) => (
         <div key={cat.label} className="mb-4 last:mb-0">
-          <h3 className="mb-2 text-xs uppercase tracking-widest text-[var(--color-text-muted)]">
+          <SectionLabel as="h3" className="mb-2">
             {cat.label}
-          </h3>
+          </SectionLabel>
           <div className="flex flex-col gap-1">
             {cat.shortcuts.map((s) => (
               <div key={s.action} className="flex items-center justify-between py-1.5">

--- a/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ToolDefinition, ToolGroupMeta } from '@/types/tools'
 import { useUiStore } from '@/stores/ui.store'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 
 type Props = {
   group: ToolGroupMeta
@@ -142,9 +143,9 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
             style={flyoutStyle}
             className="font-ui min-w-[160px] overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] py-1 shadow-lg"
           >
-            <div className="px-2.5 pb-1 pt-1 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+            <SectionLabel as="div" className="px-2.5 pb-1 pt-1">
               {group.label}
-            </div>
+            </SectionLabel>
             {tools.map((tool) => {
               const isActive = tool.id === activeTool
               return (

--- a/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
@@ -127,7 +127,7 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
         createPortal(
           <div
             style={tooltipStyle}
-            className="font-ui pointer-events-none rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2 py-1 text-[11px] text-[var(--color-text)] shadow-md"
+            className="font-ui pointer-events-none rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[var(--color-text)] shadow-md"
           >
             {group.label}
           </div>,
@@ -142,7 +142,7 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
             style={flyoutStyle}
             className="font-ui min-w-[160px] overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] py-1 shadow-lg"
           >
-            <div className="px-2.5 pb-1 pt-1 text-[11px] font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+            <div className="px-2.5 pb-1 pt-1 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
               {group.label}
             </div>
             {tools.map((tool) => {

--- a/apps/cockpit/src/components/shell/SidebarGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarGroup.tsx
@@ -97,7 +97,7 @@ export function SidebarGroup({
         onKeyDown={handleKeyDown}
         aria-expanded={!collapsed}
         data-sidebar-group={group.id}
-        className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)]/60"
+        className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs font-bold uppercase tracking-widest text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)]"
       >
         {/* Chevron: size 12 (was 10), rotate-90 when expanded with smooth ease-in-out */}
         <CaretRightIcon

--- a/apps/cockpit/src/components/shell/SidebarItem.tsx
+++ b/apps/cockpit/src/components/shell/SidebarItem.tsx
@@ -43,7 +43,7 @@ export function SidebarItem({ id, name, icon, tabIndex }: SidebarItemProps) {
         aria-current={isActive ? 'page' : undefined}
         tabIndex={tabIndex}
         data-sidebar-item={id}
-        className={`flex h-8 min-w-0 flex-1 items-center gap-2 rounded-sm border-l-2 px-2 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)]/60 ${
+        className={`flex h-8 min-w-0 flex-1 items-center gap-2 rounded-sm border-l-2 px-2 text-xs transition-colors focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
           isActive
             ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)] text-[var(--color-accent)] shadow-[inset_3px_0_8px_-4px_var(--color-accent)]'
             : 'border-transparent text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
@@ -64,11 +64,11 @@ export function SidebarItem({ id, name, icon, tabIndex }: SidebarItemProps) {
         aria-label={isPinned ? `Unpin ${name}` : `Pin ${name}`}
         aria-pressed={isPinned}
         tabIndex={tabIndex}
-        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)]/60 ${
+        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
           isPinned ? 'text-[var(--color-accent)] opacity-100' : 'opacity-60 group-hover:opacity-100'
         }`}
       >
-        <PushPinIcon size={13} weight={isPinned ? 'fill' : 'regular'} />
+        <PushPinIcon size={14} weight={isPinned ? 'fill' : 'regular'} />
       </button>
     </div>
   )

--- a/apps/cockpit/src/components/shell/SidebarPinned.tsx
+++ b/apps/cockpit/src/components/shell/SidebarPinned.tsx
@@ -26,8 +26,8 @@ export function SidebarPinned({ filterToolIds = null }: SidebarPinnedProps) {
   return (
     <div className="mb-1">
       <div className="flex items-center gap-1.5 px-2 py-1 text-[var(--color-text-muted)]">
-        <PushPinIcon size={10} className="shrink-0" />
-        <span className="text-[11px] font-bold uppercase tracking-normal">[Pinned]</span>
+        <PushPinIcon size={12} className="shrink-0" />
+        <span className="text-xs font-bold uppercase tracking-normal">[Pinned]</span>
       </div>
       <div className="flex flex-col gap-1 px-1">
         {pinnedTools.map((tool) => (

--- a/apps/cockpit/src/components/shell/SidebarPinned.tsx
+++ b/apps/cockpit/src/components/shell/SidebarPinned.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { PushPinIcon } from '@phosphor-icons/react'
 import { TOOLS } from '@/app/tool-registry'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { useSettingsStore } from '@/stores/settings.store'
 import { SidebarItem } from './SidebarItem'
 
@@ -25,10 +26,10 @@ export function SidebarPinned({ filterToolIds = null }: SidebarPinnedProps) {
 
   return (
     <div className="mb-1">
-      <div className="flex items-center gap-1.5 px-2 py-1 text-[var(--color-text-muted)]">
-        <PushPinIcon size={12} className="shrink-0" />
-        <span className="text-xs font-bold uppercase tracking-normal">[Pinned]</span>
-      </div>
+      <SectionLabel as="h3" className="px-2 py-1">
+        <PushPinIcon size={12} className="shrink-0" aria-hidden="true" />
+        Pinned
+      </SectionLabel>
       <div className="flex flex-col gap-1 px-1">
         {pinnedTools.map((tool) => (
           <SidebarItem key={tool.id} id={tool.id} name={tool.name} icon={tool.icon} tabIndex={0} />

--- a/apps/cockpit/src/components/shell/SidebarRecent.tsx
+++ b/apps/cockpit/src/components/shell/SidebarRecent.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { ClockCounterClockwiseIcon } from '@phosphor-icons/react'
 import { TOOLS } from '@/app/tool-registry'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useUiStore } from '@/stores/ui.store'
 import { SidebarItem } from './SidebarItem'
@@ -31,10 +32,10 @@ export function SidebarRecent({ filterToolIds = null }: SidebarRecentProps) {
 
   return (
     <div className="mb-1">
-      <div className="flex items-center gap-1.5 px-2 py-1 text-[var(--color-text-muted)]">
-        <ClockCounterClockwiseIcon size={12} className="shrink-0" />
-        <span className="text-xs font-bold uppercase tracking-normal">[Recent]</span>
-      </div>
+      <SectionLabel as="h3" className="px-2 py-1">
+        <ClockCounterClockwiseIcon size={12} className="shrink-0" aria-hidden="true" />
+        Recent
+      </SectionLabel>
       {/* tabIndex={0} makes recent items explicit participants in keyboard nav */}
       <div className="flex flex-col gap-1 px-1">
         {recentTools.map((tool) => (

--- a/apps/cockpit/src/components/shell/SidebarRecent.tsx
+++ b/apps/cockpit/src/components/shell/SidebarRecent.tsx
@@ -32,8 +32,8 @@ export function SidebarRecent({ filterToolIds = null }: SidebarRecentProps) {
   return (
     <div className="mb-1">
       <div className="flex items-center gap-1.5 px-2 py-1 text-[var(--color-text-muted)]">
-        <ClockCounterClockwiseIcon size={10} className="shrink-0" />
-        <span className="text-[11px] font-bold uppercase tracking-normal">[Recent]</span>
+        <ClockCounterClockwiseIcon size={12} className="shrink-0" />
+        <span className="text-xs font-bold uppercase tracking-normal">[Recent]</span>
       </div>
       {/* tabIndex={0} makes recent items explicit participants in keyboard nav */}
       <div className="flex flex-col gap-1 px-1">

--- a/apps/cockpit/src/components/shell/StatusBar.tsx
+++ b/apps/cockpit/src/components/shell/StatusBar.tsx
@@ -30,7 +30,7 @@ function ClockDisplay() {
   const clock = useClock()
   return (
     <span className="flex items-center gap-1 tabular-nums" title="Current time">
-      <ClockIcon size={10} aria-hidden="true" />
+      <ClockIcon size={12} aria-hidden="true" />
       {clock}
     </span>
   )
@@ -71,7 +71,7 @@ export function StatusBar() {
   const themeLabel = theme === 'system' ? 'System' : (THEME_META[theme]?.shortLabel ?? theme)
 
   return (
-    <div className="font-ui flex h-7 shrink-0 items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-[11px]">
+    <div className="font-ui flex h-7 shrink-0 items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-xs">
       {/* Left: active tool + last action */}
       <div className="flex items-center gap-3">
         <span className="font-medium text-[var(--color-text-muted)]">{tool?.name ?? ''}</span>

--- a/apps/cockpit/src/components/shell/ThemePicker.tsx
+++ b/apps/cockpit/src/components/shell/ThemePicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { CheckIcon, MonitorIcon } from '@phosphor-icons/react'
 import type { Theme } from '@/types/models'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { ALL_THEMES, THEME_META, getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import type { EffectiveTheme } from '@/lib/theme'
 
@@ -244,22 +245,16 @@ export function ThemePicker({ value, onChange }: ThemePickerProps) {
       <div>{renderChip('system')}</div>
 
       <div role="group" aria-labelledby="theme-group-dark">
-        <h5
-          id="theme-group-dark"
-          className="mb-1.5 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
-        >
+        <SectionLabel as="h5" id="theme-group-dark" className="mb-1.5">
           Dark
-        </h5>
+        </SectionLabel>
         <div className="grid grid-cols-3 gap-2">{DARK_THEMES.map(renderChip)}</div>
       </div>
 
       <div role="group" aria-labelledby="theme-group-light">
-        <h5
-          id="theme-group-light"
-          className="mb-1.5 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
-        >
+        <SectionLabel as="h5" id="theme-group-light" className="mb-1.5">
           Light
-        </h5>
+        </SectionLabel>
         <div className="grid grid-cols-3 gap-2">{LIGHT_THEMES.map(renderChip)}</div>
       </div>
     </div>

--- a/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
@@ -6,6 +6,7 @@ import { TOOLS } from '@/app/tool-registry'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useUiStore } from '@/stores/ui.store'
 import type { ToolDefinition } from '@/types/tools'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 function resolveTools(ids: string[]): ToolDefinition[] {
   return ids
@@ -62,7 +63,7 @@ export function WorkspaceEmptyState() {
     <EmptyState
       icon={ToolboxIcon}
       title="Select a tool to get started"
-      description="Use the sidebar or press ⌘K"
+      description={`Use the sidebar or press ${formatShortcut('mod+k')}`}
       action={
         hasChips ? (
           <div className="flex flex-col items-center gap-[var(--space-3)]">

--- a/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { ToolboxIcon } from '@phosphor-icons/react'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { TOOLS } from '@/app/tool-registry'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useUiStore } from '@/stores/ui.store'
@@ -21,9 +22,7 @@ type ChipRowProps = {
 function ChipRow({ label, tools, onSelect }: ChipRowProps) {
   return (
     <div className="flex flex-col items-center gap-[var(--space-1)]">
-      <span className="text-2xs font-bold uppercase tracking-wide text-[var(--color-text-muted)]">
-        {label}
-      </span>
+      <SectionLabel>{label}</SectionLabel>
       <div className="flex flex-wrap items-center justify-center gap-[var(--space-2)]">
         {tools.map((tool) => (
           <button

--- a/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
@@ -188,7 +188,7 @@ export function WorkspaceTabStrip() {
                   setActiveTab(tab.id)
                 }
               }}
-              className={`group relative flex max-w-[180px] min-w-[80px] shrink-0 cursor-pointer select-none items-center gap-1.5 px-3 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)] ${
+              className={`group relative flex max-w-[180px] min-w-[80px] shrink-0 cursor-pointer select-none items-center gap-1.5 px-3 text-xs transition-colors focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
                 isActive
                   ? 'bg-[var(--color-bg)] text-[var(--color-accent)]'
                   : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
@@ -219,7 +219,7 @@ export function WorkspaceTabStrip() {
                 aria-label={`Close ${title}`}
                 className="flex h-4 w-4 shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--color-surface-hover)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
               >
-                <XIcon size={10} />
+                <XIcon size={12} />
               </button>
 
               {/* Bottom pill indicator for active tab */}

--- a/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback, useEffect } from 'react'
 import { XIcon, PlusIcon } from '@phosphor-icons/react'
 import { useUiStore } from '@/stores/ui.store'
 import { getToolById } from '@/app/tool-registry'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type ContextMenu = {
   tabId: string
@@ -248,8 +249,8 @@ export function WorkspaceTabStrip() {
       {/* + button pinned outside the scroll area */}
       <button
         onClick={toggleCommandPalette}
-        aria-label="Open new tool (⌘K)"
-        title="Open new tool (⌘K)"
+        aria-label={`Open new tool (${formatShortcut('mod+k')})`}
+        title={`Open new tool (${formatShortcut('mod+k')})`}
         className="flex h-full w-8 shrink-0 items-center justify-center text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
       >
         <PlusIcon size={12} />

--- a/apps/cockpit/src/components/shell/__tests__/WorkspaceEmptyState.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/WorkspaceEmptyState.test.tsx
@@ -4,6 +4,7 @@ import { WorkspaceEmptyState } from '@/components/shell/WorkspaceEmptyState'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useUiStore } from '@/stores/ui.store'
 import { DEFAULT_SETTINGS } from '@/types/models'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 vi.mock('@/lib/db', () => ({
   setSetting: vi.fn().mockResolvedValue(undefined),
@@ -18,10 +19,14 @@ beforeEach(() => {
 })
 
 describe('WorkspaceEmptyState', () => {
-  it('shows the base copy and ⌘K hint with no chips when nothing is pinned or recent', () => {
+  it('shows the base copy and mod+K hint with no chips when nothing is pinned or recent', () => {
     render(<WorkspaceEmptyState />)
     expect(screen.getByText('Select a tool to get started')).toBeInTheDocument()
-    expect(screen.getByText('Use the sidebar or press ⌘K')).toBeInTheDocument()
+    // Asserted through formatShortcut rather than against a literal "⌘K": jsdom's user agent is
+    // not a Mac, so the hint correctly says Ctrl+K here, which is the whole point of the change.
+    expect(
+      screen.getByText(`Use the sidebar or press ${formatShortcut('mod+k')}`)
+    ).toBeInTheDocument()
     expect(screen.queryByText('Pinned')).not.toBeInTheDocument()
     expect(screen.queryByText('Recent')).not.toBeInTheDocument()
   })

--- a/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
@@ -231,7 +231,7 @@ describe('SidebarPinned — favorite tools', () => {
 
     render(<SidebarPinned />)
 
-    expect(screen.getByText('[Pinned]')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Pinned' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Base64' })).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/lib/__tests__/shortcut-label.test.ts
+++ b/apps/cockpit/src/lib/__tests__/shortcut-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { formatShortcut } from '@/lib/shortcut-label'
+
+describe('formatShortcut', () => {
+  it('resolves mod per platform', () => {
+    expect(formatShortcut('mod+enter', true)).toBe('⌘↵')
+    expect(formatShortcut('mod+enter', false)).toBe('Ctrl+Enter')
+  })
+
+  it('runs modifiers together on macOS and separates them elsewhere', () => {
+    expect(formatShortcut('mod+shift+d', true)).toBe('⌘⇧D')
+    expect(formatShortcut('mod+shift+d', false)).toBe('Ctrl+Shift+D')
+  })
+
+  it('upper-cases single letters and leaves named keys alone', () => {
+    expect(formatShortcut('mod+s', true)).toBe('⌘S')
+    expect(formatShortcut('escape', true)).toBe('Esc')
+  })
+
+  // The literals this replaced said ⌘ on every platform. A hint that names a key the machine
+  // doesn't have is worse than no hint, so this is the regression worth pinning.
+  it('never emits the command symbol off macOS', () => {
+    for (const combo of ['mod+enter', 'mod+shift+d', 'mod+k', 'mod+o']) {
+      expect(formatShortcut(combo, false)).not.toContain('⌘')
+    }
+  })
+})

--- a/apps/cockpit/src/lib/http-method.ts
+++ b/apps/cockpit/src/lib/http-method.ts
@@ -1,0 +1,33 @@
+/**
+ * One colour per HTTP verb, shared by the API client and the cURL converter.
+ *
+ * The two tools each carried their own map and they disagreed: one had POST as info and PATCH as
+ * warning, the other POST as warning and PATCH as accent. Reading the same request in both tools
+ * gave it two different colours, which quietly trains you that the colour means nothing.
+ *
+ * The scale it does mean: how much the verb changes on the server. Safe read, creates, replaces,
+ * modifies, destroys — and metadata verbs stay muted because they change nothing at all.
+ */
+const METHOD_TOKENS: Record<string, string> = {
+  GET: '--color-success',
+  POST: '--color-info',
+  PUT: '--color-warning',
+  PATCH: '--color-warning',
+  DELETE: '--color-error',
+  HEAD: '--color-text-muted',
+  OPTIONS: '--color-text-muted',
+}
+
+function methodToken(method: string): string {
+  return METHOD_TOKENS[method.toUpperCase()] ?? '--color-text-muted'
+}
+
+/** Tailwind text colour class. */
+export function httpMethodTextClass(method: string): string {
+  return `text-[var(${methodToken(method)})]`
+}
+
+/** Raw `var(...)`, for the one caller that needs it inside a `color-mix()`. */
+export function httpMethodColorVar(method: string): string {
+  return `var(${methodToken(method)})`
+}

--- a/apps/cockpit/src/lib/shortcut-label.ts
+++ b/apps/cockpit/src/lib/shortcut-label.ts
@@ -1,0 +1,76 @@
+import { detectPlatform } from './platform'
+
+// ⌘↵ and ⇧ are the idiom every Mac user already reads without thinking. Off macOS they are not:
+// ⇧ and ↵ aren't printed on a PC keyboard, so "Ctrl+⇧+D" asks the reader to decode a symbol their
+// hardware never showed them. Two maps, one per convention.
+const MAC_SYMBOLS: Record<string, string> = {
+  enter: '↵',
+  return: '↵',
+  escape: 'Esc',
+  esc: 'Esc',
+  shift: '⇧',
+  alt: '⌥',
+  option: '⌥',
+  ctrl: '⌃',
+  control: '⌃',
+  cmd: '⌘',
+  meta: '⌘',
+  backspace: '⌫',
+  delete: '⌦',
+  tab: '⇥',
+  space: 'Space',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+}
+
+const PC_NAMES: Record<string, string> = {
+  enter: 'Enter',
+  return: 'Enter',
+  escape: 'Esc',
+  esc: 'Esc',
+  shift: 'Shift',
+  alt: 'Alt',
+  option: 'Alt',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  cmd: 'Ctrl',
+  meta: 'Win',
+  backspace: 'Backspace',
+  delete: 'Del',
+  tab: 'Tab',
+  space: 'Space',
+  // Arrows survive the switch — they're printed on every keyboard.
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+}
+
+/**
+ * Renders a `useKeyboardShortcut` combo (`mod+enter`, `shift+alt+f`) as display text.
+ *
+ * `Kbd` is the component form, for a hint that stands beside a control. This is the string form,
+ * for the places a component can't go: `title=` tooltips, `aria-label`s, and `EmptyState`
+ * descriptions. Both resolve `mod` the same way, so a tooltip can't claim ⌘ on a Windows machine
+ * while the `<kbd>` next to it says Ctrl — which is exactly what the hardcoded literals did.
+ */
+export function formatShortcut(keys: string, isMac = detectPlatform() === 'mac'): string {
+  const names = isMac ? MAC_SYMBOLS : PC_NAMES
+
+  return (
+    keys
+      .split('+')
+      .map((raw) => {
+        const key = raw.trim().toLowerCase()
+        if (key === 'mod') return isMac ? '⌘' : 'Ctrl'
+        const symbol = names[key]
+        if (symbol) return symbol
+        return key.length === 1 ? key.toUpperCase() : raw.trim()
+      })
+      // No separator on macOS, where modifiers are conventionally run together (⌘⇧P), but a
+      // separator elsewhere, where they aren't (Ctrl+Shift+P).
+      .join(isMac ? '' : '+')
+  )
+}

--- a/apps/cockpit/src/styles/tokens.css
+++ b/apps/cockpit/src/styles/tokens.css
@@ -75,6 +75,12 @@
   --elevation-3: 0 4px 16px -4px var(--color-shadow);
 
   --focus-ring: 0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-accent);
+
+  /* Inset variant for controls that sit flush in a dense container — sidebar rows, tab strips,
+     list items. The outer ring draws 4px beyond the element, which those containers clip or
+     overlap onto the neighbouring row, so the indicator has to come inward instead. Two focus
+     treatments, both documented; anything else is drift (see DESIGN_SYSTEM.md § Focus). */
+  --focus-ring-inset: inset 0 0 0 1px var(--color-bg), inset 0 0 0 3px var(--color-accent);
 }
 
 .midnight {

--- a/apps/cockpit/src/tools/__tests__/api-client.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/api-client.test.tsx
@@ -384,7 +384,11 @@ describe('ApiClient', () => {
     const onSelect = vi.fn()
     useApiStore.setState({ requests: [request], requestHistory: [] })
 
-    render(<CollectionsSidebar activeRequestId={null} onSelect={onSelect} />)
+    render(
+      <CollectionsSidebar activeRequestId={null} onSelect={onSelect}>
+        <div />
+      </CollectionsSidebar>
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Get User' }))
 
     expect(onSelect).toHaveBeenCalledWith(request)
@@ -443,7 +447,9 @@ describe('ApiClient', () => {
     })
 
     render(
-      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} onLoadFromHistory={vi.fn()} />
+      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} onLoadFromHistory={vi.fn()}>
+        <div />
+      </CollectionsSidebar>
     )
     fireEvent.click(screen.getByText('History'))
 
@@ -519,7 +525,11 @@ describe('ApiClient', () => {
   it('confirms before deleting a saved request', () => {
     const deleteRequest = vi.fn().mockResolvedValue(undefined)
     useApiStore.setState({ requests: [savedRequest], deleteRequest })
-    render(<CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} />)
+    render(
+      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()}>
+        <div />
+      </CollectionsSidebar>
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Actions for Get User' }))
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete…' }))
@@ -536,7 +546,11 @@ describe('ApiClient', () => {
       requests: [{ ...savedRequest, collectionId: 'col-1' }],
       deleteCollection,
     })
-    render(<CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} />)
+    render(
+      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()}>
+        <div />
+      </CollectionsSidebar>
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete collection Accounts' }))
 
@@ -552,7 +566,11 @@ describe('ApiClient', () => {
         { ...savedRequest, id: 'req-2', name: 'Create order', method: 'POST', url: '/orders' },
       ],
     })
-    render(<CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} />)
+    render(
+      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()}>
+        <div />
+      </CollectionsSidebar>
+    )
 
     fireEvent.change(screen.getByLabelText('Search saved requests'), {
       target: { value: 'order' },
@@ -570,7 +588,11 @@ describe('ApiClient', () => {
     useApiStore.setState({
       requests: [savedRequest, { ...savedRequest, id: 'req-2', name: 'Create order' }],
     })
-    render(<CollectionsSidebar activeRequestId={null} onSelect={vi.fn()} />)
+    render(
+      <CollectionsSidebar activeRequestId={null} onSelect={vi.fn()}>
+        <div />
+      </CollectionsSidebar>
+    )
 
     const first = screen.getByRole('button', { name: 'Get User' })
     first.focus()

--- a/apps/cockpit/src/tools/__tests__/prompt-templates.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/prompt-templates.test.tsx
@@ -116,7 +116,7 @@ describe('PromptTemplates', () => {
       'true'
     )
     fireEvent.click(screen.getByRole('tab', { name: /preview/i }))
-    expect(screen.getByText('[ 03-PREVIEW ]')).toBeInTheDocument()
+    expect(screen.getByText('Preview')).toBeInTheDocument()
   })
 
   it('filters templates by search text', () => {

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -856,7 +856,7 @@ export default function ApiClient() {
                     : 'text-[var(--color-text-muted)]'
                 }
               >
-                <SidebarIcon size={15} aria-hidden="true" />
+                <SidebarIcon size={16} aria-hidden="true" />
               </Button>
 
               <div className="min-w-0 flex-1 basis-40">
@@ -885,7 +885,7 @@ export default function ApiClient() {
                 title="New request"
                 aria-label="New request"
               >
-                <FilePlusIcon size={15} aria-hidden="true" />
+                <FilePlusIcon size={16} aria-hidden="true" />
               </Button>
 
               <div className="flex items-center gap-1">
@@ -911,7 +911,7 @@ export default function ApiClient() {
                   title="Manage environments"
                   aria-label="Manage environments"
                 >
-                  <GearSixIcon size={15} aria-hidden="true" />
+                  <GearSixIcon size={16} aria-hidden="true" />
                 </Button>
               </div>
 
@@ -967,7 +967,7 @@ export default function ApiClient() {
                 className="gap-1.5"
                 title="Send request (⌘↵)"
               >
-                <PaperPlaneTiltIcon size={13} aria-hidden="true" />
+                <PaperPlaneTiltIcon size={14} aria-hidden="true" />
                 Send
               </Button>
               <Button
@@ -1016,7 +1016,7 @@ export default function ApiClient() {
                     onClick={addParam}
                     className="gap-1"
                   >
-                    <PlusIcon size={10} aria-hidden="true" />
+                    <PlusIcon size={12} aria-hidden="true" />
                     Add
                   </Button>
                 </div>
@@ -1079,7 +1079,7 @@ export default function ApiClient() {
                     onClick={addHeader}
                     className="gap-1"
                   >
-                    <PlusIcon size={10} aria-hidden="true" />
+                    <PlusIcon size={12} aria-hidden="true" />
                     Add
                   </Button>
                 </div>
@@ -1232,7 +1232,7 @@ export default function ApiClient() {
                         title="Save response to a file (⌘S)"
                         aria-label="Save response to a file"
                       >
-                        <DownloadSimpleIcon size={13} aria-hidden="true" />
+                        <DownloadSimpleIcon size={14} aria-hidden="true" />
                       </Button>
                     </div>
                   </div>

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -48,6 +48,7 @@ import {
 } from '@phosphor-icons/react'
 import { formatBytes } from '@/lib/format'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
 const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'])
@@ -978,7 +979,7 @@ export default function ApiClient() {
                   onClick={() => void handleSend()}
                   loading={loading}
                   className="gap-1.5"
-                  title="Send request (⌘↵)"
+                  title={`Send request (${formatShortcut('mod+enter')})`}
                 >
                   <PaperPlaneTiltIcon size={14} aria-hidden="true" />
                   Send
@@ -1233,7 +1234,7 @@ export default function ApiClient() {
                           variant="icon"
                           size="xs"
                           onClick={() => void handleSaveResponse()}
-                          title="Save response to a file (⌘S)"
+                          title={`Save response to a file (${formatShortcut('mod+s')})`}
                           aria-label="Save response to a file"
                         >
                           <DownloadSimpleIcon size={14} aria-hidden="true" />
@@ -1275,7 +1276,7 @@ export default function ApiClient() {
                     <EmptyState
                       icon={PaperPlaneTiltIcon}
                       title="Send a request to see the response"
-                      description="⌘↵ sends the current request."
+                      description={`${formatShortcut('mod+enter')} sends the current request.`}
                     />
                   </div>
                 )}

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import { useToolState } from '@/hooks/useToolState'
@@ -13,6 +13,8 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Spinner } from '@/components/shared/Spinner'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { Alert } from '@/components/shared/Alert'
 import { StatusBadge } from '@/components/shared/StatusBadge'
 import { useUiStore } from '@/stores/ui.store'
@@ -227,6 +229,24 @@ function applyMethodDefaults(draft: RequestDraft, nextMethod: string): RequestDr
       ? draft.headers
       : [{ key: 'Content-Type', value: 'application/json', enabled: true }, ...draft.headers],
   }
+}
+
+/**
+ * Request beside response when both are up, request alone when the response pane is hidden.
+ *
+ * A local wrapper rather than a conditional at the call site: the two panels are ~300 lines of
+ * JSX, and lifting them into consts purely to choose a container is a lot of churn for one
+ * branch. `false` is the shape `{cond && <section/>}` actually produces.
+ */
+function RequestResponseLayout({ children }: { children: [ReactNode, ReactNode | false] }) {
+  const [request, response] = children
+  if (!response) return <div className="flex min-h-0 flex-1">{request}</div>
+  return (
+    <SplitPane storageKey="api-client" stackBelow={1000} aria-label="Resize request and response">
+      {request}
+      {response}
+    </SplitPane>
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -842,7 +862,7 @@ export default function ApiClient() {
         toolbar={
           <>
             {/* Request identity + save actions */}
-            <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2">
+            <Toolbar aria-label="Request identity and save actions">
               <Button
                 type="button"
                 variant="icon"
@@ -889,7 +909,7 @@ export default function ApiClient() {
                 <FilePlusIcon size={16} aria-hidden="true" />
               </Button>
 
-              <div className="flex items-center gap-1">
+              <ToolbarGroup>
                 <Select
                   value={activeEnvironmentId || ''}
                   onChange={(e) => setActiveEnvironmentId(e.target.value || null)}
@@ -914,9 +934,9 @@ export default function ApiClient() {
                 >
                   <GearSixIcon size={16} aria-hidden="true" />
                 </Button>
-              </div>
+              </ToolbarGroup>
 
-              <div className="flex items-center gap-1.5">
+              <ToolbarGroup>
                 <Button
                   type="button"
                   variant={dirty ? 'primary' : 'secondary'}
@@ -931,11 +951,11 @@ export default function ApiClient() {
                 <Button type="button" variant="secondary" size="sm" onClick={handleSaveAs}>
                   Save As
                 </Button>
-              </div>
-            </div>
+              </ToolbarGroup>
+            </Toolbar>
 
             {/* URL bar */}
-            <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
+            <Toolbar aria-label="Request URL and send">
               <Select
                 value={method}
                 onChange={(e) => handleMethodChange(e.target.value)}
@@ -981,25 +1001,15 @@ export default function ApiClient() {
               >
                 {responseVisible ? 'Hide Response' : 'Show Response'}
               </Button>
-            </div>
+            </Toolbar>
           </>
         }
       >
-        <div
-          className={`grid min-h-0 flex-1 ${
-            responseVisible
-              ? 'grid-cols-2 max-[1000px]:grid-cols-1 max-[1000px]:grid-rows-2'
-              : 'grid-cols-1'
-          }`}
-        >
+        <RequestResponseLayout>
           {/* ── Request panel ─────────────────────────────────── */}
           <section
             aria-label="Request"
-            className={`flex min-h-0 min-w-0 flex-col overflow-hidden ${
-              responseVisible
-                ? 'border-r border-[var(--color-border)] max-[1000px]:border-b max-[1000px]:border-r-0'
-                : ''
-            }`}
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
           >
             <TabBar tabs={requestTabs} activeTab={requestTab} onTabChange={setRequestTab} />
 
@@ -1141,7 +1151,7 @@ export default function ApiClient() {
             {/* Body tab */}
             {requestTab === 'body' && (
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                <div className="flex flex-wrap items-center gap-1 border-b border-[var(--color-border)] px-3 py-1.5">
+                <Toolbar className="gap-1" aria-label="Request body format">
                   {BODY_MODES.map((mode) => (
                     <Button
                       key={mode.id}
@@ -1164,7 +1174,7 @@ export default function ApiClient() {
                       Body not available for {method}
                     </span>
                   )}
-                </div>
+                </Toolbar>
                 {showBody ? (
                   <div className="min-h-0 flex-1 overflow-hidden">
                     <Editor
@@ -1198,7 +1208,7 @@ export default function ApiClient() {
             <section
               id={responsePaneId}
               aria-label="Response"
-              className="flex min-h-0 min-w-0 flex-col overflow-hidden"
+              className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
             >
               {error && (
                 <Alert
@@ -1210,7 +1220,7 @@ export default function ApiClient() {
               )}
               {response && (
                 <>
-                  <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
+                  <Toolbar aria-label="Response summary and actions">
                     <StatusBadge
                       variant={response.status < 400 ? 'success' : 'error'}
                       className="font-mono"
@@ -1223,7 +1233,8 @@ export default function ApiClient() {
                     <span className="text-2xs text-[var(--color-text-muted)]">
                       {formatBytes(response.size)}
                     </span>
-                    <div className="ml-auto flex items-center gap-1">
+                    <ToolbarSpacer />
+                    <ToolbarGroup>
                       <CopyButton text={prettyBody} />
                       <Button
                         type="button"
@@ -1235,8 +1246,8 @@ export default function ApiClient() {
                       >
                         <DownloadSimpleIcon size={14} aria-hidden="true" />
                       </Button>
-                    </div>
-                  </div>
+                    </ToolbarGroup>
+                  </Toolbar>
                   <TabBar
                     tabs={RESPONSE_TABS}
                     activeTab={responseTab}
@@ -1287,7 +1298,7 @@ export default function ApiClient() {
               )}
             </section>
           )}
-        </div>
+        </RequestResponseLayout>
       </ToolLayout>
 
       {showEnvModal && <EnvironmentModal onClose={() => setShowEnvModal(false)} />}

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -840,466 +840,459 @@ export default function ApiClient() {
   }, [state.libraryOpen, updateState])
 
   return (
-    <div
-      className={`grid h-full min-h-0 bg-[var(--color-bg)] ${
-        state.libraryOpen
-          ? 'grid-cols-[minmax(13rem,17rem)_minmax(0,1fr)] max-[900px]:grid-cols-[11.5rem_minmax(0,1fr)]'
-          : 'grid-cols-[minmax(0,1fr)]'
-      }`}
-    >
-      {state.libraryOpen && (
-        <CollectionsSidebar
-          activeRequestId={state.activeRequestId}
-          onSelect={handleSelectLoadedRequest}
-          onLoadFromHistory={handleLoadFromHistory}
-          onImport={() => setShowImportModal(true)}
-          onExport={() => void handleExport()}
-        />
-      )}
-
-      <ToolLayout
-        fullBleed
-        toolbar={
-          <>
-            {/* Request identity + save actions */}
-            <Toolbar aria-label="Request identity and save actions">
-              <Button
-                type="button"
-                variant="icon"
-                size="sm"
-                onClick={toggleLibrary}
-                aria-expanded={state.libraryOpen}
-                aria-label={state.libraryOpen ? 'Hide request library' : 'Show request library'}
-                title={state.libraryOpen ? 'Hide request library' : 'Show request library'}
-                className={
-                  state.libraryOpen
-                    ? 'text-[var(--color-accent)]'
-                    : 'text-[var(--color-text-muted)]'
-                }
-              >
-                <SidebarIcon size={16} aria-hidden="true" />
-              </Button>
-
-              <div className="min-w-0 flex-1 basis-40">
-                <InlineInput
-                  value={name}
-                  onChange={(e) => updateDraft({ name: e.target.value })}
-                  placeholder={DEFAULT_REQUEST_NAME}
-                  aria-label="Request name"
-                  className="w-full truncate"
-                />
-                <p
-                  className={`text-2xs ${
-                    dirty ? 'text-[var(--color-warning)]' : 'text-[var(--color-text-muted)]'
-                  }`}
-                  aria-live="polite"
-                >
-                  {statusLine}
-                </p>
-              </div>
-
-              <Button
-                type="button"
-                variant="icon"
-                size="sm"
-                onClick={handleNewRequest}
-                title="New request"
-                aria-label="New request"
-              >
-                <FilePlusIcon size={16} aria-hidden="true" />
-              </Button>
-
-              <ToolbarGroup>
-                <Select
-                  value={activeEnvironmentId || ''}
-                  onChange={(e) => setActiveEnvironmentId(e.target.value || null)}
-                  aria-label="Active environment"
-                  title="Active environment"
-                  className="max-w-36"
-                >
-                  <option value="">No Environment</option>
-                  {environments.map((e) => (
-                    <option key={e.id} value={e.id}>
-                      {e.name}
-                    </option>
-                  ))}
-                </Select>
+    <>
+      <CollectionsSidebar
+        activeRequestId={state.activeRequestId}
+        open={state.libraryOpen}
+        onSelect={handleSelectLoadedRequest}
+        onLoadFromHistory={handleLoadFromHistory}
+        onImport={() => setShowImportModal(true)}
+        onExport={() => void handleExport()}
+      >
+        <ToolLayout
+          fullBleed
+          toolbar={
+            <>
+              {/* Request identity + save actions */}
+              <Toolbar aria-label="Request identity and save actions">
                 <Button
                   type="button"
                   variant="icon"
                   size="sm"
-                  onClick={() => setShowEnvModal(true)}
-                  title="Manage environments"
-                  aria-label="Manage environments"
+                  onClick={toggleLibrary}
+                  aria-expanded={state.libraryOpen}
+                  aria-label={state.libraryOpen ? 'Hide request library' : 'Show request library'}
+                  title={state.libraryOpen ? 'Hide request library' : 'Show request library'}
+                  className={
+                    state.libraryOpen
+                      ? 'text-[var(--color-accent)]'
+                      : 'text-[var(--color-text-muted)]'
+                  }
                 >
-                  <GearSixIcon size={16} aria-hidden="true" />
+                  <SidebarIcon size={16} aria-hidden="true" />
                 </Button>
-              </ToolbarGroup>
 
-              <ToolbarGroup>
+                <div className="min-w-0 flex-1 basis-40">
+                  <InlineInput
+                    value={name}
+                    onChange={(e) => updateDraft({ name: e.target.value })}
+                    placeholder={DEFAULT_REQUEST_NAME}
+                    aria-label="Request name"
+                    className="w-full truncate"
+                  />
+                  <p
+                    className={`text-2xs ${
+                      dirty ? 'text-[var(--color-warning)]' : 'text-[var(--color-text-muted)]'
+                    }`}
+                    aria-live="polite"
+                  >
+                    {statusLine}
+                  </p>
+                </div>
+
                 <Button
                   type="button"
-                  variant={dirty ? 'primary' : 'secondary'}
+                  variant="icon"
                   size="sm"
-                  loading={saving}
-                  disabled={!dirty && !!state.activeRequestId}
-                  onClick={() => void handleSave()}
-                  title="Save request"
+                  onClick={handleNewRequest}
+                  title="New request"
+                  aria-label="New request"
                 >
-                  Save
+                  <FilePlusIcon size={16} aria-hidden="true" />
                 </Button>
-                <Button type="button" variant="secondary" size="sm" onClick={handleSaveAs}>
-                  Save As
-                </Button>
-              </ToolbarGroup>
-            </Toolbar>
 
-            {/* URL bar */}
-            <Toolbar aria-label="Request URL and send">
-              <Select
-                value={method}
-                onChange={(e) => handleMethodChange(e.target.value)}
-                aria-label="HTTP method"
-                className={`font-mono font-bold ${httpMethodTextClass(method)}`}
-              >
-                {METHODS.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </Select>
-              <Input
-                value={url}
-                onChange={(e) => updateDraft({ url: e.target.value })}
-                placeholder="{{baseUrl}}/endpoint"
-                aria-label="Request URL"
-                size="md"
-                className="min-w-40 flex-1 basis-48 font-mono"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') void handleSend()
-                }}
-              />
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                onClick={() => void handleSend()}
-                loading={loading}
-                className="gap-1.5"
-                title="Send request (⌘↵)"
-              >
-                <PaperPlaneTiltIcon size={14} aria-hidden="true" />
-                Send
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={toggleResponsePane}
-                aria-expanded={responseVisible}
-                aria-controls={responsePaneId}
-              >
-                {responseVisible ? 'Hide Response' : 'Show Response'}
-              </Button>
-            </Toolbar>
-          </>
-        }
-      >
-        <RequestResponseLayout>
-          {/* ── Request panel ─────────────────────────────────── */}
-          <section
-            aria-label="Request"
-            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-          >
-            <TabBar tabs={requestTabs} activeTab={requestTab} onTabChange={setRequestTab} />
-
-            {/* Params tab */}
-            {requestTab === 'params' && (
-              <div className="min-h-0 flex-1 overflow-auto p-3">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
-                    Query Parameters
-                  </h3>
+                <ToolbarGroup>
+                  <Select
+                    value={activeEnvironmentId || ''}
+                    onChange={(e) => setActiveEnvironmentId(e.target.value || null)}
+                    aria-label="Active environment"
+                    title="Active environment"
+                    className="max-w-36"
+                  >
+                    <option value="">No Environment</option>
+                    {environments.map((e) => (
+                      <option key={e.id} value={e.id}>
+                        {e.name}
+                      </option>
+                    ))}
+                  </Select>
                   <Button
                     type="button"
-                    variant="secondary"
-                    size="xs"
-                    onClick={addParam}
-                    className="gap-1"
-                  >
-                    <PlusIcon size={12} aria-hidden="true" />
-                    Add
-                  </Button>
-                </div>
-                {params.length > 0 ? (
-                  <div className="flex flex-col gap-1">
-                    {params.map((p, i) => (
-                      <div key={i} className="flex items-center gap-1">
-                        <Input
-                          value={p.key}
-                          onChange={(e) => updateParam(i, { key: e.target.value })}
-                          placeholder="Key"
-                          aria-label={`Query parameter ${i + 1} name`}
-                          className="w-1/3 min-w-0 font-mono"
-                        />
-                        <Input
-                          value={p.value}
-                          onChange={(e) => updateParam(i, { value: e.target.value })}
-                          placeholder="Value"
-                          aria-label={`Query parameter ${i + 1} value`}
-                          className="min-w-0 flex-1 font-mono"
-                        />
-                        <Button
-                          type="button"
-                          variant="icon"
-                          size="xs"
-                          onClick={() => removeParam(i)}
-                          aria-label={`Remove query parameter ${p.key || i + 1}`}
-                          className="hover:text-[var(--color-error)]"
-                        >
-                          <XIcon size={14} aria-hidden />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState
-                    icon={LinkIcon}
+                    variant="icon"
                     size="sm"
-                    title="No query parameters"
-                    description="Add them here, or type them straight into the URL."
-                  />
-                )}
-              </div>
-            )}
+                    onClick={() => setShowEnvModal(true)}
+                    title="Manage environments"
+                    aria-label="Manage environments"
+                  >
+                    <GearSixIcon size={16} aria-hidden="true" />
+                  </Button>
+                </ToolbarGroup>
 
-            {/* Headers tab */}
-            {requestTab === 'headers' && (
-              <div className="min-h-0 flex-1 overflow-auto p-3">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
-                    Headers
-                    {activeHeaderCount > 0 && (
-                      <span className="ml-1 text-[var(--color-text)]">({activeHeaderCount})</span>
-                    )}
-                  </h3>
+                <ToolbarGroup>
                   <Button
                     type="button"
-                    variant="secondary"
-                    size="xs"
-                    onClick={addHeader}
-                    className="gap-1"
-                  >
-                    <PlusIcon size={12} aria-hidden="true" />
-                    Add
-                  </Button>
-                </div>
-                {headers.length > 0 ? (
-                  <div className="flex flex-col gap-1">
-                    {headers.map((h, i) => (
-                      <div key={i} className="flex items-center gap-1">
-                        <input
-                          type="checkbox"
-                          checked={h.enabled}
-                          onChange={(e) => updateHeader(i, { enabled: e.target.checked })}
-                          aria-label={`Send header ${h.key || i + 1}`}
-                          className="accent-[var(--color-accent)]"
-                        />
-                        <Input
-                          value={h.key}
-                          onChange={(e) => updateHeader(i, { key: e.target.value })}
-                          placeholder="Header name"
-                          aria-label={`Header ${i + 1} name`}
-                          className="w-1/3 min-w-0 font-mono"
-                        />
-                        <Input
-                          value={h.value}
-                          onChange={(e) => updateHeader(i, { value: e.target.value })}
-                          placeholder="Value (or {{env_var}})"
-                          aria-label={`Header ${i + 1} value`}
-                          className="min-w-0 flex-1 font-mono"
-                        />
-                        <Button
-                          type="button"
-                          variant="icon"
-                          size="xs"
-                          onClick={() => removeHeader(i)}
-                          aria-label={`Remove header ${h.key || i + 1}`}
-                          className="hover:text-[var(--color-error)]"
-                        >
-                          <XIcon size={14} aria-hidden />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <EmptyState
-                    icon={ListBulletsIcon}
+                    variant={dirty ? 'primary' : 'secondary'}
                     size="sm"
-                    title="No headers"
-                    description="Add Accept, Authorization, or any custom header."
-                  />
-                )}
-              </div>
-            )}
+                    loading={saving}
+                    disabled={!dirty && !!state.activeRequestId}
+                    onClick={() => void handleSave()}
+                    title="Save request"
+                  >
+                    Save
+                  </Button>
+                  <Button type="button" variant="secondary" size="sm" onClick={handleSaveAs}>
+                    Save As
+                  </Button>
+                </ToolbarGroup>
+              </Toolbar>
 
-            {/* Auth tab */}
-            {requestTab === 'auth' && (
-              <AuthTab auth={auth} onChange={(a) => updateDraft({ auth: a })} />
-            )}
-
-            {/* Body tab */}
-            {requestTab === 'body' && (
-              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                <Toolbar className="gap-1" aria-label="Request body format">
-                  {BODY_MODES.map((mode) => (
-                    <Button
-                      key={mode.id}
-                      type="button"
-                      variant="ghost"
-                      size="xs"
-                      aria-pressed={bodyMode === mode.id}
-                      onClick={() => updateDraft({ bodyMode: mode.id })}
-                      className={
-                        bodyMode === mode.id
-                          ? 'bg-[var(--color-accent-dim)] font-bold text-[var(--color-accent)]'
-                          : ''
-                      }
-                    >
-                      {mode.label}
-                    </Button>
+              {/* URL bar */}
+              <Toolbar aria-label="Request URL and send">
+                <Select
+                  value={method}
+                  onChange={(e) => handleMethodChange(e.target.value)}
+                  aria-label="HTTP method"
+                  className={`font-mono font-bold ${httpMethodTextClass(method)}`}
+                >
+                  {METHODS.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
                   ))}
-                  {!BODY_METHODS.has(method) && (
-                    <span className="ml-2 text-2xs text-[var(--color-text-muted)]">
-                      Body not available for {method}
-                    </span>
-                  )}
-                </Toolbar>
-                {showBody ? (
-                  <div className="min-h-0 flex-1 overflow-hidden">
-                    <Editor
-                      theme={monacoTheme}
-                      language={bodyEditorLang}
-                      value={body}
-                      onChange={(v) => updateDraft({ body: v ?? '' })}
-                      options={monacoOptions}
-                    />
-                  </div>
-                ) : (
-                  <div className="flex min-h-0 flex-1 items-center justify-center">
-                    <EmptyState
-                      icon={CodeIcon}
-                      size="sm"
-                      title={bodyMode === 'none' ? 'Body is disabled' : `No body for ${method}`}
-                      description={
-                        bodyMode === 'none'
-                          ? 'Pick JSON or Text above to send a request body.'
-                          : `${method} requests do not include a body.`
-                      }
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-          </section>
-
-          {/* ── Response panel ────────────────────────────────── */}
-          {responseVisible && (
+                </Select>
+                <Input
+                  value={url}
+                  onChange={(e) => updateDraft({ url: e.target.value })}
+                  placeholder="{{baseUrl}}/endpoint"
+                  aria-label="Request URL"
+                  size="md"
+                  className="min-w-40 flex-1 basis-48 font-mono"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') void handleSend()
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => void handleSend()}
+                  loading={loading}
+                  className="gap-1.5"
+                  title="Send request (⌘↵)"
+                >
+                  <PaperPlaneTiltIcon size={14} aria-hidden="true" />
+                  Send
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={toggleResponsePane}
+                  aria-expanded={responseVisible}
+                  aria-controls={responsePaneId}
+                >
+                  {responseVisible ? 'Hide Response' : 'Show Response'}
+                </Button>
+              </Toolbar>
+            </>
+          }
+        >
+          <RequestResponseLayout>
+            {/* ── Request panel ─────────────────────────────────── */}
             <section
-              id={responsePaneId}
-              aria-label="Response"
+              aria-label="Request"
               className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
             >
-              {error && (
-                <Alert
-                  variant="error"
-                  className="rounded-none border-b border-[var(--color-border)] px-4 py-2"
-                >
-                  {error}
-                </Alert>
-              )}
-              {response && (
-                <>
-                  <Toolbar aria-label="Response summary and actions">
-                    <StatusBadge
-                      variant={response.status < 400 ? 'success' : 'error'}
-                      className="font-mono"
+              <TabBar tabs={requestTabs} activeTab={requestTab} onTabChange={setRequestTab} />
+
+              {/* Params tab */}
+              {requestTab === 'params' && (
+                <div className="min-h-0 flex-1 overflow-auto p-3">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
+                      Query Parameters
+                    </h3>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="xs"
+                      onClick={addParam}
+                      className="gap-1"
                     >
-                      {response.status} {response.statusText}
-                    </StatusBadge>
-                    <span className="text-2xs text-[var(--color-text-muted)]">
-                      {response.time}ms
-                    </span>
-                    <span className="text-2xs text-[var(--color-text-muted)]">
-                      {formatBytes(response.size)}
-                    </span>
-                    <ToolbarSpacer />
-                    <ToolbarGroup>
-                      <CopyButton text={prettyBody} />
-                      <Button
-                        type="button"
-                        variant="icon"
-                        size="xs"
-                        onClick={() => void handleSaveResponse()}
-                        title="Save response to a file (⌘S)"
-                        aria-label="Save response to a file"
-                      >
-                        <DownloadSimpleIcon size={14} aria-hidden="true" />
-                      </Button>
-                    </ToolbarGroup>
-                  </Toolbar>
-                  <TabBar
-                    tabs={RESPONSE_TABS}
-                    activeTab={responseTab}
-                    onTabChange={setResponseTab}
-                  />
-                  <div className="min-h-0 flex-1 overflow-hidden">
-                    {responseTab === 'body' ? (
-                      <Editor
-                        theme={monacoTheme}
-                        language={responseLanguage}
-                        value={prettyBody}
-                        onMount={handleResponseEditorMount}
-                        options={{ ...monacoOptions, readOnly: true }}
-                      />
-                    ) : (
-                      <div className="h-full overflow-auto p-3">
-                        {Object.entries(response.headers).map(([key, value]) => (
-                          <div key={key} className="mb-1 flex items-start gap-1 text-xs">
-                            <span className="shrink-0 font-bold text-[var(--color-accent)]">
-                              {key}
-                            </span>
-                            <span className="text-[var(--color-text-muted)]">: </span>
-                            <span className="break-all text-[var(--color-text)]">{value}</span>
-                          </div>
-                        ))}
-                      </div>
-                    )}
+                      <PlusIcon size={12} aria-hidden="true" />
+                      Add
+                    </Button>
                   </div>
-                </>
-              )}
-              {!response && !error && !loading && (
-                <div className="flex min-h-0 flex-1 items-center justify-center">
-                  <EmptyState
-                    icon={PaperPlaneTiltIcon}
-                    title="Send a request to see the response"
-                    description="⌘↵ sends the current request."
-                  />
+                  {params.length > 0 ? (
+                    <div className="flex flex-col gap-1">
+                      {params.map((p, i) => (
+                        <div key={i} className="flex items-center gap-1">
+                          <Input
+                            value={p.key}
+                            onChange={(e) => updateParam(i, { key: e.target.value })}
+                            placeholder="Key"
+                            aria-label={`Query parameter ${i + 1} name`}
+                            className="w-1/3 min-w-0 font-mono"
+                          />
+                          <Input
+                            value={p.value}
+                            onChange={(e) => updateParam(i, { value: e.target.value })}
+                            placeholder="Value"
+                            aria-label={`Query parameter ${i + 1} value`}
+                            className="min-w-0 flex-1 font-mono"
+                          />
+                          <Button
+                            type="button"
+                            variant="icon"
+                            size="xs"
+                            onClick={() => removeParam(i)}
+                            aria-label={`Remove query parameter ${p.key || i + 1}`}
+                            className="hover:text-[var(--color-error)]"
+                          >
+                            <XIcon size={14} aria-hidden />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState
+                      icon={LinkIcon}
+                      size="sm"
+                      title="No query parameters"
+                      description="Add them here, or type them straight into the URL."
+                    />
+                  )}
                 </div>
               )}
-              {loading && (
-                <div
-                  className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--color-text-muted)]"
-                  role="status"
-                >
-                  <Spinner size="md" label="Sending request" />
-                  Sending request…
+
+              {/* Headers tab */}
+              {requestTab === 'headers' && (
+                <div className="min-h-0 flex-1 overflow-auto p-3">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
+                      Headers
+                      {activeHeaderCount > 0 && (
+                        <span className="ml-1 text-[var(--color-text)]">({activeHeaderCount})</span>
+                      )}
+                    </h3>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="xs"
+                      onClick={addHeader}
+                      className="gap-1"
+                    >
+                      <PlusIcon size={12} aria-hidden="true" />
+                      Add
+                    </Button>
+                  </div>
+                  {headers.length > 0 ? (
+                    <div className="flex flex-col gap-1">
+                      {headers.map((h, i) => (
+                        <div key={i} className="flex items-center gap-1">
+                          <input
+                            type="checkbox"
+                            checked={h.enabled}
+                            onChange={(e) => updateHeader(i, { enabled: e.target.checked })}
+                            aria-label={`Send header ${h.key || i + 1}`}
+                            className="accent-[var(--color-accent)]"
+                          />
+                          <Input
+                            value={h.key}
+                            onChange={(e) => updateHeader(i, { key: e.target.value })}
+                            placeholder="Header name"
+                            aria-label={`Header ${i + 1} name`}
+                            className="w-1/3 min-w-0 font-mono"
+                          />
+                          <Input
+                            value={h.value}
+                            onChange={(e) => updateHeader(i, { value: e.target.value })}
+                            placeholder="Value (or {{env_var}})"
+                            aria-label={`Header ${i + 1} value`}
+                            className="min-w-0 flex-1 font-mono"
+                          />
+                          <Button
+                            type="button"
+                            variant="icon"
+                            size="xs"
+                            onClick={() => removeHeader(i)}
+                            aria-label={`Remove header ${h.key || i + 1}`}
+                            className="hover:text-[var(--color-error)]"
+                          >
+                            <XIcon size={14} aria-hidden />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <EmptyState
+                      icon={ListBulletsIcon}
+                      size="sm"
+                      title="No headers"
+                      description="Add Accept, Authorization, or any custom header."
+                    />
+                  )}
+                </div>
+              )}
+
+              {/* Auth tab */}
+              {requestTab === 'auth' && (
+                <AuthTab auth={auth} onChange={(a) => updateDraft({ auth: a })} />
+              )}
+
+              {/* Body tab */}
+              {requestTab === 'body' && (
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                  <Toolbar className="gap-1" aria-label="Request body format">
+                    {BODY_MODES.map((mode) => (
+                      <Button
+                        key={mode.id}
+                        type="button"
+                        variant="ghost"
+                        size="xs"
+                        aria-pressed={bodyMode === mode.id}
+                        onClick={() => updateDraft({ bodyMode: mode.id })}
+                        className={
+                          bodyMode === mode.id
+                            ? 'bg-[var(--color-accent-dim)] font-bold text-[var(--color-accent)]'
+                            : ''
+                        }
+                      >
+                        {mode.label}
+                      </Button>
+                    ))}
+                    {!BODY_METHODS.has(method) && (
+                      <span className="ml-2 text-2xs text-[var(--color-text-muted)]">
+                        Body not available for {method}
+                      </span>
+                    )}
+                  </Toolbar>
+                  {showBody ? (
+                    <div className="min-h-0 flex-1 overflow-hidden">
+                      <Editor
+                        theme={monacoTheme}
+                        language={bodyEditorLang}
+                        value={body}
+                        onChange={(v) => updateDraft({ body: v ?? '' })}
+                        options={monacoOptions}
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex min-h-0 flex-1 items-center justify-center">
+                      <EmptyState
+                        icon={CodeIcon}
+                        size="sm"
+                        title={bodyMode === 'none' ? 'Body is disabled' : `No body for ${method}`}
+                        description={
+                          bodyMode === 'none'
+                            ? 'Pick JSON or Text above to send a request body.'
+                            : `${method} requests do not include a body.`
+                        }
+                      />
+                    </div>
+                  )}
                 </div>
               )}
             </section>
-          )}
-        </RequestResponseLayout>
-      </ToolLayout>
+
+            {/* ── Response panel ────────────────────────────────── */}
+            {responseVisible && (
+              <section
+                id={responsePaneId}
+                aria-label="Response"
+                className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+              >
+                {error && (
+                  <Alert
+                    variant="error"
+                    className="rounded-none border-b border-[var(--color-border)] px-4 py-2"
+                  >
+                    {error}
+                  </Alert>
+                )}
+                {response && (
+                  <>
+                    <Toolbar aria-label="Response summary and actions">
+                      <StatusBadge
+                        variant={response.status < 400 ? 'success' : 'error'}
+                        className="font-mono"
+                      >
+                        {response.status} {response.statusText}
+                      </StatusBadge>
+                      <span className="text-2xs text-[var(--color-text-muted)]">
+                        {response.time}ms
+                      </span>
+                      <span className="text-2xs text-[var(--color-text-muted)]">
+                        {formatBytes(response.size)}
+                      </span>
+                      <ToolbarSpacer />
+                      <ToolbarGroup>
+                        <CopyButton text={prettyBody} />
+                        <Button
+                          type="button"
+                          variant="icon"
+                          size="xs"
+                          onClick={() => void handleSaveResponse()}
+                          title="Save response to a file (⌘S)"
+                          aria-label="Save response to a file"
+                        >
+                          <DownloadSimpleIcon size={14} aria-hidden="true" />
+                        </Button>
+                      </ToolbarGroup>
+                    </Toolbar>
+                    <TabBar
+                      tabs={RESPONSE_TABS}
+                      activeTab={responseTab}
+                      onTabChange={setResponseTab}
+                    />
+                    <div className="min-h-0 flex-1 overflow-hidden">
+                      {responseTab === 'body' ? (
+                        <Editor
+                          theme={monacoTheme}
+                          language={responseLanguage}
+                          value={prettyBody}
+                          onMount={handleResponseEditorMount}
+                          options={{ ...monacoOptions, readOnly: true }}
+                        />
+                      ) : (
+                        <div className="h-full overflow-auto p-3">
+                          {Object.entries(response.headers).map(([key, value]) => (
+                            <div key={key} className="mb-1 flex items-start gap-1 text-xs">
+                              <span className="shrink-0 font-bold text-[var(--color-accent)]">
+                                {key}
+                              </span>
+                              <span className="text-[var(--color-text-muted)]">: </span>
+                              <span className="break-all text-[var(--color-text)]">{value}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+                {!response && !error && !loading && (
+                  <div className="flex min-h-0 flex-1 items-center justify-center">
+                    <EmptyState
+                      icon={PaperPlaneTiltIcon}
+                      title="Send a request to see the response"
+                      description="⌘↵ sends the current request."
+                    />
+                  </div>
+                )}
+                {loading && (
+                  <div
+                    className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-sm text-[var(--color-text-muted)]"
+                    role="status"
+                  >
+                    <Spinner size="md" label="Sending request" />
+                    Sending request…
+                  </div>
+                )}
+              </section>
+            )}
+          </RequestResponseLayout>
+        </ToolLayout>
+      </CollectionsSidebar>
 
       {showEnvModal && <EnvironmentModal onClose={() => setShowEnvModal(false)} />}
       {showSaveModal && (
@@ -1341,6 +1334,6 @@ export default function ApiClient() {
         actions={responseSelectionActions}
         onDismiss={responseSelectionToolbar.clearSelection}
       />
-    </div>
+    </>
   )
 }

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -23,7 +23,8 @@ import { useApiStore } from '@/stores/api.store'
 import { buildExportFilename, exportFile } from '@/lib/file-io'
 import { EnvironmentModal } from './components/EnvironmentModal'
 import { AuthTab } from './components/AuthTab'
-import { CollectionsSidebar, getMethodColor } from './components/CollectionsSidebar'
+import { CollectionsSidebar } from './components/CollectionsSidebar'
+import { httpMethodTextClass } from '@/lib/http-method'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { SaveRequestModal } from './components/SaveRequestModal'
 import { ImportSpecModal } from './components/ImportSpecModal'
@@ -939,7 +940,7 @@ export default function ApiClient() {
                 value={method}
                 onChange={(e) => handleMethodChange(e.target.value)}
                 aria-label="HTTP method"
-                className={`font-mono font-bold ${getMethodColor(method)}`}
+                className={`font-mono font-bold ${httpMethodTextClass(method)}`}
               >
                 {METHODS.map((m) => (
                   <option key={m} value={m}>

--- a/apps/cockpit/src/tools/api-client/components/AuthTab.tsx
+++ b/apps/cockpit/src/tools/api-client/components/AuthTab.tsx
@@ -31,9 +31,9 @@ function RevealButton({ revealed, onToggle }: { revealed: boolean; onToggle: () 
       title={revealed ? 'Hide value' : 'Reveal value'}
     >
       {revealed ? (
-        <EyeSlashIcon size={15} aria-hidden="true" />
+        <EyeSlashIcon size={16} aria-hidden="true" />
       ) : (
-        <EyeIcon size={15} aria-hidden="true" />
+        <EyeIcon size={16} aria-hidden="true" />
       )}
     </Button>
   )

--- a/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
+++ b/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
@@ -279,7 +279,7 @@ export function CollectionsSidebar({
           title="New collection"
           aria-label="New collection"
         >
-          <FolderPlusIcon size={15} aria-hidden="true" />
+          <FolderPlusIcon size={16} aria-hidden="true" />
         </Button>
       </header>
 
@@ -336,9 +336,9 @@ export function CollectionsSidebar({
                       className="min-w-0 flex-1 justify-start gap-1.5 py-1.5 text-left"
                     >
                       {isExpanded ? (
-                        <CaretDownIcon size={11} weight="bold" aria-hidden="true" />
+                        <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
                       ) : (
-                        <CaretRightIcon size={11} weight="bold" aria-hidden="true" />
+                        <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
                       )}
                       <span className="min-w-0 flex-1 truncate text-xs font-bold text-[var(--color-text)]">
                         {col.name}
@@ -456,11 +456,11 @@ export function CollectionsSidebar({
               onClick={() => setExpandedHistory((v) => !v)}
             >
               {expandedHistory ? (
-                <CaretDownIcon size={10} weight="bold" aria-hidden="true" />
+                <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
               ) : (
-                <CaretRightIcon size={10} weight="bold" aria-hidden="true" />
+                <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
               )}
-              <ClockCounterClockwiseIcon size={11} aria-hidden="true" />
+              <ClockCounterClockwiseIcon size={12} aria-hidden="true" />
               <span>History</span>
               <span className="ml-auto normal-case">{requestHistory.length}</span>
             </Button>
@@ -481,7 +481,7 @@ export function CollectionsSidebar({
                       onClick={() => onLoadFromHistory?.(method ?? 'GET', histUrl)}
                     >
                       <span
-                        className={`shrink-0 text-[9px] font-bold ${getMethodColor(method ?? 'GET')}`}
+                        className={`shrink-0 text-2xs font-bold ${getMethodColor(method ?? 'GET')}`}
                       >
                         {method}
                       </span>
@@ -511,7 +511,7 @@ export function CollectionsSidebar({
             title="Import requests from Postman, OpenAPI, AsyncAPI, protobuf, GraphQL, or JSON"
             aria-label="Import requests"
           >
-            <UploadSimpleIcon size={13} aria-hidden="true" />
+            <UploadSimpleIcon size={14} aria-hidden="true" />
           </Button>
           <Button
             type="button"
@@ -522,7 +522,7 @@ export function CollectionsSidebar({
             aria-label="Export requests"
             disabled={requests.length === 0}
           >
-            <DownloadSimpleIcon size={13} aria-hidden="true" />
+            <DownloadSimpleIcon size={14} aria-hidden="true" />
           </Button>
         </div>
       </div>
@@ -704,7 +704,7 @@ function RequestRow({
         title={`${req.method} ${req.url}`}
       >
         <span className="min-w-0 flex-1 truncate">{req.name}</span>
-        <span className={`shrink-0 text-[9px] font-bold ${getMethodColor(req.method)}`}>
+        <span className={`shrink-0 text-2xs font-bold ${getMethodColor(req.method)}`}>
           {req.method}
         </span>
       </Button>

--- a/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
+++ b/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react'
 import { useApiStore } from '@/stores/api.store'
 import type { ApiCollection, ApiRequest } from '@/types/models'
 import {
@@ -21,6 +30,7 @@ import { Input } from '@/components/shared/Input'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ConfirmDialog } from './ConfirmDialog'
 import { SearchInput } from '@/components/shared/SearchInput'
+import { MasterDetailLayout } from '@/components/shared/MasterDetailLayout'
 
 type Props = {
   activeRequestId: string | null
@@ -28,6 +38,11 @@ type Props = {
   onLoadFromHistory?: (method: string, url: string) => void
   onImport?: () => void
   onExport?: () => void
+  /** Collapsed state. ApiClient's own toolbar owns the toggle, so no toggle is rendered here. */
+  open?: boolean
+  /** The request/response side. This component renders the shared master–detail shell because
+   *  the sidebar heading's one action (new collection) needs sidebar-local state to work. */
+  children: ReactNode
 }
 
 /** `root` lists the actions; `move` swaps the same popup over to collection targets. */
@@ -61,6 +76,8 @@ export function CollectionsSidebar({
   onLoadFromHistory,
   onImport,
   onExport,
+  open = true,
+  children,
 }: Props) {
   const requestRowsId = useId()
   const collections = useApiStore((s) => s.collections)
@@ -262,273 +279,283 @@ export function CollectionsSidebar({
   const totalMatches = grouped.reduce((sum, g) => sum + g.reqs.length, 0) + unassigned.length
 
   return (
-    <aside
-      className="flex h-full min-h-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)]"
-      aria-label="Request library"
-    >
-      <header className="flex min-h-14 items-center gap-2 border-b border-[var(--color-border)] px-3">
-        <div className="min-w-0 flex-1">
-          <h2 className="font-ui text-sm font-semibold text-[var(--color-text)]">Requests</h2>
-          <p className="text-2xs text-[var(--color-text-muted)]">
-            {requests.length} saved · {collections.length} collections
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="icon"
-          size="sm"
-          onClick={() => void handleCreateCollection()}
-          title="New collection"
-          aria-label="New collection"
-        >
-          <FolderPlusIcon size={16} aria-hidden="true" />
-        </Button>
-      </header>
+    <>
+      <MasterDetailLayout
+        title="Requests"
+        subtitle={`${requests.length} saved · ${collections.length} collections`}
+        sidebarOpen={open}
+        sidebarActions={
+          <Button
+            type="button"
+            variant="icon"
+            size="sm"
+            onClick={() => void handleCreateCollection()}
+            title="New collection"
+            aria-label="New collection"
+          >
+            <FolderPlusIcon size={16} aria-hidden="true" />
+          </Button>
+        }
+        sidebar={
+          <>
+            <div className="border-b border-[var(--color-border)] p-2">
+              <SearchInput
+                value={search}
+                onValueChange={setSearch}
+                placeholder="Search requests"
+                aria-label="Search saved requests"
+                clearLabel="Clear request search"
+              />
+              {needle && (
+                <p className="mt-1.5 text-2xs text-[var(--color-text-muted)]" aria-live="polite">
+                  {totalMatches} matching {totalMatches === 1 ? 'request' : 'requests'}
+                </p>
+              )}
+            </div>
 
-      <div className="border-b border-[var(--color-border)] p-2">
-        <SearchInput
-          value={search}
-          onValueChange={setSearch}
-          placeholder="Search requests"
-          aria-label="Search saved requests"
-          clearLabel="Clear request search"
-        />
-        {needle && (
-          <p className="mt-1.5 text-2xs text-[var(--color-text-muted)]" aria-live="polite">
-            {totalMatches} matching {totalMatches === 1 ? 'request' : 'requests'}
-          </p>
-        )}
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
-        {grouped.map(({ col, reqs, total }) => {
-          const isExpanded = !!needle || !collapsedCols.has(col.id)
-          const isRenaming = editingColId === col.id
-          return (
-            <div key={col.id} className="mb-2">
-              <div className="group flex items-center gap-1 rounded px-1 hover:bg-[var(--color-surface-hover)]">
-                {isRenaming ? (
-                  <Input
-                    ref={renameInputRef}
-                    value={editingColName}
-                    onChange={(e) => setEditingColName(e.target.value)}
-                    onBlur={() => void commitRename(col)}
-                    aria-label={`Rename collection ${col.name}`}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') void commitRename(col)
-                      if (e.key === 'Escape') setEditingColId(null)
-                    }}
-                    // Boxed rather than inline: the border is what tells you the
-                    // row has flipped into edit mode. The accent colour comes from
-                    // Input's own `focus:` border — the field is autofocused on entering
-                    // rename mode and commits on blur, so it is focused for its whole
-                    // life. Restating the accent as a plain class here would do nothing:
-                    // it ties with Input's resting border on specificity and loses on
-                    // stylesheet order.
-                    className="my-1 min-w-0 flex-1 font-bold"
-                  />
-                ) : (
-                  <>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="xs"
-                      onClick={() => toggleCol(col.id)}
-                      aria-expanded={isExpanded}
-                      className="min-w-0 flex-1 justify-start gap-1.5 py-1.5 text-left"
-                    >
-                      {isExpanded ? (
-                        <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
+            <div className="min-h-0 flex-1 overflow-y-auto p-2">
+              {grouped.map(({ col, reqs, total }) => {
+                const isExpanded = !!needle || !collapsedCols.has(col.id)
+                const isRenaming = editingColId === col.id
+                return (
+                  <div key={col.id} className="mb-2">
+                    <div className="group flex items-center gap-1 rounded px-1 hover:bg-[var(--color-surface-hover)]">
+                      {isRenaming ? (
+                        <Input
+                          ref={renameInputRef}
+                          value={editingColName}
+                          onChange={(e) => setEditingColName(e.target.value)}
+                          onBlur={() => void commitRename(col)}
+                          aria-label={`Rename collection ${col.name}`}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') void commitRename(col)
+                            if (e.key === 'Escape') setEditingColId(null)
+                          }}
+                          // Boxed rather than inline: the border is what tells you the
+                          // row has flipped into edit mode. The accent colour comes from
+                          // Input's own `focus:` border — the field is autofocused on entering
+                          // rename mode and commits on blur, so it is focused for its whole
+                          // life. Restating the accent as a plain class here would do nothing:
+                          // it ties with Input's resting border on specificity and loses on
+                          // stylesheet order.
+                          className="my-1 min-w-0 flex-1 font-bold"
+                        />
                       ) : (
-                        <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
+                        <>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="xs"
+                            onClick={() => toggleCol(col.id)}
+                            aria-expanded={isExpanded}
+                            className="min-w-0 flex-1 justify-start gap-1.5 py-1.5 text-left"
+                          >
+                            {isExpanded ? (
+                              <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
+                            ) : (
+                              <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
+                            )}
+                            <span className="min-w-0 flex-1 truncate text-xs font-bold text-[var(--color-text)]">
+                              {col.name}
+                            </span>
+                            <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
+                              {total}
+                            </span>
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="icon"
+                            size="xs"
+                            onClick={() => startRename(col)}
+                            title={`Rename ${col.name}`}
+                            aria-label={`Rename collection ${col.name}`}
+                            className="opacity-0 focus-visible:opacity-100 group-hover:opacity-100"
+                          >
+                            <PencilSimpleIcon size={12} aria-hidden="true" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="icon"
+                            size="xs"
+                            onClick={() => setPendingCollectionDelete(col)}
+                            title={`Delete ${col.name}`}
+                            aria-label={`Delete collection ${col.name}`}
+                            className="opacity-0 hover:text-[var(--color-error)] focus-visible:opacity-100 group-hover:opacity-100"
+                          >
+                            <XIcon size={12} aria-hidden="true" />
+                          </Button>
+                        </>
                       )}
-                      <span className="min-w-0 flex-1 truncate text-xs font-bold text-[var(--color-text)]">
-                        {col.name}
-                      </span>
-                      <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
-                        {total}
-                      </span>
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="icon"
-                      size="xs"
-                      onClick={() => startRename(col)}
-                      title={`Rename ${col.name}`}
-                      aria-label={`Rename collection ${col.name}`}
-                      className="opacity-0 focus-visible:opacity-100 group-hover:opacity-100"
-                    >
-                      <PencilSimpleIcon size={12} aria-hidden="true" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="icon"
-                      size="xs"
-                      onClick={() => setPendingCollectionDelete(col)}
-                      title={`Delete ${col.name}`}
-                      aria-label={`Delete collection ${col.name}`}
-                      className="opacity-0 hover:text-[var(--color-error)] focus-visible:opacity-100 group-hover:opacity-100"
-                    >
-                      <XIcon size={12} aria-hidden="true" />
-                    </Button>
-                  </>
-                )}
-              </div>
+                    </div>
 
-              {isExpanded && (
-                <div className="ml-3 mt-1 flex flex-col gap-0.5 border-l border-[var(--color-border)] pl-1">
-                  {reqs.map((req) => (
-                    <RequestRow
-                      key={req.id}
-                      req={req}
-                      rowId={`${requestRowsId}-request-${req.id}`}
-                      isActive={req.id === activeRequestId}
-                      tabIndex={
-                        visibleRequestIds[0] === req.id || req.id === activeRequestId ? 0 : -1
-                      }
-                      onSelect={() => onSelect(req)}
-                      onOpenMenu={openMenu}
-                      onKeyDown={handleRowKeyDown}
-                    />
-                  ))}
-                  {reqs.length === 0 && (
-                    <p className="px-2 py-1 text-2xs italic text-[var(--color-text-muted)]">
-                      Empty collection
-                    </p>
+                    {isExpanded && (
+                      <div className="ml-3 mt-1 flex flex-col gap-0.5 border-l border-[var(--color-border)] pl-1">
+                        {reqs.map((req) => (
+                          <RequestRow
+                            key={req.id}
+                            req={req}
+                            rowId={`${requestRowsId}-request-${req.id}`}
+                            isActive={req.id === activeRequestId}
+                            tabIndex={
+                              visibleRequestIds[0] === req.id || req.id === activeRequestId ? 0 : -1
+                            }
+                            onSelect={() => onSelect(req)}
+                            onOpenMenu={openMenu}
+                            onKeyDown={handleRowKeyDown}
+                          />
+                        ))}
+                        {reqs.length === 0 && (
+                          <p className="px-2 py-1 text-2xs italic text-[var(--color-text-muted)]">
+                            Empty collection
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+
+              {unassigned.length > 0 && (
+                <div className="mt-3">
+                  <SectionLabel as="h3" className="mb-1 px-2">
+                    Unassigned
+                  </SectionLabel>
+                  <div className="flex flex-col gap-0.5">
+                    {unassigned.map((req) => (
+                      <RequestRow
+                        key={req.id}
+                        req={req}
+                        rowId={`${requestRowsId}-request-${req.id}`}
+                        isActive={req.id === activeRequestId}
+                        tabIndex={
+                          visibleRequestIds[0] === req.id || req.id === activeRequestId ? 0 : -1
+                        }
+                        onSelect={() => onSelect(req)}
+                        onOpenMenu={openMenu}
+                        onKeyDown={handleRowKeyDown}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {requests.length === 0 && (
+                <EmptyState
+                  icon={TrayIcon}
+                  size="sm"
+                  title="No saved requests"
+                  description="Send a request, then Save it to build up a collection."
+                />
+              )}
+
+              {requests.length > 0 && totalMatches === 0 && (
+                <EmptyState
+                  icon={MagnifyingGlassIcon}
+                  size="sm"
+                  title="No matches"
+                  description="Try a different search term."
+                  action={
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => setSearch('')}
+                    >
+                      Clear search
+                    </Button>
+                  }
+                />
+              )}
+
+              {requestHistory.length > 0 && (
+                <div className="mt-4 border-t border-[var(--color-border)] pt-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    aria-expanded={expandedHistory}
+                    className="w-full justify-start gap-1.5 px-2 text-2xs font-bold uppercase tracking-wider"
+                    onClick={() => setExpandedHistory((v) => !v)}
+                  >
+                    {expandedHistory ? (
+                      <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
+                    ) : (
+                      <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
+                    )}
+                    <ClockCounterClockwiseIcon size={12} aria-hidden="true" />
+                    <span>History</span>
+                    <span className="ml-auto normal-case">{requestHistory.length}</span>
+                  </Button>
+                  {expandedHistory && (
+                    <div className="mt-1 flex flex-col gap-0.5">
+                      {requestHistory.map((entry) => {
+                        const [method, ...urlParts] = entry.input.split(' ')
+                        const histUrl = urlParts.join(' ')
+                        return (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="xs"
+                            key={entry.id}
+                            className="w-full justify-start gap-1.5 text-left hover:bg-[var(--color-surface-hover)]"
+                            title={`${entry.input}\n${entry.output}\nClick to restore`}
+                            aria-label={`Restore ${entry.input}`}
+                            onClick={() => onLoadFromHistory?.(method ?? 'GET', histUrl)}
+                          >
+                            <span
+                              className={`shrink-0 text-2xs font-bold ${httpMethodTextClass(method ?? 'GET')}`}
+                            >
+                              {method}
+                            </span>
+                            <span className="min-w-0 flex-1 truncate text-[var(--color-text)]">
+                              {histUrl}
+                            </span>
+                            <span className="shrink-0 text-[var(--color-text-muted)]">
+                              {entry.output.split('·')[1]?.trim() ?? ''}
+                            </span>
+                          </Button>
+                        )
+                      })}
+                    </div>
                   )}
                 </div>
               )}
             </div>
-          )
-        })}
 
-        {unassigned.length > 0 && (
-          <div className="mt-3">
-            <SectionLabel as="h3" className="mb-1 px-2">
-              Unassigned
-            </SectionLabel>
-            <div className="flex flex-col gap-0.5">
-              {unassigned.map((req) => (
-                <RequestRow
-                  key={req.id}
-                  req={req}
-                  rowId={`${requestRowsId}-request-${req.id}`}
-                  isActive={req.id === activeRequestId}
-                  tabIndex={visibleRequestIds[0] === req.id || req.id === activeRequestId ? 0 : -1}
-                  onSelect={() => onSelect(req)}
-                  onOpenMenu={openMenu}
-                  onKeyDown={handleRowKeyDown}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {requests.length === 0 && (
-          <EmptyState
-            icon={TrayIcon}
-            size="sm"
-            title="No saved requests"
-            description="Send a request, then Save it to build up a collection."
-          />
-        )}
-
-        {requests.length > 0 && totalMatches === 0 && (
-          <EmptyState
-            icon={MagnifyingGlassIcon}
-            size="sm"
-            title="No matches"
-            description="Try a different search term."
-            action={
-              <Button type="button" variant="secondary" size="sm" onClick={() => setSearch('')}>
-                Clear search
-              </Button>
-            }
-          />
-        )}
-
-        {requestHistory.length > 0 && (
-          <div className="mt-4 border-t border-[var(--color-border)] pt-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              aria-expanded={expandedHistory}
-              className="w-full justify-start gap-1.5 px-2 text-2xs font-bold uppercase tracking-wider"
-              onClick={() => setExpandedHistory((v) => !v)}
-            >
-              {expandedHistory ? (
-                <CaretDownIcon size={12} weight="bold" aria-hidden="true" />
-              ) : (
-                <CaretRightIcon size={12} weight="bold" aria-hidden="true" />
-              )}
-              <ClockCounterClockwiseIcon size={12} aria-hidden="true" />
-              <span>History</span>
-              <span className="ml-auto normal-case">{requestHistory.length}</span>
-            </Button>
-            {expandedHistory && (
-              <div className="mt-1 flex flex-col gap-0.5">
-                {requestHistory.map((entry) => {
-                  const [method, ...urlParts] = entry.input.split(' ')
-                  const histUrl = urlParts.join(' ')
-                  return (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="xs"
-                      key={entry.id}
-                      className="w-full justify-start gap-1.5 text-left hover:bg-[var(--color-surface-hover)]"
-                      title={`${entry.input}\n${entry.output}\nClick to restore`}
-                      aria-label={`Restore ${entry.input}`}
-                      onClick={() => onLoadFromHistory?.(method ?? 'GET', histUrl)}
-                    >
-                      <span
-                        className={`shrink-0 text-2xs font-bold ${httpMethodTextClass(method ?? 'GET')}`}
-                      >
-                        {method}
-                      </span>
-                      <span className="min-w-0 flex-1 truncate text-[var(--color-text)]">
-                        {histUrl}
-                      </span>
-                      <span className="shrink-0 text-[var(--color-text-muted)]">
-                        {entry.output.split('·')[1]?.trim() ?? ''}
-                      </span>
-                    </Button>
-                  )
-                })}
+            <div className="flex items-center justify-between gap-2 border-t border-[var(--color-border)] px-2 py-1.5">
+              <span className="text-2xs text-[var(--color-text-muted)]">Library</span>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={onImport}
+                  title="Import requests from Postman, OpenAPI, AsyncAPI, protobuf, GraphQL, or JSON"
+                  aria-label="Import requests"
+                >
+                  <UploadSimpleIcon size={14} aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={onExport}
+                  title="Copy all saved requests to the clipboard as JSON"
+                  aria-label="Export requests"
+                  disabled={requests.length === 0}
+                >
+                  <DownloadSimpleIcon size={14} aria-hidden="true" />
+                </Button>
               </div>
-            )}
-          </div>
-        )}
-      </div>
+            </div>
+          </>
+        }
+      >
+        {children}
+      </MasterDetailLayout>
 
-      <div className="flex items-center justify-between gap-2 border-t border-[var(--color-border)] px-2 py-1.5">
-        <span className="text-2xs text-[var(--color-text-muted)]">Library</span>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="icon"
-            size="xs"
-            onClick={onImport}
-            title="Import requests from Postman, OpenAPI, AsyncAPI, protobuf, GraphQL, or JSON"
-            aria-label="Import requests"
-          >
-            <UploadSimpleIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant="icon"
-            size="xs"
-            onClick={onExport}
-            title="Copy all saved requests to the clipboard as JSON"
-            aria-label="Export requests"
-            disabled={requests.length === 0}
-          >
-            <DownloadSimpleIcon size={14} aria-hidden="true" />
-          </Button>
-        </div>
-      </div>
-
+      {/* Overlays sit outside the layout: the sidebar collapses to `w-0 overflow-hidden`, which
+          would clip a `position: fixed` menu rendered inside it. */}
       {menu && menuRequest && (
         <div
           ref={menuRef}
@@ -632,7 +659,7 @@ export function CollectionsSidebar({
           })()}
         </ConfirmDialog>
       )}
-    </aside>
+    </>
   )
 }
 

--- a/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
+++ b/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
@@ -15,6 +15,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Input } from '@/components/shared/Input'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ConfirmDialog } from './ConfirmDialog'
@@ -402,9 +403,9 @@ export function CollectionsSidebar({
 
         {unassigned.length > 0 && (
           <div className="mt-3">
-            <h3 className="mb-1 px-2 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+            <SectionLabel as="h3" className="mb-1 px-2">
               Unassigned
-            </h3>
+            </SectionLabel>
             <div className="flex flex-col gap-0.5">
               {unassigned.map((req) => (
                 <RequestRow

--- a/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
+++ b/apps/cockpit/src/tools/api-client/components/CollectionsSidebar.tsx
@@ -15,6 +15,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { httpMethodTextClass } from '@/lib/http-method'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Input } from '@/components/shared/Input'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -482,7 +483,7 @@ export function CollectionsSidebar({
                       onClick={() => onLoadFromHistory?.(method ?? 'GET', histUrl)}
                     >
                       <span
-                        className={`shrink-0 text-2xs font-bold ${getMethodColor(method ?? 'GET')}`}
+                        className={`shrink-0 text-2xs font-bold ${httpMethodTextClass(method ?? 'GET')}`}
                       >
                         {method}
                       </span>
@@ -705,7 +706,7 @@ function RequestRow({
         title={`${req.method} ${req.url}`}
       >
         <span className="min-w-0 flex-1 truncate">{req.name}</span>
-        <span className={`shrink-0 text-2xs font-bold ${getMethodColor(req.method)}`}>
+        <span className={`shrink-0 text-2xs font-bold ${httpMethodTextClass(req.method)}`}>
           {req.method}
         </span>
       </Button>
@@ -729,21 +730,4 @@ function RequestRow({
       </Button>
     </div>
   )
-}
-
-export function getMethodColor(method: string) {
-  switch (method) {
-    case 'GET':
-      return 'text-[var(--color-success)]'
-    case 'POST':
-      return 'text-[var(--color-warning)]'
-    case 'PUT':
-      return 'text-[var(--color-info)]'
-    case 'PATCH':
-      return 'text-[var(--color-accent)]'
-    case 'DELETE':
-      return 'text-[var(--color-error)]'
-    default:
-      return 'text-[var(--color-text-muted)]'
-  }
 }

--- a/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
@@ -218,7 +218,7 @@ export function EnvironmentModal({ onClose }: Props) {
                   onClick={() => setConfirmDeleteEnv(true)}
                   className="gap-1 text-[var(--color-error)] hover:bg-[var(--color-error)]/10"
                 >
-                  <TrashIcon size={13} aria-hidden="true" />
+                  <TrashIcon size={14} aria-hidden="true" />
                   Delete
                 </Button>
               </div>
@@ -244,7 +244,7 @@ export function EnvironmentModal({ onClose }: Props) {
                     onClick={addRow}
                     className="gap-1"
                   >
-                    <PlusIcon size={10} aria-hidden="true" />
+                    <PlusIcon size={12} aria-hidden="true" />
                     Add
                   </Button>
                 </div>
@@ -286,7 +286,7 @@ export function EnvironmentModal({ onClose }: Props) {
                             aria-label={`Delete ${row.key.trim() || `variable ${index + 1}`}`}
                             className="hover:text-[var(--color-error)]"
                           >
-                            <XIcon size={15} aria-hidden="true" />
+                            <XIcon size={16} aria-hidden="true" />
                           </Button>
                         </div>
                       )

--- a/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { Alert } from '@/components/shared/Alert'
 import { TextArea } from '@/components/shared/TextArea'
@@ -153,9 +154,9 @@ export function ImportSpecModal({ onImport, onClose }: Props) {
             </div>
             {preview.warnings.length > 0 && (
               <div className="mt-3 max-h-32 overflow-y-auto rounded border border-[var(--color-border)] p-2">
-                <div className="mb-1 font-mono text-2xs uppercase tracking-wide text-[var(--color-text-muted)]">
+                <SectionLabel as="div" className="mb-1">
                   Warnings
-                </div>
+                </SectionLabel>
                 <ul className="flex flex-col gap-1 text-xs text-[var(--color-warning)]">
                   {preview.warnings.map((warning, index) => (
                     <li key={`${index}-${warning}`}>{warning}</li>

--- a/apps/cockpit/src/tools/api-client/components/SaveRequestModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/SaveRequestModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
 import { Dialog } from '@/components/shared/Dialog'
 import { Input } from '@/components/shared/Input'
 import { Select } from '@/components/shared/Select'
@@ -81,13 +82,11 @@ export function SaveRequestModal({
       }
     >
       <div className="flex flex-col gap-4 p-4" onKeyDown={handleKeyDown}>
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Request Name</label>
+        <Field label="Request Name">
           <Input ref={nameRef} value={name} onChange={(e) => setName(e.target.value)} size="md" />
-        </div>
+        </Field>
 
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Collection</label>
+        <Field label="Collection">
           <Select size="md" value={collectionId} onChange={(e) => setCollectionId(e.target.value)}>
             <option value="">(Unassigned)</option>
             {collections.map((c) => (
@@ -97,13 +96,10 @@ export function SaveRequestModal({
             ))}
             <option value={NEW_COLLECTION_SENTINEL}>+ New Collection…</option>
           </Select>
-        </div>
+        </Field>
 
         {isNewCol && (
-          <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">
-              New Collection Name
-            </label>
+          <Field label="New Collection Name">
             <Input
               autoFocus
               value={newColName}
@@ -111,7 +107,7 @@ export function SaveRequestModal({
               placeholder="My Collection"
               size="md"
             />
-          </div>
+          </Field>
         )}
       </div>
     </Dialog>

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -413,7 +413,7 @@ export default function Base64Tool() {
                   title="Encode a file to Base64"
                   className="flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
                 >
-                  <UploadSimpleIcon size={11} />
+                  <UploadSimpleIcon size={12} />
                   Encode File
                 </Button>
                 <input

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -3,6 +3,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Alert } from '@/components/shared/Alert'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Button } from '@/components/shared/Button'
@@ -400,42 +401,45 @@ export default function Base64Tool() {
       <div className="flex flex-1 overflow-hidden">
         {/* ── Input panel ─────────────────────────────────────────── */}
         <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
-          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-            <span className="text-xs text-[var(--color-text-muted)]">
-              Input ({state.mode === 'encode' ? 'Text' : 'Base64'})
-            </span>
-            {state.mode === 'encode' && !droppedFile && (
+          <PaneHeader
+            title="Input"
+            hint={state.mode === 'encode' ? 'Text' : 'Base64'}
+            actions={
               <>
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => fileInputRef.current?.click()}
-                  title="Encode a file to Base64"
-                  className="flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
-                >
-                  <UploadSimpleIcon size={12} />
-                  Encode File
-                </Button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  className="hidden"
-                  onChange={handleFileInputChange}
-                />
+                {state.mode === 'encode' && !droppedFile && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => fileInputRef.current?.click()}
+                      title="Encode a file to Base64"
+                      className="gap-1"
+                    >
+                      <UploadSimpleIcon size={12} />
+                      Encode File
+                    </Button>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      className="hidden"
+                      onChange={handleFileInputChange}
+                    />
+                  </>
+                )}
+                {droppedFile && (
+                  <Button
+                    variant="icon"
+                    size="xs"
+                    onClick={() => setDroppedFile(null)}
+                    title="Clear file"
+                    className="hover:text-[var(--color-error)]"
+                  >
+                    <XIcon size={12} />
+                  </Button>
+                )}
               </>
-            )}
-            {droppedFile && (
-              <Button
-                variant="icon"
-                size="xs"
-                onClick={() => setDroppedFile(null)}
-                title="Clear file"
-                className="rounded p-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-error)]"
-              >
-                <XIcon size={12} />
-              </Button>
-            )}
-          </div>
+            }
+          />
 
           {droppedFile ? (
             /* File info view */
@@ -500,14 +504,11 @@ export default function Base64Tool() {
 
         {/* ── Output panel ────────────────────────────────────────── */}
         <div className="flex w-1/2 flex-col">
-          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-            <span className="text-xs text-[var(--color-text-muted)]">
-              {droppedFile
-                ? 'Output (Base64 Data URI)'
-                : `Output (${state.mode === 'encode' ? 'Base64' : 'Text'})`}
-            </span>
-            <div className="flex items-center gap-1">
-              {droppedFile ? (
+          <PaneHeader
+            title="Output"
+            hint={droppedFile ? 'Base64 Data URI' : state.mode === 'encode' ? 'Base64' : 'Text'}
+            actions={
+              droppedFile ? (
                 <>
                   <CopyButton text={droppedFile.dataUri.split(',')[1] ?? ''} label="Copy Base64" />
                   <CopyButton text={droppedFile.dataUri} label="Copy data URI" />
@@ -519,9 +520,9 @@ export default function Base64Tool() {
                   )}
                   <CopyButton text={output.text} />
                 </>
-              )}
-            </div>
-          </div>
+              )
+            }
+          />
 
           {droppedFile ? (
             /* File encode output: base64 text (truncated) + zoomable image */

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -5,6 +5,7 @@ import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Button } from '@/components/shared/Button'
@@ -399,9 +400,9 @@ export default function Base64Tool() {
       }
     >
       {/* ── Panels ────────────────────────────────────────────────── */}
-      <div className="flex flex-1 overflow-hidden">
+      <SplitPane storageKey="base64" aria-label="Resize input and output">
         {/* ── Input panel ─────────────────────────────────────────── */}
-        <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader
             title="Input"
             hint={state.mode === 'encode' ? 'Text' : 'Base64'}
@@ -504,7 +505,7 @@ export default function Base64Tool() {
         </div>
 
         {/* ── Output panel ────────────────────────────────────────── */}
-        <div className="flex w-1/2 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader
             title="Output"
             hint={droppedFile ? 'Base64 Data URI' : state.mode === 'encode' ? 'Base64' : 'Text'}
@@ -638,7 +639,7 @@ export default function Base64Tool() {
             </div>
           )}
         </div>
-      </div>
+      </SplitPane>
     </ToolLayout>
   )
 }

--- a/apps/cockpit/src/tools/base64/Base64Tool.tsx
+++ b/apps/cockpit/src/tools/base64/Base64Tool.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useEffect, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { useUiStore } from '@/stores/ui.store'
@@ -356,7 +357,7 @@ export default function Base64Tool() {
               <ArrowsLeftRightIcon size={12} aria-hidden="true" />
               Swap
             </Button>
-            <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
+            <Kbd keys="mod+enter" />
           </ToolbarGroup>
 
           <ToolbarGroup label="Encoding options" separated>

--- a/apps/cockpit/src/tools/case-converter/CaseConverter.tsx
+++ b/apps/cockpit/src/tools/case-converter/CaseConverter.tsx
@@ -6,6 +6,7 @@ import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { Field } from '@/components/shared/Field'
 import { StatusBadge } from '@/components/shared/StatusBadge'
 import { TextArea } from '@/components/shared/TextArea'
 import { ArrowUpIcon, TextAaIcon } from '@phosphor-icons/react'
@@ -116,29 +117,35 @@ export default function CaseConverter() {
   )
 
   return (
-    <ToolLayout
-      toolbar={
-        <div className="border-b border-[var(--color-border)] p-4">
-          <div className="mb-2 flex items-center gap-3">
-            <span className="font-mono text-xs text-[var(--color-text-muted)]">Input</span>
-            {detected && <StatusBadge variant="info">{detected}</StatusBadge>}
-            {words.length > 0 && (
-              <span className="text-2xs text-[var(--color-text-muted)]">
-                {words.length} word{words.length !== 1 ? 's' : ''}: {words.join(' · ')}
-              </span>
-            )}
-          </div>
-          <TextArea
-            value={state.input}
-            onChange={(e) => updateState({ input: e.target.value })}
-            placeholder="Type or paste text to convert..."
-            rows={3}
-            size="md"
-            className="resize-none"
-          />
-        </div>
-      }
-    >
+    <ToolLayout>
+      {/* The input lives in the body, not the `toolbar` slot. A toolbar is a row of controls
+          acting on the content below it; a multi-line text field is the content. */}
+      <Field
+        label="Input"
+        className="mb-4"
+        hint={
+          (detected || words.length > 0) && (
+            <span className="flex flex-wrap items-center gap-2">
+              {detected && <StatusBadge variant="info">{detected}</StatusBadge>}
+              {words.length > 0 && (
+                <span>
+                  {words.length} word{words.length !== 1 ? 's' : ''}: {words.join(' · ')}
+                </span>
+              )}
+            </span>
+          )
+        }
+      >
+        <TextArea
+          value={state.input}
+          onChange={(e) => updateState({ input: e.target.value })}
+          placeholder="Type or paste text to convert..."
+          rows={3}
+          size="md"
+          className="resize-none"
+        />
+      </Field>
+
       {cases.length > 0 ? (
         <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
           {cases.map((c) => {

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -13,6 +13,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
@@ -309,9 +310,7 @@ export default function CodeFormatter() {
                 title="Format the code (⌘↵)"
               >
                 Format
-                <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                  ⌘↵
-                </span>
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
               <Button
                 variant="secondary"

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -27,6 +27,7 @@ import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/sh
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
 import { FORMATTER_WORKER_METHODS } from '@/workers/formatter.methods'
+import { formatShortcut } from '@/lib/shortcut-label'
 import {
   LANGUAGES,
   extensionForLanguage,
@@ -307,7 +308,7 @@ export default function CodeFormatter() {
                 onClick={() => void handleFormat()}
                 disabled={!canFormat}
                 loading={isFormatting}
-                title="Format the code (⌘↵)"
+                title={`Format the code (${formatShortcut('mod+enter')})`}
               >
                 Format
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -329,7 +330,7 @@ export default function CodeFormatter() {
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasCode}
-                title="Save to a file (⌘S)"
+                title={`Save to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save to file"
               >
                 <FloppyDiskIcon size={16} aria-hidden="true" />
@@ -422,7 +423,8 @@ export default function CodeFormatter() {
             <CodeBlockIcon size={36} weight="light" aria-hidden="true" />
             <p className="text-sm">Paste or type code to format</p>
             <p className="max-w-sm text-xs opacity-60">
-              {LANGUAGES.length} languages supported. Press ⌘↵ to format, or open a file with ⌘O.
+              {LANGUAGES.length} languages supported. Press <Kbd keys="mod+enter" /> to format, or
+              open a file with <Kbd keys="mod+o" />.
             </p>
           </div>
         )}

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -238,7 +238,7 @@ export default function CodeFormatter() {
               title={state.fileName ?? 'Untitled'}
               icon={
                 <CodeBlockIcon
-                  size={15}
+                  size={16}
                   aria-hidden="true"
                   className="shrink-0 text-[var(--color-text-muted)]"
                 />
@@ -282,7 +282,7 @@ export default function CodeFormatter() {
                 title="Guess the language from the code"
                 className="gap-1"
               >
-                <MagicWandIcon size={13} aria-hidden="true" />
+                <MagicWandIcon size={14} aria-hidden="true" />
                 Auto-detect
               </Button>
               <Button
@@ -294,7 +294,7 @@ export default function CodeFormatter() {
                 {...(state.optionsOpen ? { 'aria-controls': optionsId } : {})}
                 className="gap-1"
               >
-                <SlidersHorizontalIcon size={13} aria-hidden="true" />
+                <SlidersHorizontalIcon size={14} aria-hidden="true" />
                 Style
               </Button>
             </ToolbarGroup>
@@ -321,7 +321,7 @@ export default function CodeFormatter() {
                 title="Restore the code as it was before formatting"
                 className="gap-1"
               >
-                <ArrowCounterClockwiseIcon size={13} aria-hidden="true" />
+                <ArrowCounterClockwiseIcon size={14} aria-hidden="true" />
                 Revert
               </Button>
               <CopyButton text={input} />
@@ -333,7 +333,7 @@ export default function CodeFormatter() {
                 title="Save to a file (⌘S)"
                 aria-label="Save to file"
               >
-                <FloppyDiskIcon size={15} aria-hidden="true" />
+                <FloppyDiskIcon size={16} aria-hidden="true" />
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Field } from '@/components/shared/Field'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { Input } from '@/components/shared/Input'
@@ -460,10 +461,12 @@ function ContrastInputs({
 
   return (
     <div className="flex items-end gap-4">
-      <div className="flex-1">
-        <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Foreground</label>
+      {/* Explicit htmlFor: the colour swatch shares the row, so a wrapping label would
+          forward clicks to it rather than to the text field. */}
+      <Field label="Foreground" htmlFor="contrast-fg" className="flex-1">
         <div className="flex items-center gap-2">
           <Input
+            id="contrast-fg"
             value={contrastFg}
             onChange={(e) => onFgChange(e.target.value)}
             size="md"
@@ -476,7 +479,7 @@ function ContrastInputs({
             className="h-8 w-8 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
           />
         </div>
-      </div>
+      </Field>
       <Button
         variant="secondary"
         size="sm"
@@ -487,10 +490,10 @@ function ContrastInputs({
         <ArrowsLeftRightIcon size={14} aria-hidden="true" />
         <span className="sr-only">Swap colors</span>
       </Button>
-      <div className="flex-1">
-        <label className="mb-1 block text-xs text-[var(--color-text-muted)]">Background</label>
+      <Field label="Background" htmlFor="contrast-bg" className="flex-1">
         <div className="flex items-center gap-2">
           <Input
+            id="contrast-bg"
             value={contrastBg}
             onChange={(e) => onBgChange(e.target.value)}
             size="md"
@@ -503,7 +506,7 @@ function ContrastInputs({
             className="h-8 w-8 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
           />
         </div>
-      </div>
+      </Field>
     </div>
   )
 }
@@ -724,10 +727,14 @@ export default function ColorConverter() {
               <section className="flex flex-col gap-4">
                 {/* Variable name input */}
                 <div className="flex items-center gap-3">
-                  <label className="shrink-0 text-xs text-[var(--color-text-muted)]">
+                  <label
+                    htmlFor="css-var-name"
+                    className="font-ui shrink-0 text-xs text-[var(--color-text-muted)]"
+                  >
                     Variable name
                   </label>
                   <Input
+                    id="css-var-name"
                     value={state.cssVarName}
                     onChange={(e) => updateState({ cssVarName: e.target.value })}
                     placeholder="--color-primary"

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Field } from '@/components/shared/Field'
+import { Panel } from '@/components/shared/Panel'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { Input } from '@/components/shared/Input'
@@ -589,8 +590,7 @@ export default function ColorConverter() {
     <ToolLayout maxWidth="max-w-4xl">
       <div className="flex flex-col gap-4">
         {/* ── Input ──────────────────────────────────────── */}
-        <section>
-          <h2 className="mb-2 font-mono text-sm text-[var(--color-text)]">Color Input</h2>
+        <Panel title="Color Input">
           <div className="flex items-center gap-3">
             <Input
               value={state.input}
@@ -604,7 +604,7 @@ export default function ColorConverter() {
               value={color?.hex ?? '#000000'}
               onChange={(e) => handleInputChange(e.target.value)}
               title="Pick a color"
-              className="h-10 w-10 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-0.5"
+              className="h-10 w-10 shrink-0 cursor-pointer rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-0.5"
             />
             {color && (
               <div
@@ -631,7 +631,7 @@ export default function ColorConverter() {
               ))}
             </div>
           )}
-        </section>
+        </Panel>
 
         {/* ── Section Tabs ──────────────────────────────── */}
         {color && (
@@ -828,8 +828,7 @@ export default function ColorConverter() {
         )}
 
         {/* ── Contrast Ratio ─────────────────────────────── */}
-        <section>
-          <h2 className="mb-2 font-mono text-sm text-[var(--color-text)]">Contrast Ratio (WCAG)</h2>
+        <Panel title="Contrast Ratio (WCAG)">
           <ContrastInputs
             contrastFg={state.contrastFg}
             contrastBg={state.contrastBg}
@@ -839,7 +838,7 @@ export default function ColorConverter() {
           />
           {contrast && (
             <div className="mt-3 flex items-center gap-4">
-              <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
+              <div className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-2">
                 <div className="text-xs text-[var(--color-text-muted)]">Ratio</div>
                 <div className="font-mono text-lg font-bold text-[var(--color-text)]">
                   {contrast.ratio}:1
@@ -869,7 +868,7 @@ export default function ColorConverter() {
               </div>
             </div>
           )}
-        </section>
+        </Panel>
       </div>
     </ToolLayout>
   )

--- a/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
+++ b/apps/cockpit/src/tools/css-specificity/CssSpecificity.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Button } from '@/components/shared/Button'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
@@ -243,9 +244,7 @@ export default function CssSpecificity() {
       <div className="flex flex-1 overflow-hidden">
         {/* Input */}
         <div className="flex w-2/5 flex-col border-r border-[var(--color-border)]">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
-            Selectors (one per line)
-          </div>
+          <PaneHeader title="Selectors" hint="one per line" />
           <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -4,6 +4,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 
@@ -331,8 +332,8 @@ export default function CssToTailwind() {
 
   return (
     <ToolLayout fullBleed>
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
+      <SplitPane storageKey="css-to-tailwind" aria-label="Resize CSS input and Tailwind output">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <PaneHeader title="CSS Input" />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
@@ -344,7 +345,7 @@ export default function CssToTailwind() {
             />
           </div>
         </div>
-        <div className="flex w-1/2 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader
             title="Tailwind Output"
             actions={classString ? <CopyButton text={classString} /> : undefined}
@@ -393,7 +394,7 @@ export default function CssToTailwind() {
             )}
           </div>
         </div>
-      </div>
+      </SplitPane>
     </ToolLayout>
   )
 }

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -3,6 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 
@@ -332,9 +333,7 @@ export default function CssToTailwind() {
     <ToolLayout fullBleed>
       <div className="flex flex-1 overflow-hidden">
         <div className="flex min-h-0 w-1/2 flex-col overflow-hidden border-r border-[var(--color-border)]">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
-            CSS Input
-          </div>
+          <PaneHeader title="CSS Input" />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Editor
               theme={monacoTheme}
@@ -346,10 +345,10 @@ export default function CssToTailwind() {
           </div>
         </div>
         <div className="flex w-1/2 flex-col">
-          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-            <span className="text-xs text-[var(--color-text-muted)]">Tailwind Output</span>
-            {classString && <CopyButton text={classString} />}
-          </div>
+          <PaneHeader
+            title="Tailwind Output"
+            actions={classString ? <CopyButton text={classString} /> : undefined}
+          />
           <div className="flex-1 overflow-auto p-4">
             {result ? (
               <div className="flex flex-col gap-4">

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -510,7 +510,7 @@ export default function CssValidator() {
               title="New stylesheet"
               aria-label="New stylesheet"
             >
-              <FilePlusIcon size={13} aria-hidden="true" />
+              <FilePlusIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -519,7 +519,7 @@ export default function CssValidator() {
               title="Open a .css file (⌘O)"
               aria-label="Open CSS file"
             >
-              <FolderOpenIcon size={13} aria-hidden="true" />
+              <FolderOpenIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -528,7 +528,7 @@ export default function CssValidator() {
               title="Save the stylesheet (⌘S)"
               aria-label="Save stylesheet"
             >
-              <FloppyDiskIcon size={13} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
             </Button>
           </ToolbarGroup>
 
@@ -574,7 +574,7 @@ export default function CssValidator() {
             {...(state.showRules ? { 'aria-controls': rulesPanelId } : {})}
             className="gap-1"
           >
-            <SlidersHorizontalIcon size={13} aria-hidden="true" />
+            <SlidersHorizontalIcon size={14} aria-hidden="true" />
             Rules
             {overrideCount > 0 && (
               <span className="rounded-full bg-[var(--color-accent)] px-1.5 text-2xs text-[var(--color-bg)]">
@@ -857,13 +857,13 @@ function ResultsPanel({
                     >
                       {issue.type === 'error' ? (
                         <WarningCircleIcon
-                          size={13}
+                          size={14}
                           aria-hidden="true"
                           className="shrink-0 text-[var(--color-error)]"
                         />
                       ) : (
                         <WarningIcon
-                          size={13}
+                          size={14}
                           aria-hidden="true"
                           className="shrink-0 text-[var(--color-warning)]"
                         />

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -21,6 +21,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
+import { Kbd } from '@/components/shared/Kbd'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -560,9 +561,7 @@ export default function CssValidator() {
               title="Reformat the stylesheet (⌘↵)"
             >
               Format
-              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                ⌘↵
-              </span>
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
             <CopyButton text={input} label="Copy CSS" />
           </ToolbarGroup>

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -21,6 +21,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Dialog } from '@/components/shared/Dialog'
@@ -608,9 +609,9 @@ export default function CssValidator() {
             <div className="grid gap-x-8 gap-y-3 min-[700px]:grid-cols-2 min-[1100px]:grid-cols-3">
               {RULE_CATEGORIES.map((category) => (
                 <div key={category.id}>
-                  <h2 className="mb-1 text-2xs font-bold uppercase tracking-wide text-[var(--color-text-muted)]">
+                  <SectionLabel as="h2" className="mb-1">
                     {category.label}
-                  </h2>
+                  </SectionLabel>
                   {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
                     const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
                     return (

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -53,6 +53,7 @@ import {
   type SelectorInfo,
 } from '@/tools/css-validator/css-helpers'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type Panel = 'problems' | 'selectors'
 
@@ -518,7 +519,7 @@ export default function CssValidator() {
               variant="icon"
               size="sm"
               onClick={() => void handleOpen()}
-              title="Open a .css file (⌘O)"
+              title={`Open a .css file (${formatShortcut('mod+o')})`}
               aria-label="Open CSS file"
             >
               <FolderOpenIcon size={14} aria-hidden="true" />
@@ -527,7 +528,7 @@ export default function CssValidator() {
               variant="icon"
               size="sm"
               onClick={() => void handleSave()}
-              title="Save the stylesheet (⌘S)"
+              title={`Save the stylesheet (${formatShortcut('mod+s')})`}
               aria-label="Save stylesheet"
             >
               <FloppyDiskIcon size={14} aria-hidden="true" />
@@ -558,7 +559,7 @@ export default function CssValidator() {
               onClick={() => void handleFormat()}
               disabled={!hasInput || isFormatting || !formatter}
               loading={isFormatting}
-              title="Reformat the stylesheet (⌘↵)"
+              title={`Reformat the stylesheet (${formatShortcut('mod+enter')})`}
             >
               Format
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -668,7 +669,7 @@ export default function CssValidator() {
             <EmptyState
               icon={FileCssIcon}
               title="Paste or open a stylesheet"
-              description="It is checked against the CSS specification as you type, and reformatted with ⌘↵."
+              description={`It is checked against the CSS specification as you type, and reformatted with ${formatShortcut('mod+enter')}.`}
               action={
                 TOOL_SAMPLES['css-validator'] ? (
                   <span className="pointer-events-auto">

--- a/apps/cockpit/src/tools/csv-tools/CsvTable.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTable.tsx
@@ -129,11 +129,11 @@ export default function CsvTable({ columns, rows }: CsvTableProps) {
                       >
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {sorted === 'asc' ? (
-                          <CaretUpIcon size={11} aria-hidden="true" />
+                          <CaretUpIcon size={12} aria-hidden="true" />
                         ) : sorted === 'desc' ? (
-                          <CaretDownIcon size={11} aria-hidden="true" />
+                          <CaretDownIcon size={12} aria-hidden="true" />
                         ) : (
-                          <CaretUpDownIcon size={11} aria-hidden="true" className="opacity-40" />
+                          <CaretUpDownIcon size={12} aria-hidden="true" className="opacity-40" />
                         )}
                       </Button>
                     </th>

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -19,6 +19,8 @@ import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Select } from '@/components/shared/Select'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -333,107 +335,100 @@ export default function CsvTools() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
-            <div className="flex min-w-0 items-center gap-2">
+        <DocumentToolbar aria-label="CSV document actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled'}
+            icon={
               <FileCsvIcon
                 size={16}
                 aria-hidden="true"
                 className="shrink-0 text-[var(--color-text-muted)]"
               />
-              <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-                {state.fileName ?? 'Untitled'}
-              </span>
-              <span
-                role="status"
-                aria-live="polite"
-                className="flex min-w-0 items-center gap-1 text-2xs text-[var(--color-text-muted)]"
-              >
-                {parsed.status === 'parsed' && issues.length === 0 && (
-                  <CheckCircleIcon
-                    size={12}
-                    aria-hidden="true"
-                    className="shrink-0 text-[var(--color-success)]"
-                  />
-                )}
-                {issues.length > 0 && (
-                  <WarningCircleIcon
-                    size={12}
-                    aria-hidden="true"
-                    className="shrink-0 text-[var(--color-warning)]"
-                  />
-                )}
-                <span className="truncate">{status}</span>
-              </span>
-              {issues.length > 0 && issues[0] && (
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={handleGoToIssue}
-                  title={`${issues[0].message} (line ${issues[0].line})`}
-                  className="shrink-0 gap-1"
-                >
-                  <CrosshairSimpleIcon size={12} aria-hidden="true" />
-                  Go to issue
-                </Button>
-              )}
-            </div>
+            }
+            status={status}
+            statusIcon={
+              parsed.status === 'parsed' && issues.length === 0 ? (
+                <CheckCircleIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-success)]"
+                />
+              ) : issues.length > 0 ? (
+                <WarningCircleIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-warning)]"
+                />
+              ) : undefined
+            }
+          />
+          {issues.length > 0 && issues[0] && (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleGoToIssue}
+              title={`${issues[0].message} (line ${issues[0].line})`}
+              className="shrink-0 gap-1"
+            >
+              <CrosshairSimpleIcon size={12} aria-hidden="true" />
+              Go to issue
+            </Button>
+          )}
 
-            <div className="ml-auto flex flex-wrap items-center gap-3">
-              <Select
-                aria-label="Delimiter"
-                value={delimiter}
-                onChange={(e) => updateState({ delimiter: e.target.value as Delimiter })}
-                className="w-32"
-              >
-                {DELIMITER_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </Select>
-              <Toggle
-                checked={hasHeader}
-                onChange={(checked) => updateState({ hasHeader: checked })}
-                label="Header row"
-              />
-              <Toggle
-                checked={typed}
-                onChange={(checked) => updateState({ typed: checked })}
-                label="Typed values"
-              />
-              <SegmentedControl
-                aria-label="View"
-                value={view}
-                onChange={(next) => updateState({ view: next })}
-                options={VIEW_OPTIONS}
-              />
-              {undoBuffer && (
-                <Button variant="ghost" size="sm" onClick={handleUndo} className="gap-1">
-                  <ArrowUUpLeftIcon size={14} aria-hidden="true" />
-                  Undo {undoBuffer.label.toLowerCase()}
-                </Button>
-              )}
-              <CopyButton text={activeOutput} label="Copy output" />
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleSave}
-                disabled={!hasInput}
-                title="Save the current view to a file (⌘S)"
-                aria-label="Save output to file"
-              >
-                <FloppyDiskIcon size={16} aria-hidden="true" />
+          <ToolbarGroup className="gap-3">
+            <Select
+              aria-label="Delimiter"
+              value={delimiter}
+              onChange={(e) => updateState({ delimiter: e.target.value as Delimiter })}
+              className="w-32"
+            >
+              {DELIMITER_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+            <Toggle
+              checked={hasHeader}
+              onChange={(checked) => updateState({ hasHeader: checked })}
+              label="Header row"
+            />
+            <Toggle
+              checked={typed}
+              onChange={(checked) => updateState({ typed: checked })}
+              label="Typed values"
+            />
+            <SegmentedControl
+              aria-label="View"
+              value={view}
+              onChange={(next) => updateState({ view: next })}
+              options={VIEW_OPTIONS}
+            />
+            {undoBuffer && (
+              <Button variant="ghost" size="sm" onClick={handleUndo} className="gap-1">
+                <ArrowUUpLeftIcon size={14} aria-hidden="true" />
+                Undo {undoBuffer.label.toLowerCase()}
               </Button>
-            </div>
-          </div>
-        </div>
+            )}
+            <CopyButton text={activeOutput} label="Copy output" />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSave}
+              disabled={!hasInput}
+              title="Save the current view to a file (⌘S)"
+              aria-label="Save output to file"
+            >
+              <FloppyDiskIcon size={16} aria-hidden="true" />
+            </Button>
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
-      <div className="flex min-h-0 flex-1 max-[900px]:flex-col">
+      <SplitPane storageKey="csv-tools" stackBelow={900} aria-label="Resize source and output">
         <section
           aria-label="CSV source"
-          className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-[var(--color-border)] max-[900px]:border-b min-[901px]:border-r"
+          className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
         >
           <Editor
             theme={monacoTheme}
@@ -499,7 +494,7 @@ export default function CsvTools() {
             />
           )}
         </section>
-      </div>
+      </SplitPane>
     </ToolLayout>
   )
 }

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -337,7 +337,7 @@ export default function CsvTools() {
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
             <div className="flex min-w-0 items-center gap-2">
               <FileCsvIcon
-                size={15}
+                size={16}
                 aria-hidden="true"
                 className="shrink-0 text-[var(--color-text-muted)]"
               />
@@ -410,7 +410,7 @@ export default function CsvTools() {
               />
               {undoBuffer && (
                 <Button variant="ghost" size="sm" onClick={handleUndo} className="gap-1">
-                  <ArrowUUpLeftIcon size={13} aria-hidden="true" />
+                  <ArrowUUpLeftIcon size={14} aria-hidden="true" />
                   Undo {undoBuffer.label.toLowerCase()}
                 </Button>
               )}
@@ -423,7 +423,7 @@ export default function CsvTools() {
                 title="Save the current view to a file (⌘S)"
                 aria-label="Save output to file"
               >
-                <FloppyDiskIcon size={15} aria-hidden="true" />
+                <FloppyDiskIcon size={16} aria-hidden="true" />
               </Button>
             </div>
           </div>

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -44,6 +44,7 @@ import {
 } from './csv-helpers'
 import { formatTextBytes } from '@/lib/format'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type CsvView = 'table' | 'convert' | 'analyze'
 
@@ -416,7 +417,7 @@ export default function CsvTools() {
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}
-              title="Save the current view to a file (⌘S)"
+              title={`Save the current view to a file (${formatShortcut('mod+s')})`}
               aria-label="Save output to file"
             >
               <FloppyDiskIcon size={16} aria-hidden="true" />

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -5,10 +5,12 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
 import { httpMethodColorVar } from '@/lib/http-method'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { sendToTool } from '@/lib/tool-handoff'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
 import { TextArea } from '@/components/shared/TextArea'
 import { Alert } from '@/components/shared/Alert'
 import { PlayIcon } from '@phosphor-icons/react'
@@ -274,7 +276,7 @@ export default function CurlToFetch() {
       fullBleed
       toolbar={
         parsed && (
-          <div className="flex items-center gap-3 border-b border-[var(--color-border)] px-4 py-1.5">
+          <Toolbar className="gap-x-3" aria-label="Parsed request">
             <span
               className="rounded px-2 py-0.5 text-xs font-bold"
               style={{
@@ -297,23 +299,28 @@ export default function CurlToFetch() {
                 body: {parsed.body.length} chars
               </span>
             )}
+            <ToolbarSpacer />
             <Button
               variant="ghost"
               size="xs"
               onClick={handleTestInApiClient}
               title="Open this request in API Client"
-              className="ml-auto shrink-0 gap-1"
+              className="shrink-0 gap-1"
             >
               <PlayIcon size={12} />
               Test in API Client
             </Button>
-          </div>
+          </Toolbar>
         )
       }
     >
-      <div className="flex flex-1 overflow-hidden">
+      <SplitPane
+        storageKey="curl-to-fetch"
+        defaultRatio={0.4}
+        aria-label="Resize command and output"
+      >
         {/* Input */}
-        <div className="flex w-2/5 flex-col border-r border-[var(--color-border)]">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader title="cURL Command" />
           <TextArea
             value={state.input}
@@ -327,7 +334,7 @@ export default function CurlToFetch() {
         </div>
 
         {/* Output */}
-        <div className="flex w-3/5 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-1">
             <TabBar
               tabs={OUTPUT_TABS}
@@ -355,7 +362,7 @@ export default function CurlToFetch() {
             </div>
           )}
         </div>
-      </div>
+      </SplitPane>
     </ToolLayout>
   )
 }

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -310,7 +310,7 @@ export default function CurlToFetch() {
               title="Open this request in API Client"
               className="ml-auto shrink-0 gap-1"
             >
-              <PlayIcon size={11} />
+              <PlayIcon size={12} />
               Test in API Client
             </Button>
           </div>

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -3,6 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
+import { httpMethodColorVar } from '@/lib/http-method'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -206,14 +207,6 @@ const OUTPUT_TABS = [
   { id: 'node', label: 'Node.js' },
 ]
 
-const METHOD_COLORS: Record<string, string> = {
-  GET: 'var(--color-success)',
-  POST: 'var(--color-info)',
-  PUT: 'var(--color-warning)',
-  PATCH: 'var(--color-warning)',
-  DELETE: 'var(--color-error)',
-}
-
 // ── Component ──────────────────────────────────────────────────────
 
 export default function CurlToFetch() {
@@ -285,8 +278,8 @@ export default function CurlToFetch() {
             <span
               className="rounded px-2 py-0.5 text-xs font-bold"
               style={{
-                color: METHOD_COLORS[parsed.method] ?? 'var(--color-text)',
-                background: `color-mix(in srgb, ${METHOD_COLORS[parsed.method] ?? 'var(--color-text)'} 15%, transparent)`,
+                color: httpMethodColorVar(parsed.method),
+                background: `color-mix(in srgb, ${httpMethodColorVar(parsed.method)} 15%, transparent)`,
               }}
             >
               {parsed.method}

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -3,6 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { TabBar } from '@/components/shared/TabBar'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { sendToTool } from '@/lib/tool-handoff'
@@ -320,9 +321,7 @@ export default function CurlToFetch() {
       <div className="flex flex-1 overflow-hidden">
         {/* Input */}
         <div className="flex w-2/5 flex-col border-r border-[var(--color-border)]">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
-            cURL Command
-          </div>
+          <PaneHeader title="cURL Command" />
           <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -30,6 +30,7 @@ import { exportFile } from '@/lib/file-io'
 import { DIFF_VIEWER_SAMPLE } from '@/lib/tool-samples'
 import type { DiffWorker } from '@/workers/diff.worker'
 import DiffWorkerFactory from '@/workers/diff.worker?worker'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 const { sanitize } = DOMPurify
 
@@ -419,7 +420,7 @@ export default function DiffViewer() {
       title={bothSidesFilled ? 'No comparison yet' : 'Nothing to compare'}
       description={
         bothSidesFilled
-          ? 'Press ⌘↵ to compare the two sides.'
+          ? `Press ${formatShortcut('mod+enter')} to compare the two sides.`
           : 'Paste the original on the left and the modified version on the right.'
       }
       action={
@@ -503,7 +504,7 @@ export default function DiffViewer() {
                 onClick={() => void computeDiff(true)}
                 disabled={!bothSidesFilled}
                 loading={isComparing}
-                title="Compare both sides (⌘↵)"
+                title={`Compare both sides (${formatShortcut('mod+enter')})`}
               >
                 Compare
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -15,6 +15,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
@@ -502,9 +503,7 @@ export default function DiffViewer() {
                 title="Compare both sides (⌘↵)"
               >
                 Compare
-                <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                  ⌘↵
-                </span>
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
             </div>
           </div>

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -18,12 +18,14 @@ import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { useUiStore } from '@/stores/ui.store'
 import { Button } from '@/components/shared/Button'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { Spinner } from '@/components/shared/Spinner'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
 import { exportFile } from '@/lib/file-io'
 import { DIFF_VIEWER_SAMPLE } from '@/lib/tool-samples'
 import type { DiffWorker } from '@/workers/diff.worker'
@@ -190,25 +192,24 @@ function EditorPane({
   const lines = value ? value.split('\n').length : 0
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="flex items-center gap-2 border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-        <span className="font-ui truncate text-xs font-semibold text-[var(--color-text)]">
-          {title}
-        </span>
-        <span className="truncate text-2xs text-[var(--color-text-muted)]">{hint}</span>
-        <span className="ml-auto shrink-0 text-2xs tabular-nums text-[var(--color-text-muted)]">
-          {lines} line{lines === 1 ? '' : 's'}
-        </span>
-        <Button
-          variant="icon"
-          size="sm"
-          onClick={onClear}
-          disabled={!value}
-          aria-label={`Clear ${title.toLowerCase()}`}
-          title={`Clear ${title.toLowerCase()}`}
-        >
-          <TrashIcon size={14} aria-hidden="true" />
-        </Button>
-      </div>
+      <PaneHeader
+        title={title}
+        // The line count sits in `hint`, not `status`: it changes on every keystroke, and a live
+        // region reciting a running total is noise rather than an outcome worth announcing.
+        hint={`${hint} · ${lines} line${lines === 1 ? '' : 's'}`}
+        actions={
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={onClear}
+            disabled={!value}
+            aria-label={`Clear ${title.toLowerCase()}`}
+            title={`Clear ${title.toLowerCase()}`}
+          >
+            <TrashIcon size={14} aria-hidden="true" />
+          </Button>
+        }
+      />
       <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={theme}
@@ -436,7 +437,7 @@ export default function DiffViewer() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2">
+          <Toolbar border={false} aria-label="Diff view and comparison actions">
             <SegmentedControl
               aria-label="Diff view mode"
               options={VIEW_OPTIONS}
@@ -471,7 +472,9 @@ export default function DiffViewer() {
               )}
             </span>
 
-            <div className="ml-auto flex items-center gap-2">
+            <ToolbarSpacer />
+
+            <ToolbarGroup>
               <Button
                 variant="secondary"
                 size="sm"
@@ -505,13 +508,15 @@ export default function DiffViewer() {
                 Compare
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
-            </div>
-          </div>
+            </ToolbarGroup>
+          </Toolbar>
 
           {state.optionsOpen && (
-            <div
+            <Toolbar
               id={optionsId}
-              className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2"
+              border={false}
+              aria-label="Diff options"
+              className="gap-x-4 border-t border-[var(--color-border)]"
             >
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 Layout
@@ -548,7 +553,8 @@ export default function DiffViewer() {
                 checked={state.jsonMode}
                 onChange={(checked) => updateState({ jsonMode: checked })}
               />
-              <div className="ml-auto flex items-center gap-2">
+              <ToolbarSpacer />
+              <ToolbarGroup>
                 <CopyButton text={rawPatch} label="Copy patch" />
                 <Button
                   variant="secondary"
@@ -559,8 +565,8 @@ export default function DiffViewer() {
                 >
                   Save patch…
                 </Button>
-              </div>
-            </div>
+              </ToolbarGroup>
+            </Toolbar>
           )}
         </div>
       }

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -205,7 +205,7 @@ function EditorPane({
           aria-label={`Clear ${title.toLowerCase()}`}
           title={`Clear ${title.toLowerCase()}`}
         >
-          <TrashIcon size={13} aria-hidden="true" />
+          <TrashIcon size={14} aria-hidden="true" />
         </Button>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
@@ -454,7 +454,7 @@ export default function DiffViewer() {
                   aria-hidden="true"
                   className="flex items-center gap-1 text-[var(--color-success)]"
                 >
-                  <CheckCircleIcon size={13} />
+                  <CheckCircleIcon size={14} />
                   Identical
                 </span>
               ) : stats ? (
@@ -479,7 +479,7 @@ export default function DiffViewer() {
                 title="Swap left and right"
                 className="gap-1"
               >
-                <ArrowsLeftRightIcon size={13} aria-hidden="true" />
+                <ArrowsLeftRightIcon size={14} aria-hidden="true" />
                 Swap
               </Button>
               <Button
@@ -490,7 +490,7 @@ export default function DiffViewer() {
                 {...(state.optionsOpen ? { 'aria-controls': optionsId } : {})}
                 className="gap-1"
               >
-                <SlidersHorizontalIcon size={13} aria-hidden="true" />
+                <SlidersHorizontalIcon size={14} aria-hidden="true" />
                 Options
               </Button>
               <Button

--- a/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
+++ b/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { useEffect, useId, useRef, useState, useCallback, useMemo } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { EmptyState } from '@/components/shared/EmptyState'
+import { Field } from '@/components/shared/Field'
 import { Input } from '@/components/shared/Input'
 import { StatusBadge } from '@/components/shared/StatusBadge'
 import { TextArea } from '@/components/shared/TextArea'
@@ -21,6 +22,7 @@ type HashGeneratorState = {
 }
 
 export default function HashGenerator() {
+  const compareId = useId()
   const [state, updateState] = useToolState<HashGeneratorState>('hash-generator', {
     input: '',
     compareHash: '',
@@ -107,20 +109,21 @@ export default function HashGenerator() {
   const inputBytes = useMemo(() => new TextEncoder().encode(state.input).length, [state.input])
 
   return (
-    <ToolLayout
-      toolbar={
-        <div className="border-b border-[var(--color-border)] p-4">
-          <div className="mb-2 flex items-center gap-3">
-            <span className="font-mono text-xs text-[var(--color-text-muted)]">Input</span>
-            {state.input && (
-              <span className="text-2xs tabular-nums text-[var(--color-text-muted)]">
+    <ToolLayout>
+      {/* The form lives in the body, not the `toolbar` slot. A toolbar is a row of controls
+          acting on the content below it; this is the content. */}
+      <div className="mb-4 flex flex-col gap-3">
+        <Field
+          label="Input"
+          hint={
+            state.input && (
+              <span className="tabular-nums">
                 {formatBytes(inputBytes)} · {state.input.length} chars
+                {isComputing && ' · Computing…'}
               </span>
-            )}
-            {isComputing && state.input && (
-              <span className="text-2xs text-[var(--color-text-muted)]">Computing…</span>
-            )}
-          </div>
+            )
+          }
+        >
           <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
@@ -129,55 +132,55 @@ export default function HashGenerator() {
             size="md"
             className="resize-none"
           />
+        </Field>
 
-          {/* Options row */}
-          <div className="mt-2 flex flex-wrap items-center gap-3">
-            <Toggle
-              checked={state.uppercase}
-              onChange={(uppercase) => updateState({ uppercase })}
-              label="Uppercase"
+        <div className="flex flex-wrap items-center gap-3">
+          <Toggle
+            checked={state.uppercase}
+            onChange={(uppercase) => updateState({ uppercase })}
+            label="Uppercase"
+          />
+          <Toggle
+            checked={state.hmacMode}
+            onChange={(hmacMode) => updateState({ hmacMode })}
+            label="HMAC"
+          />
+          {state.hmacMode && (
+            <Input
+              value={state.hmacKey}
+              onChange={(e) => updateState({ hmacKey: e.target.value })}
+              placeholder="Secret key..."
+              aria-label="HMAC secret key"
+              className="flex-1 font-mono"
             />
-            <Toggle
-              checked={state.hmacMode}
-              onChange={(hmacMode) => updateState({ hmacMode })}
-              label="HMAC"
+          )}
+        </div>
+
+        {/* htmlFor, not a wrapping label: the badge beside the input is labelable in some
+            browsers, and a wrapping label would forward clicks to whichever comes first. */}
+        <Field label="Compare hash" htmlFor={compareId}>
+          <div className="flex items-center gap-2">
+            <Input
+              id={compareId}
+              value={state.compareHash}
+              onChange={(e) => updateState({ compareHash: e.target.value })}
+              placeholder="Paste a hash to compare..."
+              className="flex-1 font-mono"
             />
-            {state.hmacMode && (
-              <Input
-                value={state.hmacKey}
-                onChange={(e) => updateState({ hmacKey: e.target.value })}
-                placeholder="Secret key..."
-                aria-label="HMAC secret key"
-                className="flex-1 font-mono"
-              />
+            {compareNormalized && hashes && (
+              <StatusBadge variant={matchedAlgo ? 'success' : 'error'}>
+                {matchedAlgo ? (
+                  <CheckCircleIcon size={12} weight="fill" aria-hidden="true" />
+                ) : (
+                  <XCircleIcon size={12} weight="fill" aria-hidden="true" />
+                )}
+                {matchedAlgo ? `Matches ${matchedAlgo}` : 'No match'}
+              </StatusBadge>
             )}
           </div>
+        </Field>
+      </div>
 
-          {/* Compare hash */}
-          <div className="mt-2">
-            <div className="flex items-center gap-2">
-              <Input
-                value={state.compareHash}
-                onChange={(e) => updateState({ compareHash: e.target.value })}
-                placeholder="Paste a hash to compare..."
-                aria-label="Hash to compare"
-                className="flex-1 font-mono"
-              />
-              {compareNormalized && hashes && (
-                <StatusBadge variant={matchedAlgo ? 'success' : 'error'}>
-                  {matchedAlgo ? (
-                    <CheckCircleIcon size={12} weight="fill" aria-hidden="true" />
-                  ) : (
-                    <XCircleIcon size={12} weight="fill" aria-hidden="true" />
-                  )}
-                  {matchedAlgo ? `Matches ${matchedAlgo}` : 'No match'}
-                </StatusBadge>
-              )}
-            </div>
-          </div>
-        </div>
-      }
-    >
       {hashList.length > 0 ? (
         <div className="flex flex-col gap-3">
           {hashList.map((h) => {

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -23,6 +23,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Dialog } from '@/components/shared/Dialog'
@@ -679,9 +680,9 @@ export default function HtmlValidator() {
             <div className="grid gap-x-8 gap-y-3 min-[700px]:grid-cols-2 min-[1100px]:grid-cols-4">
               {RULE_CATEGORIES.map((category) => (
                 <div key={category.id}>
-                  <h2 className="mb-1 text-2xs font-bold uppercase tracking-wide text-[var(--color-text-muted)]">
+                  <SectionLabel as="h2" className="mb-1">
                     {category.label}
-                  </h2>
+                  </SectionLabel>
                   {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
                     const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
                     return (

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -23,6 +23,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -771,22 +772,22 @@ export default function HtmlValidator() {
             aria-label="Rendered preview"
             className={`flex min-h-0 min-w-0 flex-col ${showEditor ? 'w-1/2 max-[900px]:w-full' : 'w-full'}`}
           >
-            <div className="flex shrink-0 items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-              <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-                Preview
-              </span>
-              <Button
-                variant="ghost"
-                size="xs"
-                onClick={() => setIsPopoutOpen(true)}
-                disabled={!hasInput}
-                className="gap-1"
-                title="Expand to a full-size preview (Esc to close)"
-              >
-                <FrameCornersIcon size={12} aria-hidden="true" />
-                Expand
-              </Button>
-            </div>
+            <PaneHeader
+              title="Preview"
+              actions={
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => setIsPopoutOpen(true)}
+                  disabled={!hasInput}
+                  className="gap-1"
+                  title="Expand to a full-size preview (Esc to close)"
+                >
+                  <FrameCornersIcon size={12} aria-hidden="true" />
+                  Expand
+                </Button>
+              }
+            />
             <div className="min-h-0 flex-1 bg-[var(--color-bg)]">
               {/* Deliberate palette exception below: the preview is a page
                   canvas, not app chrome, and user HTML assumes a white

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -23,6 +23,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
+import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
@@ -632,9 +633,7 @@ export default function HtmlValidator() {
               title="Reformat the markup (⌘↵)"
             >
               Format
-              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                ⌘↵
-              </span>
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
             <CopyButton text={input} label="Copy HTML" />
           </ToolbarGroup>

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -57,6 +57,7 @@ import {
   type RuleConfig,
 } from '@/tools/html-validator/html-helpers'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type ViewMode = 'editor' | 'split' | 'preview'
 type Panel = 'problems' | 'outline'
@@ -547,7 +548,7 @@ export default function HtmlValidator() {
           <EmptyState
             icon={FileHtmlIcon}
             title="Paste or open an HTML document"
-            description="It is checked as you type, previewed beside the source, and reformatted with ⌘↵."
+            description={`It is checked as you type, previewed beside the source, and reformatted with ${formatShortcut('mod+enter')}.`}
             action={
               TOOL_SAMPLES['html-validator'] ? (
                 <span className="pointer-events-auto">
@@ -672,7 +673,7 @@ export default function HtmlValidator() {
               variant="icon"
               size="sm"
               onClick={() => void handleOpen()}
-              title="Open an .html file (⌘O)"
+              title={`Open an .html file (${formatShortcut('mod+o')})`}
               aria-label="Open HTML file"
             >
               <FolderOpenIcon size={14} aria-hidden="true" />
@@ -681,7 +682,7 @@ export default function HtmlValidator() {
               variant="icon"
               size="sm"
               onClick={() => void handleSave()}
-              title="Save the document (⌘S)"
+              title={`Save the document (${formatShortcut('mod+s')})`}
               aria-label="Save HTML document"
             >
               <FloppyDiskIcon size={14} aria-hidden="true" />
@@ -712,7 +713,7 @@ export default function HtmlValidator() {
               onClick={() => void handleFormat()}
               disabled={!hasInput || isFormatting}
               loading={isFormatting}
-              title="Reformat the markup (⌘↵)"
+              title={`Reformat the markup (${formatShortcut('mod+enter')})`}
             >
               Format
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -581,7 +581,7 @@ export default function HtmlValidator() {
               title="New HTML document"
               aria-label="New HTML document"
             >
-              <FilePlusIcon size={13} aria-hidden="true" />
+              <FilePlusIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -590,7 +590,7 @@ export default function HtmlValidator() {
               title="Open an .html file (⌘O)"
               aria-label="Open HTML file"
             >
-              <FolderOpenIcon size={13} aria-hidden="true" />
+              <FolderOpenIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -599,7 +599,7 @@ export default function HtmlValidator() {
               title="Save the document (⌘S)"
               aria-label="Save HTML document"
             >
-              <FloppyDiskIcon size={13} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
             </Button>
           </ToolbarGroup>
 
@@ -645,7 +645,7 @@ export default function HtmlValidator() {
             aria-controls={rulesPanelId}
             className="gap-1"
           >
-            <SlidersHorizontalIcon size={13} aria-hidden="true" />
+            <SlidersHorizontalIcon size={14} aria-hidden="true" />
             Rules
             {overrideCount > 0 && (
               <span className="rounded-full bg-[var(--color-accent)] px-1.5 text-2xs text-[var(--color-bg)]">
@@ -1004,13 +1004,13 @@ function ResultsPanel({
                     >
                       {issue.type === 'error' ? (
                         <WarningCircleIcon
-                          size={13}
+                          size={14}
                           aria-hidden="true"
                           className="shrink-0 text-[var(--color-error)]"
                         />
                       ) : (
                         <WarningIcon
-                          size={13}
+                          size={14}
                           aria-hidden="true"
                           className="shrink-0 text-[var(--color-warning)]"
                         />

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -26,6 +26,7 @@ import { Alert } from '@/components/shared/Alert'
 import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Dialog } from '@/components/shared/Dialog'
@@ -525,6 +526,87 @@ export default function HtmlValidator() {
         ? `No problems · ${stats?.elements ?? 0} element${stats?.elements === 1 ? '' : 's'} · depth ${stats?.depth ?? 0}`
         : `${errorCount} error${errorCount === 1 ? '' : 's'}, ${warningCount} warning${warningCount === 1 ? '' : 's'}`
 
+  // Each pane renders identically whether it's alone or beside the other, so it's defined once
+  // here and placed by the layout below rather than written out under both branches.
+  const sourcePane = (
+    <section
+      aria-label="HTML source"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+    >
+      <Editor
+        theme={monacoTheme}
+        language="html"
+        value={input}
+        onChange={handleChange}
+        onMount={handleEditorMount}
+        options={monacoOptions}
+      />
+      {!hasInput && (
+        // Click-through: the hint must never sit between the user and the caret.
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-6">
+          <EmptyState
+            icon={FileHtmlIcon}
+            title="Paste or open an HTML document"
+            description="It is checked as you type, previewed beside the source, and reformatted with ⌘↵."
+            action={
+              TOOL_SAMPLES['html-validator'] ? (
+                <span className="pointer-events-auto">
+                  <Button variant="secondary" size="sm" onClick={handleLoadSample}>
+                    Load sample
+                  </Button>
+                </span>
+              ) : undefined
+            }
+          />
+        </div>
+      )}
+    </section>
+  )
+
+  const previewPane = (
+    <section aria-label="Rendered preview" className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <PaneHeader
+        title="Preview"
+        actions={
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setIsPopoutOpen(true)}
+            disabled={!hasInput}
+            className="gap-1"
+            title="Expand to a full-size preview (Esc to close)"
+          >
+            <FrameCornersIcon size={12} aria-hidden="true" />
+            Expand
+          </Button>
+        }
+      />
+      <div className="min-h-0 flex-1 bg-[var(--color-bg)]">
+        {/* Deliberate palette exception below: the preview is a page
+            canvas, not app chrome, and user HTML assumes a white
+            background — on --color-bg its black body text is unreadable. */}
+        {previewHtml ? (
+          <iframe
+            title="HTML preview"
+            sandbox=""
+            srcDoc={previewHtml}
+            className="h-full w-full border-none bg-white"
+          />
+        ) : (
+          <EmptyState
+            size="sm"
+            title={hasInput ? 'Rendering…' : 'Nothing to preview'}
+            description={
+              hasInput
+                ? 'The preview follows the source a moment behind.'
+                : 'Type or open HTML in the source pane.'
+            }
+          />
+        )}
+      </div>
+    </section>
+  )
+
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
@@ -725,94 +807,23 @@ export default function HtmlValidator() {
         </Alert>
       )}
 
-      {/* Below ~900px a 50/50 split leaves two unusable columns, so the panes stack. */}
-      <div className="flex min-h-0 flex-1 overflow-hidden max-[900px]:flex-col">
-        {showEditor && (
-          <section
-            aria-label="HTML source"
-            className={`relative flex min-h-0 min-w-0 flex-col overflow-hidden ${
-              showPreview
-                ? 'w-1/2 border-r border-[var(--color-border)] max-[900px]:w-full max-[900px]:border-r-0 max-[900px]:border-b'
-                : 'w-full'
-            }`}
-          >
-            <Editor
-              theme={monacoTheme}
-              language="html"
-              value={input}
-              onChange={handleChange}
-              onMount={handleEditorMount}
-              options={monacoOptions}
-            />
-            {!hasInput && (
-              // Click-through: the hint must never sit between the user and the caret.
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-6">
-                <EmptyState
-                  icon={FileHtmlIcon}
-                  title="Paste or open an HTML document"
-                  description="It is checked as you type, previewed beside the source, and reformatted with ⌘↵."
-                  action={
-                    TOOL_SAMPLES['html-validator'] ? (
-                      <span className="pointer-events-auto">
-                        <Button variant="secondary" size="sm" onClick={handleLoadSample}>
-                          Load sample
-                        </Button>
-                      </span>
-                    ) : undefined
-                  }
-                />
-              </div>
-            )}
-          </section>
-        )}
-
-        {showPreview && (
-          <section
-            aria-label="Rendered preview"
-            className={`flex min-h-0 min-w-0 flex-col ${showEditor ? 'w-1/2 max-[900px]:w-full' : 'w-full'}`}
-          >
-            <PaneHeader
-              title="Preview"
-              actions={
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => setIsPopoutOpen(true)}
-                  disabled={!hasInput}
-                  className="gap-1"
-                  title="Expand to a full-size preview (Esc to close)"
-                >
-                  <FrameCornersIcon size={12} aria-hidden="true" />
-                  Expand
-                </Button>
-              }
-            />
-            <div className="min-h-0 flex-1 bg-[var(--color-bg)]">
-              {/* Deliberate palette exception below: the preview is a page
-                  canvas, not app chrome, and user HTML assumes a white
-                  background — on --color-bg its black body text is unreadable. */}
-              {previewHtml ? (
-                <iframe
-                  title="HTML preview"
-                  sandbox=""
-                  srcDoc={previewHtml}
-                  className="h-full w-full border-none bg-white"
-                />
-              ) : (
-                <EmptyState
-                  size="sm"
-                  title={hasInput ? 'Rendering…' : 'Nothing to preview'}
-                  description={
-                    hasInput
-                      ? 'The preview follows the source a moment behind.'
-                      : 'Type or open HTML in the source pane.'
-                  }
-                />
-              )}
-            </div>
-          </section>
-        )}
-      </div>
+      {/* Split mode goes through SplitPane; the single-pane modes are a plain full-width box.
+          Below ~900px SplitPane stacks them, because a 50/50 split there leaves two unusable
+          columns. */}
+      {showEditor && showPreview ? (
+        <SplitPane
+          storageKey="html-validator"
+          stackBelow={900}
+          aria-label="Resize source and preview"
+        >
+          {sourcePane}
+          {previewPane}
+        </SplitPane>
+      ) : (
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {showEditor ? sourcePane : previewPane}
+        </div>
+      )}
 
       <ResultsPanel
         panel={state.panel}

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -3,6 +3,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useUiStore } from '@/stores/ui.store'
 import { buildExportFilename, exportFile } from '@/lib/file-io'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Input } from '@/components/shared/Input'
 import { TabBar } from '@/components/shared/TabBar'
 import { Toggle } from '@/components/shared/Toggle'
@@ -893,9 +894,9 @@ function ResizePanel({
   return (
     <div className="flex flex-col gap-4">
       <div>
-        <div className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2">
           Dimensions
-        </div>
+        </SectionLabel>
         <div className="flex items-center gap-2">
           <div className="flex flex-1 flex-col gap-1">
             <label className="text-2xs text-[var(--color-text-muted)]">Width (px)</label>
@@ -945,9 +946,9 @@ function ResizePanel({
       </div>
 
       <div>
-        <div className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2">
           Aspect Ratio Presets
-        </div>
+        </SectionLabel>
         <div className="flex flex-wrap gap-1.5">
           {PRESET_SIZES.map(({ label, w, h }) => (
             // eslint-disable-next-line no-restricted-syntax -- dense 10px preset chip grid; Button's smallest size (text-xs, px-1.5) makes the row wrap at this panel width.
@@ -1003,9 +1004,9 @@ function CropPanel({
 
       {/* Crop coordinates */}
       <div className={enabled ? '' : 'pointer-events-none opacity-40'}>
-        <div className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2">
           Offset
-        </div>
+        </SectionLabel>
         <div className="grid grid-cols-2 gap-2">
           <div className="flex flex-col gap-1">
             <label className="text-2xs text-[var(--color-text-muted)]">X (px)</label>
@@ -1033,9 +1034,9 @@ function CropPanel({
           </div>
         </div>
 
-        <div className="mb-2 mt-3 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2 mt-3">
           Size
-        </div>
+        </SectionLabel>
         <div className="grid grid-cols-2 gap-2">
           <div className="flex flex-col gap-1">
             <label className="text-2xs text-[var(--color-text-muted)]">Width (px)</label>
@@ -1122,9 +1123,9 @@ function ExportPanel({
   return (
     <div className="flex flex-col gap-4">
       <div>
-        <div className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2">
           Format
-        </div>
+        </SectionLabel>
         <TabBar tabs={FORMAT_TABS} activeTab={format} onTabChange={onFormatChange} />
         <div className="mt-1.5 text-2xs text-[var(--color-text-muted)]">
           {format === 'png' && 'Lossless · Supports transparency'}
@@ -1136,9 +1137,7 @@ function ExportPanel({
       {isLossy && (
         <div>
           <div className="mb-2 flex items-center justify-between">
-            <div className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
-              Quality
-            </div>
+            <SectionLabel as="div">Quality</SectionLabel>
             <span className="font-mono text-xs text-[var(--color-text)]">{quality}%</span>
           </div>
           <input
@@ -1157,9 +1156,9 @@ function ExportPanel({
       )}
 
       <div>
-        <div className="mb-2 text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+        <SectionLabel as="div" className="mb-2">
           Output Info
-        </div>
+        </SectionLabel>
         <div className="space-y-1 text-xs text-[var(--color-text-muted)]">
           <div>
             Dimensions:{' '}

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -3,6 +3,7 @@ import { useToolState } from '@/hooks/useToolState'
 import { useUiStore } from '@/stores/ui.store'
 import { buildExportFilename, exportFile } from '@/lib/file-io'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Input } from '@/components/shared/Input'
 import { TabBar } from '@/components/shared/TabBar'
@@ -898,8 +899,7 @@ function ResizePanel({
           Dimensions
         </SectionLabel>
         <div className="flex items-center gap-2">
-          <div className="flex flex-1 flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">Width (px)</label>
+          <Field label="Width (px)" className="flex-1">
             <Input
               type="number"
               min={1}
@@ -908,7 +908,7 @@ function ResizePanel({
               placeholder="Width"
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
+          </Field>
 
           <Button
             variant="icon"
@@ -921,8 +921,7 @@ function ResizePanel({
             {lockAspect ? <LockSimpleIcon size={14} /> : <LockSimpleOpenIcon size={14} />}
           </Button>
 
-          <div className="flex flex-1 flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">Height (px)</label>
+          <Field label="Height (px)" className="flex-1">
             <Input
               type="number"
               min={1}
@@ -931,7 +930,7 @@ function ResizePanel({
               placeholder="Height"
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
+          </Field>
         </div>
 
         {/* eslint-disable-next-line no-restricted-syntax -- 10px underlabel link beneath the
@@ -1008,8 +1007,7 @@ function CropPanel({
           Offset
         </SectionLabel>
         <div className="grid grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">X (px)</label>
+          <Field label="X (px)">
             <Input
               type="number"
               min={0}
@@ -1019,9 +1017,8 @@ function CropPanel({
               onChange={(e) => onChange(Number(e.target.value), y, w, h)}
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">Y (px)</label>
+          </Field>
+          <Field label="Y (px)">
             <Input
               type="number"
               min={0}
@@ -1031,15 +1028,14 @@ function CropPanel({
               onChange={(e) => onChange(x, Number(e.target.value), w, h)}
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
+          </Field>
         </div>
 
         <SectionLabel as="div" className="mb-2 mt-3">
           Size
         </SectionLabel>
         <div className="grid grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">Width (px)</label>
+          <Field label="Width (px)">
             <Input
               type="number"
               min={1}
@@ -1049,9 +1045,8 @@ function CropPanel({
               onChange={(e) => onChange(x, y, Number(e.target.value), h)}
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label className="text-2xs text-[var(--color-text-muted)]">Height (px)</label>
+          </Field>
+          <Field label="Height (px)">
             <Input
               type="number"
               min={1}
@@ -1061,7 +1056,7 @@ function CropPanel({
               onChange={(e) => onChange(x, y, w, Number(e.target.value))}
               className={NUMBER_FIELD_CLASS}
             />
-          </div>
+          </Field>
         </div>
 
         {/* eslint-disable-next-line no-restricted-syntax -- 10px underlabel link beneath the

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -573,7 +573,13 @@ export default function ImageTool() {
       toolbar={
         <>
           <Toolbar aria-label="Image actions" className="gap-3">
-            <Button variant="primary" size="sm" onClick={() => fileInputRef.current?.click()}>
+            {/* Primary only until an image is open. After that the tool's one primary action is
+                Download, in the export panel — opening another image is a restart, not the goal. */}
+            <Button
+              variant={originalImg ? 'secondary' : 'primary'}
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
+            >
               <UploadSimpleIcon size={14} />
               Open Image
             </Button>

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -572,7 +572,7 @@ export default function ImageTool() {
         <>
           <Toolbar aria-label="Image actions" className="gap-3">
             <Button variant="primary" size="sm" onClick={() => fileInputRef.current?.click()}>
-              <UploadSimpleIcon size={13} />
+              <UploadSimpleIcon size={14} />
               Open Image
             </Button>
             <input
@@ -616,7 +616,7 @@ export default function ImageTool() {
                   title="Reset all settings"
                   className="gap-1"
                 >
-                  <ArrowCounterClockwiseIcon size={13} />
+                  <ArrowCounterClockwiseIcon size={14} />
                   Reset
                 </Button>
               </>
@@ -1149,7 +1149,7 @@ function ExportPanel({
             onChange={(e) => onQualityChange(Number(e.target.value))}
             className="w-full accent-[var(--color-accent)]"
           />
-          <div className="mt-1 flex justify-between text-[9px] text-[var(--color-text-muted)]">
+          <div className="mt-1 flex justify-between text-2xs text-[var(--color-text-muted)]">
             <span>Smaller</span>
             <span>Higher quality</span>
           </div>
@@ -1190,7 +1190,7 @@ function ExportPanel({
             void onDownload()
           }}
         >
-          <DownloadSimpleIcon size={13} />
+          <DownloadSimpleIcon size={14} />
           Download {format.toUpperCase()}
         </Button>
         <Button
@@ -1200,7 +1200,7 @@ function ExportPanel({
             void onCopy()
           }}
         >
-          <CopyIcon size={13} />
+          <CopyIcon size={14} />
           Copy as PNG
         </Button>
       </div>

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -17,6 +17,7 @@ import { useToolAction } from '@/hooks/useToolAction'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
@@ -707,31 +708,29 @@ function EditorPane({
       aria-label={title}
       className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${className}`}
     >
-      <div className="flex flex-wrap items-center gap-1 border-b border-[var(--color-border)] px-3 py-1.5">
-        <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-          {title}
-        </span>
-        {fileName && (
-          <span className="max-w-[10rem] truncate text-2xs text-[var(--color-text-muted)]">
-            {fileName}
-          </span>
-        )}
-        {headerExtras ?? <span className="ml-auto" />}
-        <Button variant="ghost" size="xs" onClick={onFormat} disabled={!value.trim()}>
-          Format
-        </Button>
-        <CopyButton text={value} label={copyLabel} className="min-w-0" />
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={onSave}
-          disabled={!value.trim()}
-          aria-label={`Save ${title.toLowerCase()} to file`}
-          title="Save to a file (⌘S)"
-        >
-          <FloppyDiskIcon size={14} aria-hidden="true" />
-        </Button>
-      </div>
+      <PaneHeader
+        title={title}
+        hint={fileName ? <span className="max-w-[10rem] truncate">{fileName}</span> : undefined}
+        actions={
+          <>
+            {headerExtras}
+            <Button variant="ghost" size="xs" onClick={onFormat} disabled={!value.trim()}>
+              Format
+            </Button>
+            <CopyButton text={value} label={copyLabel} className="min-w-0" />
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onSave}
+              disabled={!value.trim()}
+              aria-label={`Save ${title.toLowerCase()} to file`}
+              title="Save to a file (⌘S)"
+            >
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+            </Button>
+          </>
+        }
+      />
       <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={monacoTheme}
@@ -771,27 +770,28 @@ function ProblemsPanel({
       aria-label="Problems"
       className="flex max-h-52 min-h-0 shrink-0 flex-col border-t border-[var(--color-border)]"
     >
-      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
-        <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-          Problems
-        </span>
-        <span className="text-2xs text-[var(--color-error)]">{total}</span>
-        {total > MAX_ISSUES && (
-          <span className="text-2xs text-[var(--color-text-muted)]">
-            showing the first {MAX_ISSUES}
-          </span>
-        )}
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={onToggle}
-          aria-expanded={open}
-          aria-controls={listId}
-          className="ml-auto"
-        >
-          {open ? 'Hide' : 'Show'}
-        </Button>
-      </div>
+      <PaneHeader
+        title="Problems"
+        // `hint`, not `status`: the tool's own summary bar already announces the count, and a
+        // second live region saying the same number means a screen reader reads it twice.
+        hint={
+          <>
+            <span className="text-[var(--color-error)]">{total}</span>
+            {total > MAX_ISSUES && <> · showing the first {MAX_ISSUES}</>}
+          </>
+        }
+        actions={
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={onToggle}
+            aria-expanded={open}
+            aria-controls={listId}
+          >
+            {open ? 'Hide' : 'Show'}
+          </Button>
+        }
+      />
       {open && (
         <ul id={listId} className="min-h-0 flex-1 overflow-auto py-1">
           {issues.map((issue, i) => (

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -42,6 +42,7 @@ import {
   findMatchingTemplate,
 } from '@/tools/json-schema-validator/templates'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type Pane = 'data' | 'schema'
 
@@ -724,7 +725,7 @@ function EditorPane({
               onClick={onSave}
               disabled={!value.trim()}
               aria-label={`Save ${title.toLowerCase()} to file`}
-              title="Save to a file (⌘S)"
+              title={`Save to a file (${formatShortcut('mod+s')})`}
             >
               <FloppyDiskIcon size={14} aria-hidden="true" />
             </Button>

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -484,7 +484,7 @@ export default function JsonSchemaValidator() {
               className="gap-1"
               title="Replace the schema with one inferred from the data"
             >
-              <MagicWandIcon size={13} aria-hidden="true" />
+              <MagicWandIcon size={14} aria-hidden="true" />
               Infer schema
             </Button>
             <Button
@@ -509,7 +509,7 @@ export default function JsonSchemaValidator() {
             </Button>
             {undoBuffer && (
               <Button variant="ghost" size="sm" onClick={handleUndo} className="gap-1">
-                <ArrowUUpLeftIcon size={13} aria-hidden="true" />
+                <ArrowUUpLeftIcon size={14} aria-hidden="true" />
                 Undo {undoBuffer.label.toLowerCase()}
               </Button>
             )}
@@ -729,7 +729,7 @@ function EditorPane({
           aria-label={`Save ${title.toLowerCase()} to file`}
           title="Save to a file (⌘S)"
         >
-          <FloppyDiskIcon size={13} aria-hidden="true" />
+          <FloppyDiskIcon size={14} aria-hidden="true" />
         </Button>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -21,6 +21,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { Button } from '@/components/shared/Button'
 import { Alert } from '@/components/shared/Alert'
 import { PaneHeader } from '@/components/shared/PaneHeader'
@@ -554,9 +555,7 @@ export default function JsonTools() {
                 title="Format the document (⌘↵)"
               >
                 Format
-                <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                  ⌘↵
-                </span>
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
               <Button variant="secondary" size="sm" onClick={handleMinify} disabled={!isValid}>
                 Minify

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -477,7 +477,7 @@ export default function JsonTools() {
               title={state.fileName ?? 'Untitled'}
               icon={
                 <BracketsCurlyIcon
-                  size={15}
+                  size={16}
                   aria-hidden="true"
                   className="shrink-0 text-[var(--color-text-muted)]"
                 />
@@ -532,7 +532,7 @@ export default function JsonTools() {
                 {...(state.queryOpen ? { 'aria-controls': queryId } : {})}
                 className="gap-1"
               >
-                <MagnifyingGlassIcon size={13} aria-hidden="true" />
+                <MagnifyingGlassIcon size={14} aria-hidden="true" />
                 Path
               </Button>
               <SegmentedControl
@@ -567,7 +567,7 @@ export default function JsonTools() {
                 disabled={!isValid}
                 className="gap-1"
               >
-                <SortAscendingIcon size={13} aria-hidden="true" />
+                <SortAscendingIcon size={14} aria-hidden="true" />
                 Sort keys
               </Button>
               <CopyButton text={input} label="Copy JSON" />
@@ -579,7 +579,7 @@ export default function JsonTools() {
                 title="Save to a file (⌘S)"
                 aria-label="Save JSON to file"
               >
-                <FloppyDiskIcon size={15} aria-hidden="true" />
+                <FloppyDiskIcon size={16} aria-hidden="true" />
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>
@@ -963,7 +963,7 @@ function compareValues(a: unknown, b: unknown): number {
 function SortIndicator({ direction }: { direction: 'asc' | 'desc' | null }) {
   const Icon =
     direction === 'asc' ? CaretUpIcon : direction === 'desc' ? CaretDownIcon : ArrowsDownUpIcon
-  return <Icon size={10} aria-hidden="true" className="text-[var(--color-text-muted)]" />
+  return <Icon size={12} aria-hidden="true" className="text-[var(--color-text-muted)]" />
 }
 
 function JsonTable({ data, onCopy }: { data: Record<string, unknown>[]; onCopy: CopyToClipboard }) {

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -25,6 +25,7 @@ import { Kbd } from '@/components/shared/Kbd'
 import { Button } from '@/components/shared/Button'
 import { Alert } from '@/components/shared/Alert'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
@@ -469,6 +470,55 @@ export default function JsonTools() {
           ? `Valid JSON · ${stats.keys} key${stats.keys === 1 ? '' : 's'} · depth ${stats.depth} · ${stats.size}`
           : 'Valid JSON'
 
+  // Lifted out of the JSX below because the source pane appears in two shapes — alone when the
+  // inspector is hidden, and as a SplitPane child when it isn't — and duplicating fifty lines of
+  // editor wiring to express that is how the two copies drift apart.
+  const sourcePane = (
+    <section
+      aria-label="JSON source"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+    >
+      <Editor
+        theme={monacoTheme}
+        language="json"
+        value={input}
+        onChange={(v) => {
+          updateState({ input: v ?? '' })
+          // The banner reports a failed format of the *old* text; leaving it
+          // up contradicts the status line as soon as the user fixes things.
+          setError(null)
+        }}
+        options={monacoOptions}
+        onMount={(editor) => {
+          editorRef.current = editor
+        }}
+      />
+      {!hasInput && (
+        // Click-through: the hint must never sit between the user and the caret.
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-6">
+          <EmptyState
+            icon={BracketsCurlyIcon}
+            title="Paste or open a JSON document"
+            description="Format with ⌘↵, inspect it as a tree or table, and query values by path."
+            action={
+              TOOL_SAMPLES['json-tools'] ? (
+                <span className="pointer-events-auto">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => updateState({ input: TOOL_SAMPLES['json-tools'] ?? '' })}
+                  >
+                    Load sample
+                  </Button>
+                </span>
+              ) : undefined
+            }
+          />
+        </div>
+      )}
+    </section>
+  )
+
   return (
     <ToolLayout
       fullBleed
@@ -632,52 +682,15 @@ export default function JsonTools() {
           {error}
         </Alert>
       )}
-      <div className="flex min-h-0 flex-1 max-[900px]:flex-col">
-        <section
-          aria-label="JSON source"
-          className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      {view === 'source' ? (
+        <div className="flex min-h-0 flex-1">{sourcePane}</div>
+      ) : (
+        <SplitPane
+          storageKey="json-tools"
+          stackBelow={900}
+          aria-label="Resize source and inspector"
         >
-          <Editor
-            theme={monacoTheme}
-            language="json"
-            value={input}
-            onChange={(v) => {
-              updateState({ input: v ?? '' })
-              // The banner reports a failed format of the *old* text; leaving it
-              // up contradicts the status line as soon as the user fixes things.
-              setError(null)
-            }}
-            options={monacoOptions}
-            onMount={(editor) => {
-              editorRef.current = editor
-            }}
-          />
-          {!hasInput && (
-            // Click-through: the hint must never sit between the user and the caret.
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-6">
-              <EmptyState
-                icon={BracketsCurlyIcon}
-                title="Paste or open a JSON document"
-                description="Format with ⌘↵, inspect it as a tree or table, and query values by path."
-                action={
-                  TOOL_SAMPLES['json-tools'] ? (
-                    <span className="pointer-events-auto">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => updateState({ input: TOOL_SAMPLES['json-tools'] ?? '' })}
-                      >
-                        Load sample
-                      </Button>
-                    </span>
-                  ) : undefined
-                }
-              />
-            </div>
-          )}
-        </section>
-
-        {view !== 'source' && (
+          {sourcePane}
           <InspectorPane
             view={view}
             parsed={parsed}
@@ -685,8 +698,8 @@ export default function JsonTools() {
             data={data}
             onCopy={copy}
           />
-        )}
-      </div>
+        </SplitPane>
+      )}
     </ToolLayout>
   )
 }
@@ -725,7 +738,8 @@ function InspectorPane({
   return (
     <section
       aria-label={view === 'tree' ? 'Tree view' : 'Table view'}
-      className="flex min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--color-border)] max-[900px]:max-h-[45%] max-[900px]:border-l-0 max-[900px]:border-t"
+      /* SplitPane owns the divider and the stacked border, so the pane itself carries neither. */
+      className="flex min-h-0 min-w-0 flex-1 flex-col"
     >
       <PaneHeader
         title={view === 'tree' ? 'Tree' : 'Table'}

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -38,6 +38,7 @@ import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
 import { formatBytes } from '@/lib/format'
 import { useCopyToClipboard, type CopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type JsonView = 'source' | 'tree' | 'table'
 
@@ -499,7 +500,7 @@ export default function JsonTools() {
           <EmptyState
             icon={BracketsCurlyIcon}
             title="Paste or open a JSON document"
-            description="Format with ⌘↵, inspect it as a tree or table, and query values by path."
+            description={`Format with ${formatShortcut('mod+enter')}, inspect it as a tree or table, and query values by path.`}
             action={
               TOOL_SAMPLES['json-tools'] ? (
                 <span className="pointer-events-auto">
@@ -602,7 +603,7 @@ export default function JsonTools() {
                 onClick={() => void handleFormat()}
                 disabled={!hasInput || isFormatting}
                 loading={isFormatting}
-                title="Format the document (⌘↵)"
+                title={`Format the document (${formatShortcut('mod+enter')})`}
               >
                 Format
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -626,7 +627,7 @@ export default function JsonTools() {
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasInput}
-                title="Save to a file (⌘S)"
+                title={`Save to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save JSON to file"
               >
                 <FloppyDiskIcon size={16} aria-hidden="true" />

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -23,6 +23,7 @@ import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Button } from '@/components/shared/Button'
 import { Alert } from '@/components/shared/Alert'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
@@ -727,45 +728,47 @@ function InspectorPane({
       aria-label={view === 'tree' ? 'Tree view' : 'Table view'}
       className="flex min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--color-border)] max-[900px]:max-h-[45%] max-[900px]:border-l-0 max-[900px]:border-t"
     >
-      <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
-        <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-          {view === 'tree' ? 'Tree' : 'Table'}
-        </span>
-        {view === 'tree' && parsed.status === 'valid' && (
+      <PaneHeader
+        title={view === 'tree' ? 'Tree' : 'Table'}
+        actions={
           <>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => setExpansion(true)}
-              className="gap-1"
-              title="Expand every node"
-            >
-              <ArrowsOutLineVerticalIcon size={12} aria-hidden="true" />
-              Expand all
-            </Button>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => setExpansion(false)}
-              className="gap-1"
-              title="Collapse every node"
-            >
-              <ArrowsInLineVerticalIcon size={12} aria-hidden="true" />
-              Collapse all
-            </Button>
-            {expandAll === null && !autoExpanded && (
+            {view === 'tree' && parsed.status === 'valid' && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => setExpansion(true)}
+                  className="gap-1"
+                  title="Expand every node"
+                >
+                  <ArrowsOutLineVerticalIcon size={12} aria-hidden="true" />
+                  Expand all
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => setExpansion(false)}
+                  className="gap-1"
+                  title="Collapse every node"
+                >
+                  <ArrowsInLineVerticalIcon size={12} aria-hidden="true" />
+                  Collapse all
+                </Button>
+                {expandAll === null && !autoExpanded && (
+                  <span className="text-2xs text-[var(--color-text-muted)]">
+                    Collapsed — {keyCount} keys
+                  </span>
+                )}
+              </>
+            )}
+            {view === 'table' && parsed.status === 'valid' && tabular && (
               <span className="text-2xs text-[var(--color-text-muted)]">
-                Collapsed — {keyCount} keys
+                {data.length} row{data.length === 1 ? '' : 's'}
               </span>
             )}
           </>
-        )}
-        {view === 'table' && parsed.status === 'valid' && tabular && (
-          <span className="text-2xs text-[var(--color-text-muted)]">
-            {data.length} row{data.length === 1 ? '' : 's'}
-          </span>
-        )}
-      </div>
+        }
+      />
 
       <div className="min-h-0 flex-1 overflow-auto">
         {parsed.status === 'empty' && (

--- a/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -173,7 +173,7 @@ export default function JwtDecoder() {
         />
         {/* Color-coded token preview */}
         {tokenParts && decoded && (
-          <div className="mt-2 break-all font-mono text-[11px] leading-relaxed">
+          <div className="mt-2 break-all font-mono text-xs leading-relaxed">
             <span className="text-[var(--color-info)]">{tokenParts[0]}</span>
             <span className="text-[var(--color-text-muted)]">.</span>
             <span className="text-[var(--color-success)]">{tokenParts[1]}</span>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -55,6 +55,7 @@ import {
 import { markdownEditorProcessor } from '@/lib/markdown'
 import { toggleTaskAtIndex } from '@/tools/markdown-editor/task-list'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -268,7 +269,7 @@ const FORMATTING_ACTIONS: FormattingAction[] = [
   // Group 1 — inline text formatting
   {
     label: 'B',
-    title: 'Bold (⌘B)',
+    title: `Bold (${formatShortcut('mod+b')})`,
     prefix: '**',
     suffix: '**',
     placeholder: 'bold text',
@@ -276,7 +277,7 @@ const FORMATTING_ACTIONS: FormattingAction[] = [
   },
   {
     label: 'I',
-    title: 'Italic (⌘I)',
+    title: `Italic (${formatShortcut('mod+i')})`,
     prefix: '_',
     suffix: '_',
     placeholder: 'italic text',

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -6,6 +6,7 @@ import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { SelectionContextToolbar } from '@/components/shared/SelectionContextToolbar'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { useUiStore } from '@/stores/ui.store'
@@ -940,6 +941,41 @@ export default function MarkdownEditor() {
     [requestDocument]
   )
 
+  // Each pane renders identically whether it's alone or beside the other, so it's defined once
+  // here and placed by the layout below rather than written out under both branches.
+  const editorPane = (
+    <div ref={editorContainerRef} className="relative min-h-0 flex-1 overflow-hidden">
+      <Editor
+        theme={monacoTheme}
+        language="markdown"
+        value={state.content}
+        onChange={(v) => updateState({ content: v ?? '' })}
+        onMount={handleEditorMount}
+        options={monacoOptions}
+      />
+      {/* Image drop overlay */}
+      {isDraggingImage && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--color-surface)]/80 backdrop-blur-sm">
+          <div className="rounded-lg border-2 border-dashed border-[var(--color-accent)] px-6 py-4 text-sm text-[var(--color-accent)]">
+            Drop image to embed
+          </div>
+        </div>
+      )}
+    </div>
+  )
+
+  const previewPane = (
+    <div className="min-h-0 flex-1">
+      <MarkdownPreview
+        ref={previewRef}
+        html={html}
+        showToc={state.showToc}
+        toc={toc}
+        onToggleTask={handleToggleTask}
+      />
+    </div>
+  )
+
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
@@ -1265,55 +1301,23 @@ export default function MarkdownEditor() {
       )}
 
       {/* ─── Body ───────────────────────────────────────────────── */}
-      <div className="flex min-h-0 flex-1 overflow-hidden max-[1000px]:flex-col">
-        {/* Editor */}
-        {showEditor && (
-          <div
-            ref={editorContainerRef}
-            className={`relative min-h-0 overflow-hidden ${
-              showPreview
-                ? 'h-full w-1/2 border-r border-[var(--color-border)] max-[1000px]:h-1/2 max-[1000px]:w-full max-[1000px]:border-b max-[1000px]:border-r-0'
-                : 'h-full w-full'
-            }`}
-          >
-            <Editor
-              theme={monacoTheme}
-              language="markdown"
-              value={state.content}
-              onChange={(v) => updateState({ content: v ?? '' })}
-              onMount={handleEditorMount}
-              options={monacoOptions}
-            />
-            {/* Image drop overlay */}
-            {isDraggingImage && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--color-surface)]/80 backdrop-blur-sm">
-                <div className="rounded-lg border-2 border-dashed border-[var(--color-accent)] px-6 py-4 text-sm text-[var(--color-accent)]">
-                  Drop image to embed
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Preview */}
-        {showPreview && (
-          <div
-            className={
-              showEditor
-                ? 'h-full min-h-0 w-1/2 max-[1000px]:h-1/2 max-[1000px]:w-full'
-                : 'h-full min-h-0 w-full'
-            }
-          >
-            <MarkdownPreview
-              ref={previewRef}
-              html={html}
-              showToc={state.showToc}
-              toc={toc}
-              onToggleTask={handleToggleTask}
-            />
-          </div>
-        )}
-      </div>
+      {/* Split mode goes through SplitPane; the single-pane modes are a plain full-width box.
+          Below ~1000px SplitPane stacks them — markdown needs more line length than most panes
+          before a 50/50 split stops being readable. */}
+      {showEditor && showPreview ? (
+        <SplitPane
+          storageKey="markdown-editor"
+          stackBelow={1000}
+          aria-label="Resize editor and preview"
+        >
+          {editorPane}
+          {previewPane}
+        </SplitPane>
+      ) : (
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {showEditor ? editorPane : previewPane}
+        </div>
+      )}
 
       <footer className="flex min-h-7 shrink-0 items-center gap-3 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-2xs text-[var(--color-text-muted)]">
         <span>{isDirty ? 'Unsaved changes' : 'All changes saved'}</span>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -1028,7 +1028,7 @@ export default function MarkdownEditor() {
             onClick={() => void handleSave()}
             className="gap-1.5"
           >
-            <FloppyDiskIcon size={13} aria-hidden="true" /> Save
+            <FloppyDiskIcon size={14} aria-hidden="true" /> Save
           </Button>
 
           <div ref={fileMenuRef} className="relative">
@@ -1043,7 +1043,7 @@ export default function MarkdownEditor() {
               aria-expanded={showFileMenu}
               aria-haspopup="menu"
             >
-              File <CaretDownIcon size={10} aria-hidden="true" className="ml-1" />
+              File <CaretDownIcon size={12} aria-hidden="true" className="ml-1" />
             </Button>
             {showFileMenu && (
               <div
@@ -1147,7 +1147,7 @@ export default function MarkdownEditor() {
               aria-expanded={showExport}
               aria-haspopup="menu"
             >
-              Export <CaretDownIcon size={10} aria-hidden="true" />
+              Export <CaretDownIcon size={12} aria-hidden="true" />
             </Button>
             {showExport && (
               <div

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -203,7 +203,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
                 variant="ghost"
                 size="xs"
                 onClick={() => scrollToHeading(entry.id)}
-                className="block w-full truncate rounded-none p-0 text-left text-[11px] leading-relaxed text-[var(--color-text-muted)] hover:bg-transparent hover:text-[var(--color-accent)]"
+                className="block w-full truncate rounded-none p-0 text-left text-xs leading-relaxed text-[var(--color-text-muted)] hover:bg-transparent hover:text-[var(--color-accent)]"
                 style={{ paddingLeft: `${(entry.level - 1) * 12}px` }}
                 title={entry.text}
               >

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, forwardRef, useImperativeHandl
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { nextHeadingId } from './heading-ids'
 
 type TocEntry = {
@@ -194,9 +195,9 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
         {/* TOC Sidebar */}
         {showToc && toc.length > 0 && (
           <div className="w-48 shrink-0 overflow-auto border-r border-[var(--color-border)] p-3">
-            <div className="mb-2 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+            <SectionLabel as="div" className="mb-2">
               Contents
-            </div>
+            </SectionLabel>
             {toc.map((entry, i) => (
               <Button
                 key={`${entry.id}-${i}`}

--- a/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
@@ -3,6 +3,8 @@ import { Button } from '@/components/shared/Button'
 import { Input } from '@/components/shared/Input'
 import { Dialog } from '@/components/shared/Dialog'
 import { Alert } from '@/components/shared/Alert'
+import { Field } from '@/components/shared/Field'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 
 type Props = {
   onInsert: (markdown: string) => void
@@ -70,10 +72,12 @@ export function ImageModal({ onInsert, onClose }: Props) {
       }
     >
       <div className="flex flex-col gap-3" onKeyDown={handleKeyDown}>
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Image URL</label>
+        {/* Explicit htmlFor: the Paste button shares the row, and a wrapping label would
+            forward clicks to whichever labelable descendant comes first. */}
+        <Field label="Image URL" htmlFor="image-modal-url">
           <div className="flex gap-2">
             <Input
+              id="image-modal-url"
               ref={urlRef}
               value={url}
               onChange={(e) => setUrl(e.target.value)}
@@ -93,21 +97,21 @@ export function ImageModal({ onInsert, onClose }: Props) {
             </Button>
           </div>
           {pasteError && <Alert variant="error">{pasteError}</Alert>}
-        </div>
+        </Field>
 
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Alt Text</label>
+        <Field label="Alt Text">
           <Input
             value={alt}
             onChange={(e) => setAlt(e.target.value)}
             placeholder="Alt text"
             size="md"
           />
-        </div>
+        </Field>
 
         {isValid && (
           <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">Preview</label>
+            {/* Not a Field: this names a preview, it doesn't label a control. */}
+            <SectionLabel>Preview</SectionLabel>
             <div className="flex items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-2">
               <img
                 src={url}

--- a/apps/cockpit/src/tools/markdown-editor/modals/LinkModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/LinkModal.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
 import { Input } from '@/components/shared/Input'
 import { Dialog } from '@/components/shared/Dialog'
 
@@ -55,8 +56,7 @@ export function LinkModal({ initialText = '', onInsert, onClose }: Props) {
       }
     >
       <div className="flex flex-col gap-3" onKeyDown={handleKeyDown}>
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">URL *</label>
+        <Field label="URL" required>
           <Input
             ref={urlRef}
             value={url}
@@ -64,20 +64,16 @@ export function LinkModal({ initialText = '', onInsert, onClose }: Props) {
             placeholder="https://example.com"
             size="md"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Link Text</label>
+        </Field>
+        <Field label="Link Text">
           <Input
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder="Link text"
             size="md"
           />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">
-            Title (tooltip)
-          </label>
+        </Field>
+        <Field label="Title (tooltip)">
           <Input
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -85,7 +81,7 @@ export function LinkModal({ initialText = '', onInsert, onClose }: Props) {
             size="md"
             disabled={newTab}
           />
-        </div>
+        </Field>
         <label className="flex cursor-pointer items-center gap-2">
           <input
             type="checkbox"

--- a/apps/cockpit/src/tools/markdown-editor/modals/TableModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/TableModal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { Input } from '@/components/shared/Input'
 import { useIsInstanceActive } from '@/app/tool-instance'
@@ -57,8 +59,7 @@ export function TableModal({ onInsert, onClose }: Props) {
     >
       <div className="flex flex-col gap-4">
         <div className="flex gap-6">
-          <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">Rows (1–10)</label>
+          <Field label="Rows (1–10)">
             <Input
               type="number"
               min={1}
@@ -68,11 +69,8 @@ export function TableModal({ onInsert, onClose }: Props) {
               size="md"
               className="w-20"
             />
-          </div>
-          <div className="flex flex-col gap-1">
-            <label className="font-mono text-xs text-[var(--color-text-muted)]">
-              Columns (1–10)
-            </label>
+          </Field>
+          <Field label="Columns (1–10)">
             <Input
               type="number"
               min={1}
@@ -82,11 +80,12 @@ export function TableModal({ onInsert, onClose }: Props) {
               size="md"
               className="w-20"
             />
-          </div>
+          </Field>
         </div>
 
         <div className="flex flex-col gap-1">
-          <label className="font-mono text-xs text-[var(--color-text-muted)]">Preview</label>
+          {/* Not a Field: this names a preview, it doesn't label a control. */}
+          <SectionLabel>Preview</SectionLabel>
           <pre className="overflow-x-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 font-mono text-xs text-[var(--color-text)]">
             {preview}
           </pre>

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -563,7 +563,7 @@ export default function MermaidEditor() {
               title="New diagram"
               aria-label="New diagram"
             >
-              <FilePlusIcon size={13} aria-hidden="true" />
+              <FilePlusIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -572,7 +572,7 @@ export default function MermaidEditor() {
               title="Open a .mmd file (⌘O)"
               aria-label="Open Mermaid file"
             >
-              <FolderOpenIcon size={13} aria-hidden="true" />
+              <FolderOpenIcon size={14} aria-hidden="true" />
             </Button>
             <Button
               variant="icon"
@@ -581,7 +581,7 @@ export default function MermaidEditor() {
               title="Save the source (⌘S)"
               aria-label="Save Mermaid source"
             >
-              <FloppyDiskIcon size={13} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
             </Button>
           </ToolbarGroup>
 
@@ -639,7 +639,7 @@ export default function MermaidEditor() {
               loading={isExporting}
               className="gap-1"
             >
-              <CopyIcon size={13} aria-hidden="true" />
+              <CopyIcon size={14} aria-hidden="true" />
               Copy {exportFormat.toUpperCase()}
             </Button>
             <Button
@@ -650,7 +650,7 @@ export default function MermaidEditor() {
               loading={isExporting}
               className="gap-1"
             >
-              <DownloadSimpleIcon size={13} aria-hidden="true" />
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
               Export
             </Button>
           </ToolbarGroup>
@@ -661,7 +661,7 @@ export default function MermaidEditor() {
             onClick={() => void handleCopySource()}
             className="gap-1"
           >
-            <CopyIcon size={13} aria-hidden="true" />
+            <CopyIcon size={14} aria-hidden="true" />
             Copy source
           </Button>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -47,6 +47,7 @@ import {
   type MermaidError,
 } from '@/tools/mermaid-editor/mermaid-helpers'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type EditorMode = 'edit' | 'split' | 'preview'
 type ExportFormat = 'svg' | 'png'
@@ -614,7 +615,7 @@ export default function MermaidEditor() {
               variant="icon"
               size="sm"
               onClick={() => void handleOpen()}
-              title="Open a .mmd file (⌘O)"
+              title={`Open a .mmd file (${formatShortcut('mod+o')})`}
               aria-label="Open Mermaid file"
             >
               <FolderOpenIcon size={14} aria-hidden="true" />
@@ -623,7 +624,7 @@ export default function MermaidEditor() {
               variant="icon"
               size="sm"
               onClick={() => void handleSave()}
-              title="Save the source (⌘S)"
+              title={`Save the source (${formatShortcut('mod+s')})`}
               aria-label="Save Mermaid source"
             >
               <FloppyDiskIcon size={14} aria-hidden="true" />

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/shared/Button'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { Select } from '@/components/shared/Select'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { ToolLayout } from '@/components/shared/ToolLayout'
@@ -526,6 +527,50 @@ export default function MermaidEditor() {
       ].join(' · ')
     : 'Empty diagram'
 
+  // Each pane renders identically whether it's alone or beside the other, so it's defined once
+  // here and placed by the layout below rather than written out under both branches.
+  const editorPane = (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <Editor
+        theme={monacoTheme}
+        language="markdown"
+        value={content}
+        onChange={handleContentChange}
+        onMount={handleEditorMount}
+        options={monacoOptions}
+      />
+    </div>
+  )
+
+  const previewPane = (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <MermaidPreview
+        svg={svgHtml}
+        isRendering={isRendering}
+        errorMessage={error?.message ?? null}
+        emptyState={
+          <EmptyState
+            icon={GraphIcon}
+            size="sm"
+            title={error ? 'Nothing has rendered yet' : 'No diagram yet'}
+            description={
+              error
+                ? 'Fix the error above and the preview will appear here.'
+                : 'Write Mermaid syntax on the left, or load a template.'
+            }
+            action={
+              !error && (
+                <Button variant="secondary" size="sm" onClick={() => handleLoadTemplate()}>
+                  Load template
+                </Button>
+              )
+            }
+          />
+        }
+      />
+    </div>
+  )
+
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
@@ -686,58 +731,23 @@ export default function MermaidEditor() {
         </Alert>
       )}
 
-      {/* Below ~900px a 50/50 split leaves two unusable columns, so the panes stack. */}
-      <div className="flex min-h-0 flex-1 overflow-hidden max-[900px]:flex-col">
-        {showEditor && (
-          <div
-            className={`min-h-0 overflow-hidden ${
-              showPreview
-                ? 'h-full w-1/2 border-r border-[var(--color-border)] max-[900px]:h-1/2 max-[900px]:w-full max-[900px]:border-r-0 max-[900px]:border-b'
-                : 'h-full w-full'
-            }`}
-          >
-            <Editor
-              theme={monacoTheme}
-              language="markdown"
-              value={content}
-              onChange={handleContentChange}
-              onMount={handleEditorMount}
-              options={monacoOptions}
-            />
-          </div>
-        )}
-
-        {showPreview && (
-          <div
-            className={`min-h-0 ${showEditor ? 'h-full w-1/2 max-[900px]:h-1/2 max-[900px]:w-full' : 'h-full w-full'}`}
-          >
-            <MermaidPreview
-              svg={svgHtml}
-              isRendering={isRendering}
-              errorMessage={error?.message ?? null}
-              emptyState={
-                <EmptyState
-                  icon={GraphIcon}
-                  size="sm"
-                  title={error ? 'Nothing has rendered yet' : 'No diagram yet'}
-                  description={
-                    error
-                      ? 'Fix the error above and the preview will appear here.'
-                      : 'Write Mermaid syntax on the left, or load a template.'
-                  }
-                  action={
-                    !error && (
-                      <Button variant="secondary" size="sm" onClick={() => handleLoadTemplate()}>
-                        Load template
-                      </Button>
-                    )
-                  }
-                />
-              }
-            />
-          </div>
-        )}
-      </div>
+      {/* Split mode goes through SplitPane; the single-pane modes are a plain full-width box.
+          Below ~900px SplitPane stacks them, because a 50/50 split there leaves two unusable
+          columns. */}
+      {showEditor && showPreview ? (
+        <SplitPane
+          storageKey="mermaid-editor"
+          stackBelow={900}
+          aria-label="Resize editor and preview"
+        >
+          {editorPane}
+          {previewPane}
+        </SplitPane>
+      ) : (
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {showEditor ? editorPane : previewPane}
+        </div>
+      )}
 
       <footer className="flex min-h-7 shrink-0 items-center gap-3 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-2xs text-[var(--color-text-muted)]">
         <span data-testid="diagram-status" role="status" aria-live="polite">

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidPreview.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidPreview.tsx
@@ -222,7 +222,7 @@ export default function MermaidPreview({
           aria-label="Zoom out"
           title="Zoom out (−)"
         >
-          <MagnifyingGlassMinusIcon size={13} aria-hidden="true" />
+          <MagnifyingGlassMinusIcon size={14} aria-hidden="true" />
         </Button>
         <span
           className="w-12 text-center font-mono text-2xs text-[var(--color-text-muted)] tabular-nums"
@@ -237,7 +237,7 @@ export default function MermaidPreview({
           aria-label="Zoom in"
           title="Zoom in (+)"
         >
-          <MagnifyingGlassPlusIcon size={13} aria-hidden="true" />
+          <MagnifyingGlassPlusIcon size={14} aria-hidden="true" />
         </Button>
         <Button
           variant="ghost"
@@ -247,7 +247,7 @@ export default function MermaidPreview({
           className="gap-1"
           title="Fit the whole diagram in the pane (F)"
         >
-          <ArrowsOutSimpleIcon size={13} aria-hidden="true" />
+          <ArrowsOutSimpleIcon size={14} aria-hidden="true" />
           Fit
         </Button>
         <Button
@@ -257,7 +257,7 @@ export default function MermaidPreview({
           className="gap-1"
           title="Back to 100% (0)"
         >
-          <ArrowCounterClockwiseIcon size={13} aria-hidden="true" />
+          <ArrowCounterClockwiseIcon size={14} aria-hidden="true" />
           Reset
         </Button>
 

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidPreview.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidPreview.tsx
@@ -8,6 +8,7 @@ import {
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
 import { Spinner } from '@/components/shared/Spinner'
+import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
 import { fitScale, svgSize, type SvgSize } from './mermaid-helpers'
 
 type Transform = { x: number; y: number; scale: number }
@@ -214,7 +215,7 @@ export default function MermaidPreview({
 
   return (
     <div className="relative flex h-full min-h-0 flex-col bg-[var(--color-surface)]">
-      <div className="flex items-center gap-1 border-b border-[var(--color-border)] px-2 py-1">
+      <Toolbar className="gap-1" wrap={false} aria-label="Diagram view controls">
         <Button
           variant="ghost"
           size="xs"
@@ -261,7 +262,8 @@ export default function MermaidPreview({
           Reset
         </Button>
 
-        <span className="ml-auto flex items-center gap-1 text-2xs text-[var(--color-text-muted)]">
+        <ToolbarSpacer />
+        <span className="flex items-center gap-1 text-2xs text-[var(--color-text-muted)]">
           {isRendering && (
             <>
               <Spinner size="xs" />
@@ -279,7 +281,7 @@ export default function MermaidPreview({
             </>
           )}
         </span>
-      </div>
+      </Toolbar>
 
       <div
         ref={attachCanvas}

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -1005,9 +1005,11 @@ export default function PromptTemplates() {
         title="Prompt Templates"
         subtitle={`${allTemplates.length} templates · ${userTemplates.length} custom`}
         sidebarActions={
+          // Secondary, not primary: the detail pane's Copy prompt is this tool's one primary
+          // action, and a sidebar heading shouldn't compete with it for the eye.
           <Button
             type="button"
-            variant="primary"
+            variant="secondary"
             size="sm"
             onClick={() => setEditorState({ mode: 'create' })}
             className="gap-1.5"

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -64,6 +64,7 @@ import type {
 } from '@/tools/prompt-templates/types'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { SearchInput } from '@/components/shared/SearchInput'
+import { MasterDetailLayout } from '@/components/shared/MasterDetailLayout'
 
 type CategoryFilter = PromptTemplateCategory | 'all'
 
@@ -999,17 +1000,11 @@ export default function PromptTemplates() {
   ])
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-[minmax(15rem,19rem)_minmax(0,1fr)] bg-[var(--color-bg)] max-[1000px]:grid-cols-[13rem_minmax(0,1fr)]">
-      <aside className="flex min-h-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)]">
-        <header className="flex min-h-14 items-center gap-3 border-b border-[var(--color-border)] px-3">
-          <div className="min-w-0 flex-1">
-            <h1 className="font-ui text-sm font-semibold text-[var(--color-text)]">
-              Prompt Templates
-            </h1>
-            <p className="text-2xs text-[var(--color-text-muted)]">
-              {allTemplates.length} templates · {userTemplates.length} custom
-            </p>
-          </div>
+    <>
+      <MasterDetailLayout
+        title="Prompt Templates"
+        subtitle={`${allTemplates.length} templates · ${userTemplates.length} custom`}
+        sidebarActions={
           <Button
             type="button"
             variant="primary"
@@ -1019,249 +1014,258 @@ export default function PromptTemplates() {
           >
             <PlusIcon size={12} aria-hidden="true" /> New
           </Button>
-        </header>
-
-        <div className="space-y-2 border-b border-[var(--color-border)] p-3">
-          <SearchInput
-            ref={searchRef}
-            value={state.search}
-            onValueChange={(search) => updateState({ search })}
-            placeholder="Search templates"
-            aria-label="Search prompt templates"
-            clearLabel="Clear template search"
-          />
-          <Select
-            value={state.category}
-            onChange={(event) => updateState({ category: event.target.value as CategoryFilter })}
-            aria-label="Filter templates by category"
-            className="w-full"
-          >
-            {FILTERS.map((filter) => (
-              <option key={filter.id} value={filter.id}>
-                {filter.label} ({categoryCount(filter.id, allTemplates)})
-              </option>
-            ))}
-          </Select>
-        </div>
-
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-1.5 text-2xs text-[var(--color-text-muted)]">
-          <span>
-            {filteredTemplates.length === allTemplates.length
-              ? 'Library'
-              : `${filteredTemplates.length} results`}
-          </span>
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="icon"
-              size="xs"
-              onClick={() => void handleImport()}
-              title="Import templates from JSON"
-              aria-label="Import templates from JSON"
-            >
-              <UploadSimpleIcon size={12} aria-hidden="true" />
-            </Button>
-            <Button
-              type="button"
-              variant="icon"
-              size="xs"
-              onClick={() => void handleExport()}
-              title="Export custom templates as JSON"
-              aria-label="Export custom templates as JSON"
-              disabled={userTemplates.length === 0}
-            >
-              <DownloadSimpleIcon size={12} aria-hidden="true" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-auto" role="listbox" aria-label="Prompt templates">
-          {filteredTemplates.map((template, index) => {
-            const selected = template.id === selectedTemplate.id
-            return (
-              <Button
-                key={template.id}
-                id={`${templateOptionsId}-option-${template.id}`}
-                type="button"
-                variant="ghost"
-                size="xs"
-                role="option"
-                aria-selected={selected}
-                tabIndex={
-                  selected ||
-                  (!filteredTemplates.some((item) => item.id === selectedTemplate.id) &&
-                    index === 0)
-                    ? 0
-                    : -1
-                }
-                onClick={() => selectTemplate(template)}
-                onKeyDown={(event) => handleListKeyDown(event, template.id)}
-                onDoubleClick={() => {
-                  selectTemplate(template)
-                  setModalOpen(true)
-                }}
-                className={`flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left ${selected ? 'bg-[var(--color-accent-dim)]' : 'hover:bg-[var(--color-surface-hover)]'}`}
-              >
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
-                      {template.name}
-                    </span>
-                    {template.author === 'user' && (
-                      <StatusBadge variant="info" className="shrink-0 uppercase">
-                        Custom
-                      </StatusBadge>
-                    )}
-                  </span>
-                  <span className="mt-1 block line-clamp-2 text-2xs leading-4 text-[var(--color-text-muted)]">
-                    {template.description}
-                  </span>
-                  <span className="mt-1.5 block text-2xs uppercase tracking-wide text-[var(--color-text-muted)]">
-                    {CATEGORY_LABELS[template.category]} · {template.optimizedFor}
-                  </span>
-                </span>
-              </Button>
-            )
-          })}
-          {filteredTemplates.length === 0 && (
-            <EmptyState
-              icon={ChatCircleTextIcon}
-              size="sm"
-              title="No matching templates"
-              description="Try a different search or category."
-              action={
-                <Button type="button" variant="secondary" size="sm" onClick={clearFilters}>
-                  Clear filters
-                </Button>
-              }
-            />
-          )}
-        </div>
-      </aside>
-
-      <main className="flex min-h-0 min-w-0 flex-col">
-        <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-          <div className="flex min-h-14 items-center gap-2 px-4 max-[1000px]:flex-wrap max-[1000px]:py-2">
-            <div className="min-w-0 flex-1 max-[1000px]:basis-full">
-              <div className="flex items-center gap-2">
-                <h2 className="truncate text-sm font-semibold text-[var(--color-text)]">
-                  {selectedTemplate.name}
-                </h2>
-                <StatusBadge variant="info" className="shrink-0 uppercase">
-                  {selectedTemplate.author === 'user' ? 'Custom' : 'Built-in'}
-                </StatusBadge>
-              </div>
-              <p className="mt-0.5 truncate text-2xs text-[var(--color-text-muted)]">
-                {selectedTemplate.description}
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="icon"
-              size="sm"
-              onClick={() => setEditorState({ mode: 'duplicate', template: selectedTemplate })}
-              title="Duplicate template"
-              aria-label="Duplicate template"
-            >
-              <CopyIcon size={14} aria-hidden="true" />
-            </Button>
-            {selectedTemplate.author === 'user' && (
-              <>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => setEditorState({ mode: 'edit', template: selectedTemplate })}
-                  title="Edit template"
-                  aria-label="Edit template"
-                >
-                  <PencilSimpleIcon size={14} aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => setConfirmDeleteId(selectedTemplate.id)}
-                  title="Delete template"
-                  aria-label="Delete template"
-                  className="hover:text-[var(--color-error)]"
-                >
-                  <TrashIcon size={14} aria-hidden="true" />
-                </Button>
-              </>
-            )}
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => setModalOpen(true)}
-              className="gap-1.5"
-            >
-              <SparkleIcon size={14} aria-hidden="true" /> Focus mode
-            </Button>
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              onClick={() => void copyRenderedPrompt()}
-              className="gap-1.5"
-            >
-              <ClipboardTextIcon size={14} aria-hidden="true" /> Copy prompt
-            </Button>
-          </div>
-          <div className="flex items-center border-t border-[var(--color-border)] pr-4">
-            <TabBar
-              noBorder
-              aria-label="Template workspace"
-              activeTab={workspaceTab}
-              onTabChange={(tab) => setWorkspaceTab(tab as 'fill' | 'preview')}
-              tabs={[
-                { id: 'fill', label: `Fill variables (${selectedTemplate.variables.length})` },
-                { id: 'preview', label: `Preview (~${tokens})` },
-              ]}
-            />
-            <span className="ml-auto text-2xs text-[var(--color-text-muted)]" aria-live="polite">
-              {savingTemplates
-                ? 'Saving template…'
-                : `Optimized for ${selectedTemplate.optimizedFor}`}
-            </span>
-          </div>
-        </header>
-
-        <div className="min-h-0 flex-1 overflow-auto">
-          {workspaceTab === 'fill' ? (
-            <div className="mx-auto max-w-3xl p-5 max-[1000px]:p-4">
-              <div className="mb-5 flex flex-wrap gap-1.5">
-                {selectedTemplate.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded-full bg-[var(--color-accent-dim)] px-2 py-1 text-2xs text-[var(--color-accent)]"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              <VariableForm
-                template={selectedTemplate}
-                values={selectedValues}
-                onChange={updateVariable}
+        }
+        sidebar={
+          <>
+            <div className="space-y-2 border-b border-[var(--color-border)] p-3">
+              <SearchInput
+                ref={searchRef}
+                value={state.search}
+                onValueChange={(search) => updateState({ search })}
+                placeholder="Search templates"
+                aria-label="Search prompt templates"
+                clearLabel="Clear template search"
               />
-              {selectedTemplate.tips && selectedTemplate.tips.length > 0 && (
-                <div className="mt-5 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs leading-5 text-[var(--color-text-muted)]">
-                  <span className="font-semibold text-[var(--color-text)]">Tip:</span>{' '}
-                  {selectedTemplate.tips[0]}
-                </div>
+              <Select
+                value={state.category}
+                onChange={(event) =>
+                  updateState({ category: event.target.value as CategoryFilter })
+                }
+                aria-label="Filter templates by category"
+                className="w-full"
+              >
+                {FILTERS.map((filter) => (
+                  <option key={filter.id} value={filter.id}>
+                    {filter.label} ({categoryCount(filter.id, allTemplates)})
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-1.5 text-2xs text-[var(--color-text-muted)]">
+              <span>
+                {filteredTemplates.length === allTemplates.length
+                  ? 'Library'
+                  : `${filteredTemplates.length} results`}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={() => void handleImport()}
+                  title="Import templates from JSON"
+                  aria-label="Import templates from JSON"
+                >
+                  <UploadSimpleIcon size={12} aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={() => void handleExport()}
+                  title="Export custom templates as JSON"
+                  aria-label="Export custom templates as JSON"
+                  disabled={userTemplates.length === 0}
+                >
+                  <DownloadSimpleIcon size={12} aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+
+            <div
+              className="min-h-0 flex-1 overflow-auto"
+              role="listbox"
+              aria-label="Prompt templates"
+            >
+              {filteredTemplates.map((template, index) => {
+                const selected = template.id === selectedTemplate.id
+                return (
+                  <Button
+                    key={template.id}
+                    id={`${templateOptionsId}-option-${template.id}`}
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    role="option"
+                    aria-selected={selected}
+                    tabIndex={
+                      selected ||
+                      (!filteredTemplates.some((item) => item.id === selectedTemplate.id) &&
+                        index === 0)
+                        ? 0
+                        : -1
+                    }
+                    onClick={() => selectTemplate(template)}
+                    onKeyDown={(event) => handleListKeyDown(event, template.id)}
+                    onDoubleClick={() => {
+                      selectTemplate(template)
+                      setModalOpen(true)
+                    }}
+                    className={`flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left ${selected ? 'bg-[var(--color-accent-dim)]' : 'hover:bg-[var(--color-surface-hover)]'}`}
+                  >
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
+                          {template.name}
+                        </span>
+                        {template.author === 'user' && (
+                          <StatusBadge variant="info" className="shrink-0 uppercase">
+                            Custom
+                          </StatusBadge>
+                        )}
+                      </span>
+                      <span className="mt-1 block line-clamp-2 text-2xs leading-4 text-[var(--color-text-muted)]">
+                        {template.description}
+                      </span>
+                      <span className="mt-1.5 block text-2xs uppercase tracking-wide text-[var(--color-text-muted)]">
+                        {CATEGORY_LABELS[template.category]} · {template.optimizedFor}
+                      </span>
+                    </span>
+                  </Button>
+                )
+              })}
+              {filteredTemplates.length === 0 && (
+                <EmptyState
+                  icon={ChatCircleTextIcon}
+                  size="sm"
+                  title="No matching templates"
+                  description="Try a different search or category."
+                  action={
+                    <Button type="button" variant="secondary" size="sm" onClick={clearFilters}>
+                      Clear filters
+                    </Button>
+                  }
+                />
               )}
             </div>
-          ) : (
-            <PreviewPane
-              renderedPrompt={renderedPrompt}
-              tokens={tokens}
-              missingVariables={missingVariables}
-            />
-          )}
-        </div>
-      </main>
+          </>
+        }
+      >
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+            <div className="flex min-h-14 items-center gap-2 px-4 max-[1000px]:flex-wrap max-[1000px]:py-2">
+              <div className="min-w-0 flex-1 max-[1000px]:basis-full">
+                <div className="flex items-center gap-2">
+                  <h2 className="truncate text-sm font-semibold text-[var(--color-text)]">
+                    {selectedTemplate.name}
+                  </h2>
+                  <StatusBadge variant="info" className="shrink-0 uppercase">
+                    {selectedTemplate.author === 'user' ? 'Custom' : 'Built-in'}
+                  </StatusBadge>
+                </div>
+                <p className="mt-0.5 truncate text-2xs text-[var(--color-text-muted)]">
+                  {selectedTemplate.description}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="icon"
+                size="sm"
+                onClick={() => setEditorState({ mode: 'duplicate', template: selectedTemplate })}
+                title="Duplicate template"
+                aria-label="Duplicate template"
+              >
+                <CopyIcon size={14} aria-hidden="true" />
+              </Button>
+              {selectedTemplate.author === 'user' && (
+                <>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => setEditorState({ mode: 'edit', template: selectedTemplate })}
+                    title="Edit template"
+                    aria-label="Edit template"
+                  >
+                    <PencilSimpleIcon size={14} aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => setConfirmDeleteId(selectedTemplate.id)}
+                    title="Delete template"
+                    aria-label="Delete template"
+                    className="hover:text-[var(--color-error)]"
+                  >
+                    <TrashIcon size={14} aria-hidden="true" />
+                  </Button>
+                </>
+              )}
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setModalOpen(true)}
+                className="gap-1.5"
+              >
+                <SparkleIcon size={14} aria-hidden="true" /> Focus mode
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => void copyRenderedPrompt()}
+                className="gap-1.5"
+              >
+                <ClipboardTextIcon size={14} aria-hidden="true" /> Copy prompt
+              </Button>
+            </div>
+            <div className="flex items-center border-t border-[var(--color-border)] pr-4">
+              <TabBar
+                noBorder
+                aria-label="Template workspace"
+                activeTab={workspaceTab}
+                onTabChange={(tab) => setWorkspaceTab(tab as 'fill' | 'preview')}
+                tabs={[
+                  { id: 'fill', label: `Fill variables (${selectedTemplate.variables.length})` },
+                  { id: 'preview', label: `Preview (~${tokens})` },
+                ]}
+              />
+              <span className="ml-auto text-2xs text-[var(--color-text-muted)]" aria-live="polite">
+                {savingTemplates
+                  ? 'Saving template…'
+                  : `Optimized for ${selectedTemplate.optimizedFor}`}
+              </span>
+            </div>
+          </header>
+
+          <div className="min-h-0 flex-1 overflow-auto">
+            {workspaceTab === 'fill' ? (
+              <div className="mx-auto max-w-3xl p-5 max-[1000px]:p-4">
+                <div className="mb-5 flex flex-wrap gap-1.5">
+                  {selectedTemplate.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full bg-[var(--color-accent-dim)] px-2 py-1 text-2xs text-[var(--color-accent)]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <VariableForm
+                  template={selectedTemplate}
+                  values={selectedValues}
+                  onChange={updateVariable}
+                />
+                {selectedTemplate.tips && selectedTemplate.tips.length > 0 && (
+                  <div className="mt-5 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs leading-5 text-[var(--color-text-muted)]">
+                    <span className="font-semibold text-[var(--color-text)]">Tip:</span>{' '}
+                    {selectedTemplate.tips[0]}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <PreviewPane
+                renderedPrompt={renderedPrompt}
+                tokens={tokens}
+                missingVariables={missingVariables}
+              />
+            )}
+          </div>
+        </main>
+      </MasterDetailLayout>
 
       <QuickFillModal
         open={modalOpen}
@@ -1303,6 +1307,6 @@ export default function PromptTemplates() {
           </p>
         </Dialog>
       )}
-    </div>
+    </>
   )
 }

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -20,6 +20,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -519,10 +520,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
         <div className="grid min-h-0 flex-1 grid-cols-[minmax(22rem,0.8fr)_minmax(26rem,1fr)] overflow-hidden max-[900px]:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1fr)]">
           <div className="min-h-0 overflow-auto border-r border-[var(--color-border)] p-4">
             <div className="space-y-3">
-              <label className="block">
-                <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                  Name
-                </span>
+              <Field label="Name">
                 <Input
                   ref={firstInputRef}
                   value={draft.name}
@@ -532,11 +530,8 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                   className="w-full"
                   aria-label="Template name"
                 />
-              </label>
-              <label className="block">
-                <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                  Description
-                </span>
+              </Field>
+              <Field label="Description">
                 <TextArea
                   value={draft.description}
                   onChange={(event) =>
@@ -546,12 +541,9 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                   aria-label="Template description"
                   className="resize-none"
                 />
-              </label>
+              </Field>
               <div className="grid grid-cols-2 gap-3">
-                <label className="block">
-                  <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                    Category
-                  </span>
+                <Field label="Category">
                   <Select
                     value={draft.category}
                     onChange={(event) =>
@@ -569,11 +561,8 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                       </option>
                     ))}
                   </Select>
-                </label>
-                <label className="block">
-                  <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                    Optimized For
-                  </span>
+                </Field>
+                <Field label="Optimized For">
                   <Select
                     value={draft.optimizedFor}
                     onChange={(event) =>
@@ -591,12 +580,9 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                       </option>
                     ))}
                   </Select>
-                </label>
+                </Field>
               </div>
-              <label className="block">
-                <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                  Tags
-                </span>
+              <Field label="Tags">
                 <Input
                   value={joinList(draft.tags)}
                   onChange={(event) =>
@@ -606,11 +592,8 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                   className="w-full"
                   aria-label="Template tags"
                 />
-              </label>
-              <label className="block">
-                <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                  Tips
-                </span>
+              </Field>
+              <Field label="Tips">
                 <Input
                   value={joinList(draft.tips)}
                   onChange={(event) =>
@@ -620,7 +603,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                   className="w-full"
                   aria-label="Template tips"
                 />
-              </label>
+              </Field>
             </div>
           </div>
 
@@ -723,10 +706,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                       Req
                     </label>
                     {variable.type === 'select' && (
-                      <label className="col-span-3 block">
-                        <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
-                          Options
-                        </span>
+                      <Field label="Options" className="col-span-3">
                         <Input
                           value={joinList(variable.options ?? [])}
                           onChange={(event) =>
@@ -743,7 +723,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                           aria-label={`${variable.name} options`}
                           className="w-full"
                         />
-                      </label>
+                      </Field>
                     )}
                   </div>
                 ))}

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -723,7 +723,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                     </label>
                     {variable.type === 'select' && (
                       <label className="col-span-3 block">
-                        <span className="mb-1 block font-mono text-[9px] uppercase tracking-widest text-[var(--color-text-muted)]">
+                        <span className="mb-1 block font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
                           Options
                         </span>
                         <Input
@@ -1130,7 +1130,7 @@ export default function PromptTemplates() {
                   <span className="mt-1 block line-clamp-2 text-2xs leading-4 text-[var(--color-text-muted)]">
                     {template.description}
                   </span>
-                  <span className="mt-1.5 block text-[9px] uppercase tracking-wide text-[var(--color-text-muted)]">
+                  <span className="mt-1.5 block text-2xs uppercase tracking-wide text-[var(--color-text-muted)]">
                     {CATEGORY_LABELS[template.category]} · {template.optimizedFor}
                   </span>
                 </span>
@@ -1211,7 +1211,7 @@ export default function PromptTemplates() {
               onClick={() => setModalOpen(true)}
               className="gap-1.5"
             >
-              <SparkleIcon size={13} aria-hidden="true" /> Focus mode
+              <SparkleIcon size={14} aria-hidden="true" /> Focus mode
             </Button>
             <Button
               type="button"
@@ -1220,7 +1220,7 @@ export default function PromptTemplates() {
               onClick={() => void copyRenderedPrompt()}
               className="gap-1.5"
             >
-              <ClipboardTextIcon size={13} aria-hidden="true" /> Copy prompt
+              <ClipboardTextIcon size={14} aria-hidden="true" /> Copy prompt
             </Button>
           </div>
           <div className="flex items-center border-t border-[var(--color-border)] pr-4">

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -20,6 +20,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Alert } from '@/components/shared/Alert'
@@ -625,9 +626,9 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
 
           <div className="flex min-h-0 flex-col overflow-hidden">
             <label className="flex min-h-0 flex-1 flex-col">
-              <span className="border-b border-[var(--color-border)] px-4 py-2 font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
+              <SectionLabel className="border-b border-[var(--color-border)] px-4 py-2">
                 Prompt Body
-              </span>
+              </SectionLabel>
               <TextArea
                 value={draft.prompt}
                 onChange={(event) => {
@@ -645,10 +646,10 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
               />
             </label>
             <div className="max-h-56 overflow-auto border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-              <div className="mb-2 flex items-center justify-between font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
+              <SectionLabel as="div" className="mb-2 justify-between">
                 <span>Variables</span>
                 <span>{draft.variables.length}</span>
-              </div>
+              </SectionLabel>
               <div className="space-y-2">
                 {draft.variables.map((variable) => (
                   <div

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -20,6 +20,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Field } from '@/components/shared/Field'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
@@ -187,10 +188,14 @@ function PreviewPane({ renderedPrompt, tokens, missingVariables }: PreviewPanePr
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex h-8 shrink-0 items-center justify-between border-b border-[var(--color-border)] px-3 font-mono text-2xs text-[var(--color-text-muted)]">
-        <span>[ 03-PREVIEW ]</span>
-        <span className={`rounded border px-2 py-0.5 ${tokenClass(tone)}`}>~{tokens} TOKENS</span>
-      </div>
+      <PaneHeader
+        title="Preview"
+        actions={
+          <span className={`font-mono rounded border px-2 py-0.5 text-2xs ${tokenClass(tone)}`}>
+            ~{tokens} tokens
+          </span>
+        }
+      />
       {missingVariables.length > 0 && (
         <div className="border-b border-[var(--color-border)] bg-[var(--color-warning)]/10 px-3 py-2 text-xs text-[var(--color-warning)]">
           Missing required: {missingVariables.join(', ')}

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -322,7 +322,7 @@ export default function RefactoringToolkit() {
             title={state.fileName ?? 'Untitled'}
             icon={
               <ArrowsClockwiseIcon
-                size={15}
+                size={16}
                 aria-hidden="true"
                 className="shrink-0 text-[var(--color-text-muted)]"
               />
@@ -354,7 +354,7 @@ export default function RefactoringToolkit() {
               {...(state.panelOpen ? { 'aria-controls': panelId } : {})}
               className="gap-1"
             >
-              <SlidersHorizontalIcon size={13} aria-hidden="true" />
+              <SlidersHorizontalIcon size={14} aria-hidden="true" />
               Transforms
               {selectedCount > 0 && (
                 <span className="ml-1 text-2xs tabular-nums opacity-70">{selectedCount}</span>
@@ -420,7 +420,7 @@ export default function RefactoringToolkit() {
               title="Restore the code from before the last apply"
               className="gap-1"
             >
-              <ArrowCounterClockwiseIcon size={13} aria-hidden="true" />
+              <ArrowCounterClockwiseIcon size={14} aria-hidden="true" />
               Undo
             </Button>
             <CopyButton text={copyText} label={showDiff ? 'Copy transformed code' : 'Copy code'} />
@@ -432,7 +432,7 @@ export default function RefactoringToolkit() {
               title="Save the code to a file (⌘S)"
               aria-label="Save code to file"
             >
-              <FloppyDiskIcon size={15} aria-hidden="true" />
+              <FloppyDiskIcon size={16} aria-hidden="true" />
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>
@@ -457,7 +457,7 @@ export default function RefactoringToolkit() {
           >
             <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2">
               <MagnifyingGlassIcon
-                size={13}
+                size={14}
                 aria-hidden="true"
                 className="shrink-0 text-[var(--color-text-muted)]"
               />

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -15,6 +15,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
 import { Button } from '@/components/shared/Button'
 import { Input, Select } from '@/components/shared/Input'
@@ -408,9 +409,7 @@ export default function RefactoringToolkit() {
               }
             >
               {hasDestructive ? 'Apply (removes code)' : 'Apply'}
-              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                ⌘↵
-              </span>
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
             <Button
               variant="ghost"

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -37,6 +37,7 @@ import {
   type TransformCategory,
 } from '@/tools/refactoring-toolkit/transforms'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type RefactoringView = 'source' | 'diff'
 
@@ -404,8 +405,8 @@ export default function RefactoringToolkit() {
               disabled={!canApply}
               title={
                 hasDestructive
-                  ? 'Apply the transforms — this removes code (⌘↵)'
-                  : 'Apply the transforms to the buffer (⌘↵)'
+                  ? `Apply the transforms — this removes code (${formatShortcut('mod+enter')})`
+                  : `Apply the transforms to the buffer (${formatShortcut('mod+enter')})`
               }
             >
               {hasDestructive ? 'Apply (removes code)' : 'Apply'}
@@ -428,7 +429,7 @@ export default function RefactoringToolkit() {
               size="sm"
               onClick={handleSave}
               disabled={!hasCode}
-              title="Save the code to a file (⌘S)"
+              title={`Save the code to a file (${formatShortcut('mod+s')})`}
               aria-label="Save code to file"
             >
               <FloppyDiskIcon size={16} aria-hidden="true" />

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -3,6 +3,7 @@ import { diffChars } from 'diff'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Button } from '@/components/shared/Button'
@@ -303,8 +304,8 @@ export default function RegexTester() {
           </Toolbar>
 
           {/* Main panels */}
-          <div className="flex flex-1 overflow-hidden">
-            <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+          <SplitPane storageKey="regex-tester" aria-label="Resize test string and matches">
+            <div className="flex min-h-0 flex-1 flex-col">
               <PaneHeader title="Test String" />
               <TextArea
                 value={state.testString}
@@ -315,7 +316,7 @@ export default function RegexTester() {
                 className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
               />
             </div>
-            <div className="flex w-1/2 flex-col">
+            <div className="flex min-h-0 flex-1 flex-col">
               <PaneHeader
                 title={mode === 'replace' ? 'Replace Preview' : 'Highlighted Matches'}
                 status={
@@ -385,7 +386,7 @@ export default function RegexTester() {
                 />
               )}
             </div>
-          </div>
+          </SplitPane>
 
           {/* Match details */}
           {matchCount > 0 && (

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { diffChars } from 'diff'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Button } from '@/components/shared/Button'
@@ -304,9 +305,7 @@ export default function RegexTester() {
           {/* Main panels */}
           <div className="flex flex-1 overflow-hidden">
             <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
-              <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
-                Test String
-              </div>
+              <PaneHeader title="Test String" />
               <TextArea
                 value={state.testString}
                 onChange={(e) => updateState({ testString: e.target.value })}
@@ -317,20 +316,20 @@ export default function RegexTester() {
               />
             </div>
             <div className="flex w-1/2 flex-col">
-              <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-                <span className="text-xs text-[var(--color-text-muted)]">
-                  {mode === 'replace' ? 'Replace Preview' : 'Highlighted Matches'}
-                </span>
-                {mode === 'replace' && state.pattern && state.testString && !replaceError && (
-                  <div className="flex items-center gap-2">
-                    {diffStats && (
-                      <span className="font-mono text-2xs text-[var(--color-text-muted)]">
-                        <span className="text-[var(--color-success)]">+{diffStats.added}</span>
-                        {' / '}
-                        <span className="text-[var(--color-error)]">-{diffStats.removed}</span>
-                        {' chars'}
-                      </span>
-                    )}
+              <PaneHeader
+                title={mode === 'replace' ? 'Replace Preview' : 'Highlighted Matches'}
+                status={
+                  diffStats && mode === 'replace' && state.pattern && !replaceError ? (
+                    <>
+                      <span className="text-[var(--color-success)]">+{diffStats.added}</span>
+                      {' / '}
+                      <span className="text-[var(--color-error)]">-{diffStats.removed}</span>
+                      {' chars'}
+                    </>
+                  ) : undefined
+                }
+                actions={
+                  mode === 'replace' && state.pattern && state.testString && !replaceError ? (
                     <Button
                       variant={showDiff ? 'secondary' : 'ghost'}
                       size="xs"
@@ -339,9 +338,9 @@ export default function RegexTester() {
                     >
                       Diff
                     </Button>
-                  </div>
-                )}
-              </div>
+                  ) : undefined
+                }
+              />
               {mode === 'replace' ? (
                 <div className="flex-1 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm">
                   {replaceError ? (

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { diffChars } from 'diff'
 import { useToolState } from '@/hooks/useToolState'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Button } from '@/components/shared/Button'
 import { ToolLayout } from '@/components/shared/ToolLayout'
@@ -439,9 +440,9 @@ export default function RegexTester() {
             </div>
             {REFERENCE_CATEGORIES.map((cat) => (
               <div key={cat.label} className="mb-3">
-                <div className="mb-1 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]">
+                <SectionLabel as="div" className="mb-1">
                   {cat.label}
-                </div>
+                </SectionLabel>
                 {cat.items.map((r) => (
                   <Button
                     key={r.pattern}

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -40,6 +40,7 @@ import { useUiStore } from '@/stores/ui.store'
 import type { Snippet } from '@/types/models'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { SearchInput } from '@/components/shared/SearchInput'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 const FAVORITE_TAG = '⭐'
 
@@ -607,9 +608,13 @@ export default function SnippetsManager() {
         title="Snippets"
         subtitle={`${snippets.length} saved locally`}
         sidebarActions={
+          // Secondary for the same reason as prompt-templates: the sidebar heading never carries
+          // the accent. Snippets saves as you type, so when one is selected the tool has no
+          // primary at all — correct for a live-editing tool. The empty state's CTA covers the
+          // one moment there's nothing to edit.
           <Button
             type="button"
-            variant="primary"
+            variant="secondary"
             size="sm"
             onClick={() => void handleNew()}
             className="gap-1.5"
@@ -889,7 +894,7 @@ export default function SnippetsManager() {
                     variant="icon"
                     size="sm"
                     onClick={() => void handleDuplicate()}
-                    title="Duplicate snippet (⌘⇧D)"
+                    title={`Duplicate snippet (${formatShortcut('mod+shift+d')})`}
                     aria-label="Duplicate snippet"
                   >
                     <CopyIcon size={14} aria-hidden="true" />

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -31,6 +31,7 @@ import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { InlineInput } from '@/components/shared/InlineInput'
+import { MasterDetailLayout } from '@/components/shared/MasterDetailLayout'
 import { useMonaco } from '@/hooks/useMonaco'
 import { useIsInstanceActive } from '@/app/tool-instance'
 import { buildExportFilename, exportFile, openFileDialog } from '@/lib/file-io'
@@ -601,15 +602,11 @@ export default function SnippetsManager() {
   }, [handleDuplicate, handleExportAll, handleImport, handleNew, isInstanceActive, selected])
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-[minmax(15rem,19rem)_minmax(0,1fr)] bg-[var(--color-bg)] max-[1000px]:grid-cols-[13rem_minmax(0,1fr)]">
-      <aside className="flex min-h-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)]">
-        <header className="flex min-h-14 items-center gap-3 border-b border-[var(--color-border)] px-3">
-          <div className="min-w-0 flex-1">
-            <h1 className="font-ui text-sm font-semibold text-[var(--color-text)]">Snippets</h1>
-            <p className="text-2xs text-[var(--color-text-muted)]">
-              {snippets.length} saved locally
-            </p>
-          </div>
+    <>
+      <MasterDetailLayout
+        title="Snippets"
+        subtitle={`${snippets.length} saved locally`}
+        sidebarActions={
           <Button
             type="button"
             variant="primary"
@@ -620,508 +617,517 @@ export default function SnippetsManager() {
             <PlusIcon size={12} aria-hidden="true" />
             New
           </Button>
-        </header>
-
-        <div className="space-y-2 border-b border-[var(--color-border)] p-3">
-          <SearchInput
-            ref={searchInputRef}
-            value={search}
-            onValueChange={setSearch}
-            placeholder="Search snippets"
-            aria-label="Search snippets"
-          />
-
-          <div className="grid grid-cols-2 gap-2">
-            <Select
-              value={activeFolder}
-              onChange={(event) => setActiveFolder(event.target.value)}
-              aria-label="Filter by folder"
-              title="Filter by folder"
-            >
-              <option value="">All folders</option>
-              {allFolders.map((folder) => (
-                <option key={folder} value={folder}>
-                  {folder}
-                </option>
-              ))}
-            </Select>
-            <Select
-              value={sortMode}
-              onChange={(event) => setSortMode(event.target.value as SortMode)}
-              aria-label="Sort snippets"
-              title="Sort snippets"
-            >
-              <option value="updated">Recently edited</option>
-              <option value="created">Recently created</option>
-              <option value="title">Title A–Z</option>
-              <option value="language">Language</option>
-            </Select>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-pressed={favoritesOnly}
-              onClick={() => setFavoritesOnly((current) => !current)}
-              className={`gap-1.5 ${favoritesOnly ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''}`}
-            >
-              <StarIcon size={12} weight={favoritesOnly ? 'fill' : 'regular'} aria-hidden="true" />
-              Favorites
-            </Button>
-            {allTags.length > 0 && (
-              <Select
-                value={filterTag}
-                onChange={(event) => setFilterTag(event.target.value)}
-                aria-label="Filter by tag"
-                title="Filter by tag"
-                className="min-w-0 flex-1"
-              >
-                <option value="">All tags</option>
-                {allTags.map((tag) => (
-                  <option key={tag} value={tag}>
-                    #{tag}
-                  </option>
-                ))}
-              </Select>
-            )}
-            {hasFilters && (
-              <Button type="button" variant="ghost" size="sm" onClick={clearFilters}>
-                Clear
-              </Button>
-            )}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-1.5 text-2xs text-[var(--color-text-muted)]">
-          <span>
-            {filtered.length === snippets.length ? 'Library' : `${filtered.length} results`}
-          </span>
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="icon"
-              size="xs"
-              onClick={() => void handleImport()}
-              title="Import snippets from JSON"
-              aria-label="Import snippets from JSON"
-            >
-              <UploadSimpleIcon size={12} aria-hidden="true" />
-            </Button>
-            <Button
-              type="button"
-              variant="icon"
-              size="xs"
-              onClick={() => void handleExportAll()}
-              title="Export snippets as JSON"
-              aria-label="Export snippets as JSON"
-              disabled={snippets.length === 0}
-            >
-              <DownloadSimpleIcon size={12} aria-hidden="true" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-y-auto" role="listbox" aria-label="Snippets">
-          {filtered.map((snippet) => {
-            const isSelected = snippet.id === selectedId
-            const matches = isSelected ? undefined : matchMap.get(snippet.id)
-            const tone = LANG_TONES[snippet.language] ?? 'accent'
-            return (
-              <Button
-                key={snippet.id}
-                id={`${snippetOptionsId}-option-${snippet.id}`}
-                type="button"
-                variant="ghost"
-                size="xs"
-                role="option"
-                aria-selected={isSelected}
-                tabIndex={isSelected || (!selectedId && filtered[0]?.id === snippet.id) ? 0 : -1}
-                onClick={() => setSelectedId(snippet.id)}
-                onKeyDown={(event) => handleListKeyDown(event, snippet.id)}
-                className={`group flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
-                  isSelected
-                    ? 'bg-[var(--color-accent-dim)]'
-                    : 'hover:bg-[var(--color-surface-hover)]'
-                }`}
-              >
-                <div className="flex items-start gap-2">
-                  <span
-                    className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-2xs font-bold uppercase ${LANG_TONE_CLASSES[tone]}`}
-                  >
-                    {LANG_EXTENSIONS[snippet.language] ?? snippet.language}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="flex items-center gap-1.5">
-                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
-                        {highlightMatches(snippet.title || 'Untitled', matches, 'title')}
-                      </span>
-                      {isFavorite(snippet.tags) && (
-                        <StarIcon
-                          size={12}
-                          weight="fill"
-                          aria-label="Favorite"
-                          className="shrink-0 text-[var(--color-warning)]"
-                        />
-                      )}
-                      <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
-                        {relativeTime(snippet.updatedAt)}
-                      </span>
-                    </span>
-                    <span className="mt-1 block truncate text-2xs text-[var(--color-text-muted)]">
-                      {contentPreview(snippet.content) || 'Empty snippet'}
-                    </span>
-                    {(snippet.folder || visibleTags(snippet.tags).length > 0) && (
-                      <span className="mt-1.5 flex items-center gap-2 overflow-hidden text-2xs text-[var(--color-text-muted)]">
-                        {snippet.folder && (
-                          <span className="flex min-w-0 items-center gap-1 truncate">
-                            <FolderOpenIcon size={9} aria-hidden="true" />
-                            {snippet.folder}
-                          </span>
-                        )}
-                        {visibleTags(snippet.tags)
-                          .slice(0, 2)
-                          .map((tag) => (
-                            <span key={tag} className="truncate">
-                              #{tag}
-                            </span>
-                          ))}
-                      </span>
-                    )}
-                  </span>
-                </div>
-              </Button>
-            )
-          })}
-
-          {filtered.length === 0 && (
-            <EmptyState
-              icon={ScissorsIcon}
-              size="sm"
-              title={snippets.length === 0 ? 'No snippets yet' : 'No matches'}
-              description={
-                snippets.length === 0
-                  ? 'Save reusable code and commands here.'
-                  : 'Try a different search or clear the filters.'
-              }
-              action={
-                snippets.length === 0 ? null : (
-                  <Button type="button" variant="secondary" size="sm" onClick={clearFilters}>
-                    Clear filters
-                  </Button>
-                )
-              }
-            />
-          )}
-        </div>
-      </aside>
-
-      <main className="flex min-h-0 min-w-0 flex-col">
-        {selected ? (
+        }
+        sidebar={
           <>
-            <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-              <div className="flex min-h-14 items-center gap-2 px-4 max-[1000px]:flex-wrap max-[1000px]:py-2">
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => void handleToggleFavorite()}
-                  title={isFavorite(selected.tags) ? 'Remove from favorites' : 'Add to favorites'}
-                  aria-label={
-                    isFavorite(selected.tags) ? 'Remove from favorites' : 'Add to favorites'
-                  }
-                  className={isFavorite(selected.tags) ? 'text-[var(--color-warning)]' : ''}
-                >
-                  <StarIcon
-                    size={16}
-                    weight={isFavorite(selected.tags) ? 'fill' : 'regular'}
-                    aria-hidden="true"
-                  />
-                </Button>
-                <div className="min-w-0 flex-1 max-[1000px]:basis-[calc(100%-2.5rem)]">
-                  <InlineInput
-                    ref={setTitleInputRef}
-                    value={selected.title}
-                    onChange={(event) =>
-                      void updateSnippet(selected.id, { title: event.target.value })
-                    }
-                    placeholder="Snippet title"
-                    aria-label="Snippet title"
-                    className="w-full"
-                  />
-                  <p className="text-2xs text-[var(--color-text-muted)]" aria-live="polite">
-                    {saving ? 'Saving changes…' : `Edited ${relativeTime(selected.updatedAt)}`}
-                  </p>
-                </div>
+            <div className="space-y-2 border-b border-[var(--color-border)] p-3">
+              <SearchInput
+                ref={searchInputRef}
+                value={search}
+                onValueChange={setSearch}
+                placeholder="Search snippets"
+                aria-label="Search snippets"
+              />
+
+              <div className="grid grid-cols-2 gap-2">
                 <Select
-                  value={selected.language}
-                  onChange={(event) =>
-                    void updateSnippet(selected.id, { language: event.target.value })
-                  }
-                  aria-label="Snippet language"
-                  title="Snippet language"
-                  className="w-32"
+                  value={activeFolder}
+                  onChange={(event) => setActiveFolder(event.target.value)}
+                  aria-label="Filter by folder"
+                  title="Filter by folder"
                 >
-                  {LANGUAGES.map((language) => (
-                    <option key={language} value={language}>
-                      {language}
+                  <option value="">All folders</option>
+                  {allFolders.map((folder) => (
+                    <option key={folder} value={folder}>
+                      {folder}
                     </option>
                   ))}
                 </Select>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => void handleCopy()}
-                  title="Copy snippet"
-                  aria-label="Copy snippet"
+                <Select
+                  value={sortMode}
+                  onChange={(event) => setSortMode(event.target.value as SortMode)}
+                  aria-label="Sort snippets"
+                  title="Sort snippets"
                 >
-                  <ClipboardTextIcon size={14} aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => void handleDuplicate()}
-                  title="Duplicate snippet (⌘⇧D)"
-                  aria-label="Duplicate snippet"
-                >
-                  <CopyIcon size={14} aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => void handleDownload()}
-                  title="Save snippet as file"
-                  aria-label="Save snippet as file"
-                >
-                  <DownloadSimpleIcon size={14} aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => setDetailsOpen((current) => !current)}
-                  title={detailsOpen ? 'Hide details' : 'Show details'}
-                  aria-label={detailsOpen ? 'Hide snippet details' : 'Show snippet details'}
-                  aria-expanded={detailsOpen}
-                  className={
-                    detailsOpen ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''
-                  }
-                >
-                  <SidebarIcon size={14} aria-hidden="true" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="icon"
-                  size="sm"
-                  onClick={() => setDeleteDialogOpen(true)}
-                  title="Delete snippet"
-                  aria-label="Delete snippet"
-                  className="hover:text-[var(--color-error)]"
-                >
-                  <TrashIcon size={14} aria-hidden="true" />
-                </Button>
-              </div>
-            </header>
-
-            <div className="relative min-h-0 flex-1 overflow-hidden">
-              <div className="absolute inset-0 min-h-0 min-w-0 overflow-hidden">
-                <Editor
-                  theme={monacoTheme}
-                  language={selected.language}
-                  value={selected.content}
-                  onChange={(value) => void updateSnippet(selected.id, { content: value ?? '' })}
-                  options={{
-                    ...monacoOptions,
-                    minimap: { enabled: false },
-                    lineNumbers: 'on',
-                    padding: { top: 12, bottom: 12 },
-                    scrollBeyondLastLine: false,
-                  }}
-                />
+                  <option value="updated">Recently edited</option>
+                  <option value="created">Recently created</option>
+                  <option value="title">Title A–Z</option>
+                  <option value="language">Language</option>
+                </Select>
               </div>
 
-              {detailsOpen && (
-                <aside
-                  aria-label="Snippet details"
-                  className="absolute inset-y-0 right-0 z-10 w-60 overflow-y-auto border-l border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-lg max-[1000px]:w-52"
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  aria-pressed={favoritesOnly}
+                  onClick={() => setFavoritesOnly((current) => !current)}
+                  className={`gap-1.5 ${favoritesOnly ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''}`}
                 >
-                  <h2 className="mb-4 text-xs font-semibold text-[var(--color-text)]">Details</h2>
-
-                  <Field label="Folder">
-                    <Input
-                      value={selected.folder}
-                      onChange={(event) =>
-                        void updateSnippet(selected.id, { folder: event.target.value })
-                      }
-                      placeholder="No folder"
-                      list={folderListId}
-                      className="w-full"
-                    />
-                  </Field>
-                  <datalist id={folderListId}>
-                    {allFolders.map((folder) => (
-                      <option key={folder} value={folder} />
+                  <StarIcon
+                    size={12}
+                    weight={favoritesOnly ? 'fill' : 'regular'}
+                    aria-hidden="true"
+                  />
+                  Favorites
+                </Button>
+                {allTags.length > 0 && (
+                  <Select
+                    value={filterTag}
+                    onChange={(event) => setFilterTag(event.target.value)}
+                    aria-label="Filter by tag"
+                    title="Filter by tag"
+                    className="min-w-0 flex-1"
+                  >
+                    <option value="">All tags</option>
+                    {allTags.map((tag) => (
+                      <option key={tag} value={tag}>
+                        #{tag}
+                      </option>
                     ))}
-                  </datalist>
+                  </Select>
+                )}
+                {hasFilters && (
+                  <Button type="button" variant="ghost" size="sm" onClick={clearFilters}>
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
 
-                  <div className="mt-5">
-                    <SectionLabel as="div" className="mb-2">
-                      <TagIcon size={12} aria-hidden="true" />
-                      Tags
-                    </SectionLabel>
-                    <div className="flex flex-wrap gap-1.5">
-                      {visibleTags(selected.tags).map((tag) => (
-                        <span
-                          key={tag}
-                          className="inline-flex items-center gap-1 rounded-full bg-[var(--color-accent-dim)] px-2 py-1 text-2xs text-[var(--color-accent)]"
-                        >
-                          {tag}
-                          <Button
-                            type="button"
-                            variant="icon"
-                            size="xs"
-                            onClick={() => void handleRemoveTag(tag)}
-                            aria-label={`Remove ${tag} tag`}
-                            className="rounded-full p-0 hover:bg-transparent hover:text-[var(--color-error)]"
-                          >
-                            <XIcon size={9} aria-hidden="true" />
-                          </Button>
+            <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-1.5 text-2xs text-[var(--color-text-muted)]">
+              <span>
+                {filtered.length === snippets.length ? 'Library' : `${filtered.length} results`}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={() => void handleImport()}
+                  title="Import snippets from JSON"
+                  aria-label="Import snippets from JSON"
+                >
+                  <UploadSimpleIcon size={12} aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="xs"
+                  onClick={() => void handleExportAll()}
+                  title="Export snippets as JSON"
+                  aria-label="Export snippets as JSON"
+                  disabled={snippets.length === 0}
+                >
+                  <DownloadSimpleIcon size={12} aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto" role="listbox" aria-label="Snippets">
+              {filtered.map((snippet) => {
+                const isSelected = snippet.id === selectedId
+                const matches = isSelected ? undefined : matchMap.get(snippet.id)
+                const tone = LANG_TONES[snippet.language] ?? 'accent'
+                return (
+                  <Button
+                    key={snippet.id}
+                    id={`${snippetOptionsId}-option-${snippet.id}`}
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    role="option"
+                    aria-selected={isSelected}
+                    tabIndex={
+                      isSelected || (!selectedId && filtered[0]?.id === snippet.id) ? 0 : -1
+                    }
+                    onClick={() => setSelectedId(snippet.id)}
+                    onKeyDown={(event) => handleListKeyDown(event, snippet.id)}
+                    className={`group flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
+                      isSelected
+                        ? 'bg-[var(--color-accent-dim)]'
+                        : 'hover:bg-[var(--color-surface-hover)]'
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <span
+                        className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-2xs font-bold uppercase ${LANG_TONE_CLASSES[tone]}`}
+                      >
+                        {LANG_EXTENSIONS[snippet.language] ?? snippet.language}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-1.5">
+                          <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--color-text)]">
+                            {highlightMatches(snippet.title || 'Untitled', matches, 'title')}
+                          </span>
+                          {isFavorite(snippet.tags) && (
+                            <StarIcon
+                              size={12}
+                              weight="fill"
+                              aria-label="Favorite"
+                              className="shrink-0 text-[var(--color-warning)]"
+                            />
+                          )}
+                          <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
+                            {relativeTime(snippet.updatedAt)}
+                          </span>
                         </span>
-                      ))}
+                        <span className="mt-1 block truncate text-2xs text-[var(--color-text-muted)]">
+                          {contentPreview(snippet.content) || 'Empty snippet'}
+                        </span>
+                        {(snippet.folder || visibleTags(snippet.tags).length > 0) && (
+                          <span className="mt-1.5 flex items-center gap-2 overflow-hidden text-2xs text-[var(--color-text-muted)]">
+                            {snippet.folder && (
+                              <span className="flex min-w-0 items-center gap-1 truncate">
+                                <FolderOpenIcon size={9} aria-hidden="true" />
+                                {snippet.folder}
+                              </span>
+                            )}
+                            {visibleTags(snippet.tags)
+                              .slice(0, 2)
+                              .map((tag) => (
+                                <span key={tag} className="truncate">
+                                  #{tag}
+                                </span>
+                              ))}
+                          </span>
+                        )}
+                      </span>
                     </div>
+                  </Button>
+                )
+              })}
 
-                    <div className="relative mt-2">
-                      <Input
-                        ref={tagInputRef}
-                        role="combobox"
-                        aria-label="Add tag"
-                        aria-autocomplete="list"
-                        aria-expanded={tagSuggestions.length > 0}
-                        aria-controls={tagSuggestions.length > 0 ? tagSuggestionsId : undefined}
-                        aria-activedescendant={
-                          suggestionIndex >= 0
-                            ? `${tagSuggestionsId}-option-${suggestionIndex}`
-                            : undefined
-                        }
-                        value={tagInput}
-                        onChange={(event) => {
-                          setTagInput(event.target.value)
-                          setSuggestionIndex(-1)
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === 'ArrowDown') {
-                            event.preventDefault()
-                            setSuggestionIndex((current) =>
-                              Math.min(current + 1, tagSuggestions.length - 1)
-                            )
-                          } else if (event.key === 'ArrowUp') {
-                            event.preventDefault()
-                            setSuggestionIndex((current) => Math.max(current - 1, -1))
-                          } else if (event.key === 'Enter') {
-                            event.preventDefault()
-                            const suggestion = tagSuggestions[suggestionIndex]
-                            void handleAddTag(suggestion)
-                          } else if (event.key === 'Escape') {
-                            setTagInput('')
-                            setSuggestionIndex(-1)
-                          }
-                        }}
-                        placeholder="Add a tag"
-                        className="w-full"
-                      />
-                      {tagSuggestions.length > 0 && (
-                        <div
-                          id={tagSuggestionsId}
-                          role="listbox"
-                          aria-label="Tag suggestions"
-                          data-testid="tag-suggestions"
-                          className="absolute left-0 right-0 top-full z-10 mt-1 overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg"
-                        >
-                          {tagSuggestions.map((suggestion, index) => (
-                            <Button
-                              key={suggestion}
-                              id={`${tagSuggestionsId}-option-${index}`}
-                              type="button"
-                              variant="ghost"
-                              size="xs"
-                              role="option"
-                              aria-selected={index === suggestionIndex}
-                              onMouseDown={(event) => {
-                                event.preventDefault()
-                                void handleAddTag(suggestion)
-                              }}
-                              className={`block w-full rounded-none px-2 py-1.5 text-left text-xs text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] ${
-                                index === suggestionIndex ? 'bg-[var(--color-surface-hover)]' : ''
-                              }`}
-                            >
-                              {suggestion}
-                            </Button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  {editorStats && (
-                    <dl className="mt-6 space-y-2 border-t border-[var(--color-border)] pt-4 text-2xs">
-                      <div className="flex justify-between gap-2">
-                        <dt className="text-[var(--color-text-muted)]">Lines</dt>
-                        <dd className="text-[var(--color-text)]">{editorStats.lines}</dd>
-                      </div>
-                      <div className="flex justify-between gap-2">
-                        <dt className="text-[var(--color-text-muted)]">Characters</dt>
-                        <dd className="text-[var(--color-text)]">{editorStats.characters}</dd>
-                      </div>
-                      <div className="flex justify-between gap-2">
-                        <dt className="text-[var(--color-text-muted)]">Bytes</dt>
-                        <dd className="text-[var(--color-text)]">{editorStats.bytes}</dd>
-                      </div>
-                    </dl>
-                  )}
-
-                  <dl className="mt-5 space-y-2 border-t border-[var(--color-border)] pt-4 text-2xs">
-                    <div>
-                      <dt className="text-[var(--color-text-muted)]">Created</dt>
-                      <dd className="mt-0.5 text-[var(--color-text)]">
-                        {formatTimestamp(selected.createdAt)}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-[var(--color-text-muted)]">Last edited</dt>
-                      <dd className="mt-0.5 text-[var(--color-text)]">
-                        {formatTimestamp(selected.updatedAt)}
-                      </dd>
-                    </div>
-                  </dl>
-                </aside>
+              {filtered.length === 0 && (
+                <EmptyState
+                  icon={ScissorsIcon}
+                  size="sm"
+                  title={snippets.length === 0 ? 'No snippets yet' : 'No matches'}
+                  description={
+                    snippets.length === 0
+                      ? 'Save reusable code and commands here.'
+                      : 'Try a different search or clear the filters.'
+                  }
+                  action={
+                    snippets.length === 0 ? null : (
+                      <Button type="button" variant="secondary" size="sm" onClick={clearFilters}>
+                        Clear filters
+                      </Button>
+                    )
+                  }
+                />
               )}
             </div>
           </>
-        ) : (
-          <EmptyState
-            icon={ScissorsIcon}
-            title="Build your snippet library"
-            description="Create a snippet or import an existing JSON backup to get started."
-            className="h-full"
-            action={
-              <div className="flex items-center gap-2">
-                <Button type="button" variant="primary" onClick={() => void handleNew()}>
-                  <PlusIcon size={12} aria-hidden="true" className="mr-1.5" />
-                  New snippet
-                </Button>
-                <Button type="button" variant="secondary" onClick={() => void handleImport()}>
-                  <UploadSimpleIcon size={12} aria-hidden="true" className="mr-1.5" />
-                  Import JSON
-                </Button>
+        }
+      >
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+          {selected ? (
+            <>
+              <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+                <div className="flex min-h-14 items-center gap-2 px-4 max-[1000px]:flex-wrap max-[1000px]:py-2">
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => void handleToggleFavorite()}
+                    title={isFavorite(selected.tags) ? 'Remove from favorites' : 'Add to favorites'}
+                    aria-label={
+                      isFavorite(selected.tags) ? 'Remove from favorites' : 'Add to favorites'
+                    }
+                    className={isFavorite(selected.tags) ? 'text-[var(--color-warning)]' : ''}
+                  >
+                    <StarIcon
+                      size={16}
+                      weight={isFavorite(selected.tags) ? 'fill' : 'regular'}
+                      aria-hidden="true"
+                    />
+                  </Button>
+                  <div className="min-w-0 flex-1 max-[1000px]:basis-[calc(100%-2.5rem)]">
+                    <InlineInput
+                      ref={setTitleInputRef}
+                      value={selected.title}
+                      onChange={(event) =>
+                        void updateSnippet(selected.id, { title: event.target.value })
+                      }
+                      placeholder="Snippet title"
+                      aria-label="Snippet title"
+                      className="w-full"
+                    />
+                    <p className="text-2xs text-[var(--color-text-muted)]" aria-live="polite">
+                      {saving ? 'Saving changes…' : `Edited ${relativeTime(selected.updatedAt)}`}
+                    </p>
+                  </div>
+                  <Select
+                    value={selected.language}
+                    onChange={(event) =>
+                      void updateSnippet(selected.id, { language: event.target.value })
+                    }
+                    aria-label="Snippet language"
+                    title="Snippet language"
+                    className="w-32"
+                  >
+                    {LANGUAGES.map((language) => (
+                      <option key={language} value={language}>
+                        {language}
+                      </option>
+                    ))}
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => void handleCopy()}
+                    title="Copy snippet"
+                    aria-label="Copy snippet"
+                  >
+                    <ClipboardTextIcon size={14} aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => void handleDuplicate()}
+                    title="Duplicate snippet (⌘⇧D)"
+                    aria-label="Duplicate snippet"
+                  >
+                    <CopyIcon size={14} aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => void handleDownload()}
+                    title="Save snippet as file"
+                    aria-label="Save snippet as file"
+                  >
+                    <DownloadSimpleIcon size={14} aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => setDetailsOpen((current) => !current)}
+                    title={detailsOpen ? 'Hide details' : 'Show details'}
+                    aria-label={detailsOpen ? 'Hide snippet details' : 'Show snippet details'}
+                    aria-expanded={detailsOpen}
+                    className={
+                      detailsOpen ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''
+                    }
+                  >
+                    <SidebarIcon size={14} aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    size="sm"
+                    onClick={() => setDeleteDialogOpen(true)}
+                    title="Delete snippet"
+                    aria-label="Delete snippet"
+                    className="hover:text-[var(--color-error)]"
+                  >
+                    <TrashIcon size={14} aria-hidden="true" />
+                  </Button>
+                </div>
+              </header>
+
+              <div className="relative min-h-0 flex-1 overflow-hidden">
+                <div className="absolute inset-0 min-h-0 min-w-0 overflow-hidden">
+                  <Editor
+                    theme={monacoTheme}
+                    language={selected.language}
+                    value={selected.content}
+                    onChange={(value) => void updateSnippet(selected.id, { content: value ?? '' })}
+                    options={{
+                      ...monacoOptions,
+                      minimap: { enabled: false },
+                      lineNumbers: 'on',
+                      padding: { top: 12, bottom: 12 },
+                      scrollBeyondLastLine: false,
+                    }}
+                  />
+                </div>
+
+                {detailsOpen && (
+                  <aside
+                    aria-label="Snippet details"
+                    className="absolute inset-y-0 right-0 z-10 w-60 overflow-y-auto border-l border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-lg max-[1000px]:w-52"
+                  >
+                    <h2 className="mb-4 text-xs font-semibold text-[var(--color-text)]">Details</h2>
+
+                    <Field label="Folder">
+                      <Input
+                        value={selected.folder}
+                        onChange={(event) =>
+                          void updateSnippet(selected.id, { folder: event.target.value })
+                        }
+                        placeholder="No folder"
+                        list={folderListId}
+                        className="w-full"
+                      />
+                    </Field>
+                    <datalist id={folderListId}>
+                      {allFolders.map((folder) => (
+                        <option key={folder} value={folder} />
+                      ))}
+                    </datalist>
+
+                    <div className="mt-5">
+                      <SectionLabel as="div" className="mb-2">
+                        <TagIcon size={12} aria-hidden="true" />
+                        Tags
+                      </SectionLabel>
+                      <div className="flex flex-wrap gap-1.5">
+                        {visibleTags(selected.tags).map((tag) => (
+                          <span
+                            key={tag}
+                            className="inline-flex items-center gap-1 rounded-full bg-[var(--color-accent-dim)] px-2 py-1 text-2xs text-[var(--color-accent)]"
+                          >
+                            {tag}
+                            <Button
+                              type="button"
+                              variant="icon"
+                              size="xs"
+                              onClick={() => void handleRemoveTag(tag)}
+                              aria-label={`Remove ${tag} tag`}
+                              className="rounded-full p-0 hover:bg-transparent hover:text-[var(--color-error)]"
+                            >
+                              <XIcon size={9} aria-hidden="true" />
+                            </Button>
+                          </span>
+                        ))}
+                      </div>
+
+                      <div className="relative mt-2">
+                        <Input
+                          ref={tagInputRef}
+                          role="combobox"
+                          aria-label="Add tag"
+                          aria-autocomplete="list"
+                          aria-expanded={tagSuggestions.length > 0}
+                          aria-controls={tagSuggestions.length > 0 ? tagSuggestionsId : undefined}
+                          aria-activedescendant={
+                            suggestionIndex >= 0
+                              ? `${tagSuggestionsId}-option-${suggestionIndex}`
+                              : undefined
+                          }
+                          value={tagInput}
+                          onChange={(event) => {
+                            setTagInput(event.target.value)
+                            setSuggestionIndex(-1)
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === 'ArrowDown') {
+                              event.preventDefault()
+                              setSuggestionIndex((current) =>
+                                Math.min(current + 1, tagSuggestions.length - 1)
+                              )
+                            } else if (event.key === 'ArrowUp') {
+                              event.preventDefault()
+                              setSuggestionIndex((current) => Math.max(current - 1, -1))
+                            } else if (event.key === 'Enter') {
+                              event.preventDefault()
+                              const suggestion = tagSuggestions[suggestionIndex]
+                              void handleAddTag(suggestion)
+                            } else if (event.key === 'Escape') {
+                              setTagInput('')
+                              setSuggestionIndex(-1)
+                            }
+                          }}
+                          placeholder="Add a tag"
+                          className="w-full"
+                        />
+                        {tagSuggestions.length > 0 && (
+                          <div
+                            id={tagSuggestionsId}
+                            role="listbox"
+                            aria-label="Tag suggestions"
+                            data-testid="tag-suggestions"
+                            className="absolute left-0 right-0 top-full z-10 mt-1 overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg"
+                          >
+                            {tagSuggestions.map((suggestion, index) => (
+                              <Button
+                                key={suggestion}
+                                id={`${tagSuggestionsId}-option-${index}`}
+                                type="button"
+                                variant="ghost"
+                                size="xs"
+                                role="option"
+                                aria-selected={index === suggestionIndex}
+                                onMouseDown={(event) => {
+                                  event.preventDefault()
+                                  void handleAddTag(suggestion)
+                                }}
+                                className={`block w-full rounded-none px-2 py-1.5 text-left text-xs text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] ${
+                                  index === suggestionIndex ? 'bg-[var(--color-surface-hover)]' : ''
+                                }`}
+                              >
+                                {suggestion}
+                              </Button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    {editorStats && (
+                      <dl className="mt-6 space-y-2 border-t border-[var(--color-border)] pt-4 text-2xs">
+                        <div className="flex justify-between gap-2">
+                          <dt className="text-[var(--color-text-muted)]">Lines</dt>
+                          <dd className="text-[var(--color-text)]">{editorStats.lines}</dd>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <dt className="text-[var(--color-text-muted)]">Characters</dt>
+                          <dd className="text-[var(--color-text)]">{editorStats.characters}</dd>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <dt className="text-[var(--color-text-muted)]">Bytes</dt>
+                          <dd className="text-[var(--color-text)]">{editorStats.bytes}</dd>
+                        </div>
+                      </dl>
+                    )}
+
+                    <dl className="mt-5 space-y-2 border-t border-[var(--color-border)] pt-4 text-2xs">
+                      <div>
+                        <dt className="text-[var(--color-text-muted)]">Created</dt>
+                        <dd className="mt-0.5 text-[var(--color-text)]">
+                          {formatTimestamp(selected.createdAt)}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-[var(--color-text-muted)]">Last edited</dt>
+                        <dd className="mt-0.5 text-[var(--color-text)]">
+                          {formatTimestamp(selected.updatedAt)}
+                        </dd>
+                      </div>
+                    </dl>
+                  </aside>
+                )}
               </div>
-            }
-          />
-        )}
-      </main>
+            </>
+          ) : (
+            <EmptyState
+              icon={ScissorsIcon}
+              title="Build your snippet library"
+              description="Create a snippet or import an existing JSON backup to get started."
+              className="h-full"
+              action={
+                <div className="flex items-center gap-2">
+                  <Button type="button" variant="primary" onClick={() => void handleNew()}>
+                    <PlusIcon size={12} aria-hidden="true" className="mr-1.5" />
+                    New snippet
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={() => void handleImport()}>
+                    <UploadSimpleIcon size={12} aria-hidden="true" className="mr-1.5" />
+                    Import JSON
+                  </Button>
+                </div>
+              }
+            />
+          )}
+        </main>
+      </MasterDetailLayout>
 
       {deleteDialogOpen && selected && (
         <Dialog
@@ -1150,6 +1156,6 @@ export default function SnippetsManager() {
           </p>
         </Dialog>
       )}
-    </div>
+    </>
   )
 }

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -25,6 +25,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { Field } from '@/components/shared/Field'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -950,8 +951,7 @@ export default function SnippetsManager() {
                 >
                   <h2 className="mb-4 text-xs font-semibold text-[var(--color-text)]">Details</h2>
 
-                  <label className="block text-2xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-                    Folder
+                  <Field label="Folder">
                     <Input
                       value={selected.folder}
                       onChange={(event) =>
@@ -959,9 +959,9 @@ export default function SnippetsManager() {
                       }
                       placeholder="No folder"
                       list={folderListId}
-                      className="mt-1.5 w-full"
+                      className="w-full"
                     />
-                  </label>
+                  </Field>
                   <datalist id={folderListId}>
                     {allFolders.map((folder) => (
                       <option key={folder} value={folder} />

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -25,6 +25,7 @@ import {
   XIcon,
 } from '@phosphor-icons/react'
 import { Button } from '@/components/shared/Button'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Dialog } from '@/components/shared/Dialog'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
@@ -968,10 +969,10 @@ export default function SnippetsManager() {
                   </datalist>
 
                   <div className="mt-5">
-                    <div className="mb-2 flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+                    <SectionLabel as="div" className="mb-2">
                       <TagIcon size={12} aria-hidden="true" />
                       Tags
-                    </div>
+                    </SectionLabel>
                     <div className="flex flex-wrap gap-1.5">
                       {visibleTags(selected.tags).map((tag) => (
                         <span

--- a/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
+++ b/apps/cockpit/src/tools/snippets/SnippetsManager.tsx
@@ -738,7 +738,7 @@ export default function SnippetsManager() {
                 tabIndex={isSelected || (!selectedId && filtered[0]?.id === snippet.id) ? 0 : -1}
                 onClick={() => setSelectedId(snippet.id)}
                 onKeyDown={(event) => handleListKeyDown(event, snippet.id)}
-                className={`group flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:shadow-[inset_var(--focus-ring)] ${
+                className={`group flex w-full justify-start rounded-none border-b border-[var(--color-border)] px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)] ${
                   isSelected
                     ? 'bg-[var(--color-accent-dim)]'
                     : 'hover:bg-[var(--color-surface-hover)]'
@@ -746,7 +746,7 @@ export default function SnippetsManager() {
               >
                 <div className="flex items-start gap-2">
                   <span
-                    className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[9px] font-bold uppercase ${LANG_TONE_CLASSES[tone]}`}
+                    className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-2xs font-bold uppercase ${LANG_TONE_CLASSES[tone]}`}
                   >
                     {LANG_EXTENSIONS[snippet.language] ?? snippet.language}
                   </span>
@@ -757,7 +757,7 @@ export default function SnippetsManager() {
                       </span>
                       {isFavorite(snippet.tags) && (
                         <StarIcon
-                          size={11}
+                          size={12}
                           weight="fill"
                           aria-label="Favorite"
                           className="shrink-0 text-[var(--color-warning)]"
@@ -771,7 +771,7 @@ export default function SnippetsManager() {
                       {contentPreview(snippet.content) || 'Empty snippet'}
                     </span>
                     {(snippet.folder || visibleTags(snippet.tags).length > 0) && (
-                      <span className="mt-1.5 flex items-center gap-2 overflow-hidden text-[9px] text-[var(--color-text-muted)]">
+                      <span className="mt-1.5 flex items-center gap-2 overflow-hidden text-2xs text-[var(--color-text-muted)]">
                         {snippet.folder && (
                           <span className="flex min-w-0 items-center gap-1 truncate">
                             <FolderOpenIcon size={9} aria-hidden="true" />
@@ -832,7 +832,7 @@ export default function SnippetsManager() {
                   className={isFavorite(selected.tags) ? 'text-[var(--color-warning)]' : ''}
                 >
                   <StarIcon
-                    size={15}
+                    size={16}
                     weight={isFavorite(selected.tags) ? 'fill' : 'regular'}
                     aria-hidden="true"
                   />
@@ -969,7 +969,7 @@ export default function SnippetsManager() {
 
                   <div className="mt-5">
                     <div className="mb-2 flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
-                      <TagIcon size={11} aria-hidden="true" />
+                      <TagIcon size={12} aria-hidden="true" />
                       Tags
                     </div>
                     <div className="flex flex-wrap gap-1.5">

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -249,7 +249,7 @@ export default function TsPlayground() {
               title={state.fileName ?? 'Untitled.ts'}
               icon={
                 <FileTsIcon
-                  size={15}
+                  size={16}
                   aria-hidden="true"
                   className="shrink-0 text-[var(--color-text-muted)]"
                 />
@@ -294,7 +294,7 @@ export default function TsPlayground() {
                 {...(state.optionsOpen ? { 'aria-controls': optionsId } : {})}
                 className="gap-1"
               >
-                <SlidersHorizontalIcon size={13} aria-hidden="true" />
+                <SlidersHorizontalIcon size={14} aria-hidden="true" />
                 Options
               </Button>
               <Button
@@ -320,7 +320,7 @@ export default function TsPlayground() {
                 title="Save the JavaScript output to a file (⌘S)"
                 aria-label="Save output to file"
               >
-                <FloppyDiskIcon size={15} aria-hidden="true" />
+                <FloppyDiskIcon size={16} aria-hidden="true" />
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>
@@ -497,7 +497,7 @@ export default function TsPlayground() {
                     className="flex items-start gap-2 py-0.5 text-xs"
                   >
                     <Icon
-                      size={13}
+                      size={14}
                       aria-hidden="true"
                       className="mt-0.5 shrink-0"
                       style={{ color: SEVERITY_COLOR[d.category] }}

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -16,6 +16,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
 import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
@@ -307,9 +308,7 @@ export default function TsPlayground() {
                 title="Compile now (⌘↵)"
               >
                 Compile
-                <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                  ⌘↵
-                </span>
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
               <CopyButton text={output} label="Copy output" />
               <Button

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -30,6 +30,7 @@ import type { Diagnostic } from '@/workers/typescript.api'
 import type { TypeScriptWorker } from '@/workers/typescript.worker'
 import TypeScriptWorkerFactory from '@/workers/typescript.worker?worker'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type TsPlaygroundState = {
   input: string
@@ -305,7 +306,7 @@ export default function TsPlayground() {
                 disabled={!hasCode}
                 // Deliberately not `loading`: a background auto-compile would
                 // then disable the very button that requests an announced one.
-                title="Compile now (⌘↵)"
+                title={`Compile now (${formatShortcut('mod+enter')})`}
               >
                 Compile
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -316,7 +317,7 @@ export default function TsPlayground() {
                 size="sm"
                 onClick={handleSave}
                 disabled={!output}
-                title="Save the JavaScript output to a file (⌘S)"
+                title={`Save the JavaScript output to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save output to file"
               >
                 <FloppyDiskIcon size={16} aria-hidden="true" />

--- a/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
+++ b/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
@@ -4,6 +4,7 @@ import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
+import { SplitPane } from '@/components/shared/SplitPane'
 import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
@@ -194,8 +195,8 @@ export default function UrlCodec() {
       }
     >
       {/* Input / Output panels */}
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
+      <SplitPane storageKey="url-codec" aria-label="Resize input and output">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader title="Input" hint={state.mode === 'encode' ? 'Text' : 'Encoded'} />
           <TextArea
             value={state.input}
@@ -206,7 +207,7 @@ export default function UrlCodec() {
             className="flex-1 resize-none rounded-none border-0 bg-[var(--color-bg)] p-4 focus:border-0"
           />
         </div>
-        <div className="flex w-1/2 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           <PaneHeader
             title="Output"
             hint={state.mode === 'encode' ? 'Encoded' : 'Text'}
@@ -222,7 +223,7 @@ export default function UrlCodec() {
             </pre>
           )}
         </div>
-      </div>
+      </SplitPane>
 
       {/* URL parts panel */}
       {urlParts && (

--- a/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
+++ b/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useEffect } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
@@ -194,9 +195,7 @@ export default function UrlCodec() {
       {/* Input / Output panels */}
       <div className="flex flex-1 overflow-hidden">
         <div className="flex w-1/2 flex-col border-r border-[var(--color-border)]">
-          <div className="border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-muted)]">
-            Input ({state.mode === 'encode' ? 'Text' : 'Encoded'})
-          </div>
+          <PaneHeader title="Input" hint={state.mode === 'encode' ? 'Text' : 'Encoded'} />
           <TextArea
             value={state.input}
             onChange={(e) => updateState({ input: e.target.value })}
@@ -207,12 +206,11 @@ export default function UrlCodec() {
           />
         </div>
         <div className="flex w-1/2 flex-col">
-          <div className="flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1">
-            <span className="text-xs text-[var(--color-text-muted)]">
-              Output ({state.mode === 'encode' ? 'Encoded' : 'Text'})
-            </span>
-            <CopyButton text={output.text} />
-          </div>
+          <PaneHeader
+            title="Output"
+            hint={state.mode === 'encode' ? 'Encoded' : 'Text'}
+            actions={<CopyButton text={output.text} />}
+          />
           {output.error ? (
             <Alert variant="error" className="m-4">
               {output.error}

--- a/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
+++ b/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useEffect } from 'react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Alert } from '@/components/shared/Alert'
 import { useUiStore } from '@/stores/ui.store'
@@ -163,7 +164,7 @@ export default function UrlCodec() {
               <ArrowsLeftRightIcon size={12} aria-hidden="true" />
               Swap
             </Button>
-            <span className="text-2xs text-[var(--color-text-muted)]">⌘↵</span>
+            <Kbd keys="mod+enter" />
           </ToolbarGroup>
           <ToolbarGroup label="Encoding options" separated>
             <Select

--- a/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
+++ b/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/shared/Button'
 import { Input, Select } from '@/components/shared/Input'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Alert } from '@/components/shared/Alert'
+import { Panel } from '@/components/shared/Panel'
 import { StatusBadge } from '@/components/shared/StatusBadge'
 
 // ── UUID Generation ──────────────────────────────────────────────────
@@ -237,8 +238,7 @@ export default function UuidGenerator() {
     <ToolLayout maxWidth="max-w-4xl">
       <div className="flex flex-col gap-4">
         {/* ── Generate ─────────────────────────────────────── */}
-        <section className="flex flex-col gap-3">
-          <h2 className="font-mono text-sm text-[var(--color-text)]">Generate</h2>
+        <Panel title="Generate">
           <div className="flex flex-wrap items-center gap-3">
             <Select
               value={state.version}
@@ -255,39 +255,37 @@ export default function UuidGenerator() {
             </Button>
             {state.lastGenerated && (
               <div className="flex items-center gap-2">
-                <code className="rounded bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)]">
+                <code className="rounded bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)]">
                   {state.lastGenerated}
                 </code>
                 <CopyButton text={state.lastGenerated} />
               </div>
             )}
           </div>
-        </section>
+        </Panel>
 
         {/* ── Constants ────────────────────────────────────── */}
-        <section className="flex flex-col gap-3">
-          <h2 className="font-mono text-sm text-[var(--color-text)]">Constants</h2>
+        <Panel title="Constants">
           <div className="flex flex-wrap items-center gap-4">
             <div className="flex items-center gap-2">
-              <code className="rounded bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
+              <code className="rounded bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
                 {NIL_UUID}
               </code>
               <span className="text-xs text-[var(--color-text-muted)]">Nil</span>
               <CopyButton text={NIL_UUID} />
             </div>
             <div className="flex items-center gap-2">
-              <code className="rounded bg-[var(--color-surface)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
+              <code className="rounded bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-text-muted)]">
                 {MAX_UUID}
               </code>
               <span className="text-xs text-[var(--color-text-muted)]">Max</span>
               <CopyButton text={MAX_UUID} />
             </div>
           </div>
-        </section>
+        </Panel>
 
         {/* ── Bulk Generate ────────────────────────────────── */}
-        <section className="flex flex-col gap-3">
-          <h2 className="font-mono text-sm text-[var(--color-text)]">Bulk Generate</h2>
+        <Panel title="Bulk Generate">
           <div className="flex flex-wrap items-center gap-3">
             <Input
               type="number"
@@ -312,15 +310,14 @@ export default function UuidGenerator() {
             {bulkUuids.length > 0 && <CopyButton text={bulkOutput} label="Copy All" />}
           </div>
           {bulkOutput && (
-            <pre className="max-h-60 overflow-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3 text-xs text-[var(--color-text)]">
+            <pre className="mt-3 max-h-60 overflow-auto rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-3 text-xs text-[var(--color-text)]">
               {bulkOutput}
             </pre>
           )}
-        </section>
+        </Panel>
 
         {/* ── Validate & Parse ─────────────────────────────── */}
-        <section className="flex flex-col gap-3">
-          <h2 className="font-mono text-sm text-[var(--color-text)]">Validate & Parse</h2>
+        <Panel title="Validate & Parse">
           <Input
             type="text"
             value={state.validateInput}
@@ -330,7 +327,7 @@ export default function UuidGenerator() {
             className="w-full max-w-xl font-mono"
           />
           {parsed && (
-            <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
+            <div className="mt-3 rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-3">
               {parsed.valid ? (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center gap-2">
@@ -365,7 +362,7 @@ export default function UuidGenerator() {
               )}
             </div>
           )}
-        </section>
+        </Panel>
       </div>
     </ToolLayout>
   )

--- a/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
+++ b/apps/cockpit/src/tools/uuid-generator/UuidGenerator.tsx
@@ -304,7 +304,9 @@ export default function UuidGenerator() {
               <option value="json">JSON array</option>
               <option value="csv">CSV</option>
             </Select>
-            <Button variant="primary" size="md" onClick={generateBulk}>
+            {/* Secondary: the tool's one primary is Generate at the top. Bulk is the same
+                operation with a count, not a second headline action. */}
+            <Button variant="secondary" size="md" onClick={generateBulk}>
               Generate
             </Button>
             {bulkUuids.length > 0 && <CopyButton text={bulkOutput} label="Copy All" />}

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -18,6 +18,7 @@ import { useWorker, type WorkerRpc } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Alert } from '@/components/shared/Alert'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -355,9 +356,7 @@ export default function XmlTools() {
               title="Format the document (⌘↵)"
             >
               Format
-              <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                ⌘↵
-              </span>
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
             <Button
               variant="secondary"

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -34,6 +34,7 @@ import type { XmlWorker } from '@/workers/xml.worker'
 import type { XmlInspection, XmlIssue, XmlTreeNode } from '@/workers/xml.api'
 import XmlWorkerFactory from '@/workers/xml.worker?worker'
 import { useCopyToClipboard, type CopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type XmlView = 'source' | 'tree' | 'json' | 'xpath'
 
@@ -353,7 +354,7 @@ export default function XmlTools() {
               onClick={() => void runTransform('format')}
               disabled={!hasInput || isBusy}
               loading={isBusy}
-              title="Format the document (⌘↵)"
+              title={`Format the document (${formatShortcut('mod+enter')})`}
             >
               Format
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -372,7 +373,7 @@ export default function XmlTools() {
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}
-              title="Save to a file (⌘S)"
+              title={`Save to a file (${formatShortcut('mod+s')})`}
               aria-label="Save XML to file"
             >
               <FloppyDiskIcon size={16} aria-hidden="true" />
@@ -425,7 +426,7 @@ export default function XmlTools() {
               <EmptyState
                 icon={BracketsAngleIcon}
                 title="Paste or open an XML document"
-                description="Format with ⌘↵, browse it as a tree, convert it to JSON, or query it with XPath."
+                description={`Format with ${formatShortcut('mod+enter')}, browse it as a tree, convert it to JSON, or query it with XPath.`}
                 action={
                   TOOL_SAMPLES['xml-tools'] ? (
                     <span className="pointer-events-auto">

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -289,7 +289,7 @@ export default function XmlTools() {
             title={state.fileName ?? 'Untitled'}
             icon={
               <BracketsAngleIcon
-                size={15}
+                size={16}
                 aria-hidden="true"
                 className="shrink-0 text-[var(--color-text-muted)]"
               />
@@ -375,7 +375,7 @@ export default function XmlTools() {
               title="Save to a file (⌘S)"
               aria-label="Save XML to file"
             >
-              <FloppyDiskIcon size={15} aria-hidden="true" />
+              <FloppyDiskIcon size={16} aria-hidden="true" />
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>
@@ -724,7 +724,7 @@ function TreeNodeRow({
           disabled={!hasChildren}
         >
           <span className="w-3 shrink-0 text-[var(--color-text-muted)]">
-            {hasChildren && <Caret size={10} aria-hidden="true" />}
+            {hasChildren && <Caret size={12} aria-hidden="true" />}
           </span>
           {/* One span, no flex gap: the pieces of a tag have to read as a tag,
               not as `<catalog >`. */}

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -18,6 +18,7 @@ import { useWorker, type WorkerRpc } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { Alert } from '@/components/shared/Alert'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Button } from '@/components/shared/Button'
@@ -550,17 +551,6 @@ function InspectorPane({
   )
 }
 
-function PaneHeader({ title, children }: { title: string; children?: React.ReactNode }) {
-  return (
-    <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
-      <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-        {title}
-      </span>
-      {children}
-    </div>
-  )
-}
-
 function TreePane({
   input,
   worker,
@@ -614,33 +604,38 @@ function TreePane({
 
   return (
     <>
-      <PaneHeader title="Tree">
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={() => setExpansion(true)}
-          className="gap-1"
-          title="Expand every node"
-        >
-          <ArrowsOutLineVerticalIcon size={12} aria-hidden="true" />
-          Expand all
-        </Button>
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={() => setExpansion(false)}
-          className="gap-1"
-          title="Collapse every node"
-        >
-          <ArrowsInLineVerticalIcon size={12} aria-hidden="true" />
-          Collapse all
-        </Button>
-        {expandAll === null && !autoExpanded && (
-          <span className="text-2xs text-[var(--color-text-muted)]">
-            Collapsed — {elementCount} elements
-          </span>
-        )}
-      </PaneHeader>
+      <PaneHeader
+        title="Tree"
+        actions={
+          <>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setExpansion(true)}
+              className="gap-1"
+              title="Expand every node"
+            >
+              <ArrowsOutLineVerticalIcon size={12} aria-hidden="true" />
+              Expand all
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setExpansion(false)}
+              className="gap-1"
+              title="Collapse every node"
+            >
+              <ArrowsInLineVerticalIcon size={12} aria-hidden="true" />
+              Collapse all
+            </Button>
+            {expandAll === null && !autoExpanded && (
+              <span className="text-2xs text-[var(--color-text-muted)]">
+                Collapsed — {elementCount} elements
+              </span>
+            )}
+          </>
+        }
+      />
       <div className="min-h-0 flex-1 overflow-auto p-3 font-mono">
         {tree ? (
           <TreeNodeRow key={treeKey} node={tree} defaultExpanded={expanded} onCopy={onCopy} />
@@ -826,7 +821,10 @@ function JsonPane({
 
   return (
     <>
-      <PaneHeader title="JSON">{json && <CopyButton text={json} label="Copy JSON" />}</PaneHeader>
+      <PaneHeader
+        title="JSON"
+        actions={json ? <CopyButton text={json} label="Copy JSON" /> : undefined}
+      />
       <div className="min-h-0 flex-1 overflow-hidden">
         {failure ? (
           <EmptyState
@@ -904,11 +902,18 @@ function XPathPane({
 
   return (
     <>
-      <PaneHeader title="XPath">
-        <output className="text-2xs text-[var(--color-text-muted)]">
-          {queried && !failure ? `${matches.length} match${matches.length === 1 ? '' : 'es'}` : ''}
-        </output>
-      </PaneHeader>
+      <PaneHeader
+        title="XPath"
+        actions={
+          <>
+            <output className="text-2xs text-[var(--color-text-muted)]">
+              {queried && !failure
+                ? `${matches.length} match${matches.length === 1 ? '' : 'es'}`
+                : ''}
+            </output>
+          </>
+        }
+      />
       <div className="border-b border-[var(--color-border)] px-3 py-2">
         <Input
           aria-label="XPath expression"

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -322,7 +322,7 @@ export default function YamlTools() {
               title={state.fileName ?? 'Untitled'}
               icon={
                 <FileCodeIcon
-                  size={15}
+                  size={16}
                   aria-hidden="true"
                   className="shrink-0 text-[var(--color-text-muted)]"
                 />
@@ -387,7 +387,7 @@ export default function YamlTools() {
                 disabled={!hasInput}
                 className="gap-1"
               >
-                <SortAscendingIcon size={13} aria-hidden="true" />
+                <SortAscendingIcon size={14} aria-hidden="true" />
                 Sort keys
               </Button>
               <Button variant="secondary" size="sm" onClick={handleCompact} disabled={!hasInput}>
@@ -395,7 +395,7 @@ export default function YamlTools() {
               </Button>
               {undoBuffer && (
                 <Button variant="ghost" size="sm" onClick={handleUndo} className="gap-1">
-                  <ArrowUUpLeftIcon size={13} aria-hidden="true" />
+                  <ArrowUUpLeftIcon size={14} aria-hidden="true" />
                   Undo {undoBuffer.label.toLowerCase()}
                 </Button>
               )}
@@ -408,7 +408,7 @@ export default function YamlTools() {
                 title="Save to a file (⌘S)"
                 aria-label="Save YAML to file"
               >
-                <FloppyDiskIcon size={15} aria-hidden="true" />
+                <FloppyDiskIcon size={16} aria-hidden="true" />
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -16,6 +16,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { Alert } from '@/components/shared/Alert'
@@ -559,17 +560,6 @@ function InspectorPane({
   )
 }
 
-function PaneHeader({ title, children }: { title: string; children?: ReactNode }) {
-  return (
-    <div className="flex flex-wrap items-center gap-2 border-b border-[var(--color-border)] px-3 py-1.5">
-      <span className="font-ui text-2xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-        {title}
-      </span>
-      {children}
-    </div>
-  )
-}
-
 function TreePane({
   documents,
   keyCount,
@@ -593,29 +583,34 @@ function TreePane({
 
   return (
     <>
-      <PaneHeader title="Tree">
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={() => setExpansion(true)}
-          title="Expand every node"
-        >
-          Expand all
-        </Button>
-        <Button
-          variant="ghost"
-          size="xs"
-          onClick={() => setExpansion(false)}
-          title="Collapse every node"
-        >
-          Collapse all
-        </Button>
-        {expandAll === null && !autoExpanded && (
-          <span className="text-2xs text-[var(--color-text-muted)]">
-            Collapsed — {keyCount} keys
-          </span>
-        )}
-      </PaneHeader>
+      <PaneHeader
+        title="Tree"
+        actions={
+          <>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setExpansion(true)}
+              title="Expand every node"
+            >
+              Expand all
+            </Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setExpansion(false)}
+              title="Collapse every node"
+            >
+              Collapse all
+            </Button>
+            {expandAll === null && !autoExpanded && (
+              <span className="text-2xs text-[var(--color-text-muted)]">
+                Collapsed — {keyCount} keys
+              </span>
+            )}
+          </>
+        }
+      />
       <div
         className="min-h-0 flex-1 overflow-auto p-3 font-mono text-xs"
         // Remount when the default changes, otherwise editing a document across
@@ -685,31 +680,36 @@ function JsonPane({
 
   return (
     <>
-      <PaneHeader title="JSON">
-        <CopyButton text={value} label="Copy JSON" />
-        {draft !== null && (
+      <PaneHeader
+        title="JSON"
+        actions={
           <>
-            <Button
-              variant="primary"
-              size="xs"
-              onClick={() => {
-                onApply(draft)
-                onDraftChange(null)
-              }}
-              disabled={!canApply}
-              title="Replace the YAML document with this JSON"
-            >
-              Apply to YAML
-            </Button>
-            <Button variant="ghost" size="xs" onClick={() => onDraftChange(null)}>
-              Discard edits
-            </Button>
-            <span className="text-2xs text-[var(--color-text-muted)]">
-              {draftError ? `Invalid JSON — ${draftError}` : 'Edited — not applied'}
-            </span>
+            <CopyButton text={value} label="Copy JSON" />
+            {draft !== null && (
+              <>
+                <Button
+                  variant="primary"
+                  size="xs"
+                  onClick={() => {
+                    onApply(draft)
+                    onDraftChange(null)
+                  }}
+                  disabled={!canApply}
+                  title="Replace the YAML document with this JSON"
+                >
+                  Apply to YAML
+                </Button>
+                <Button variant="ghost" size="xs" onClick={() => onDraftChange(null)}>
+                  Discard edits
+                </Button>
+                <span className="text-2xs text-[var(--color-text-muted)]">
+                  {draftError ? `Invalid JSON — ${draftError}` : 'Edited — not applied'}
+                </span>
+              </>
+            )}
           </>
-        )}
-      </PaneHeader>
+        }
+      />
       <div className="min-h-0 flex-1 overflow-hidden">
         <Editor
           theme={monacoTheme}

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -41,6 +41,7 @@ import {
   type YamlParse,
 } from '@/tools/yaml-tools/yaml-helpers'
 import { useCopyToClipboard, type CopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 type YamlView = 'source' | 'tree' | 'json'
 
@@ -376,7 +377,7 @@ export default function YamlTools() {
                 onClick={() => void handleFormat()}
                 disabled={!hasInput || isFormatting}
                 loading={isFormatting}
-                title="Format the document (⌘↵)"
+                title={`Format the document (${formatShortcut('mod+enter')})`}
               >
                 Format
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
@@ -406,7 +407,7 @@ export default function YamlTools() {
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasInput}
-                title="Save to a file (⌘S)"
+                title={`Save to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save YAML to file"
               >
                 <FloppyDiskIcon size={16} aria-hidden="true" />
@@ -454,7 +455,7 @@ export default function YamlTools() {
               <EmptyState
                 icon={FileCodeIcon}
                 title="Paste or open a YAML document"
-                description="Format with ⌘↵, inspect it as a tree, and read it as JSON — multi-document streams included."
+                description={`Format with ${formatShortcut('mod+enter')}, inspect it as a tree, and read it as JSON — multi-document streams included.`}
                 action={
                   TOOL_SAMPLES['yaml-tools'] ? (
                     <span className="pointer-events-auto">
@@ -686,8 +687,10 @@ function JsonPane({
             <CopyButton text={value} label="Copy JSON" />
             {draft !== null && (
               <>
+                {/* Secondary: the toolbar's Format is the tool's primary. This row only appears
+                    when a draft exists, so it doesn't need an accent to be found. */}
                 <Button
-                  variant="primary"
+                  variant="secondary"
                   size="xs"
                   onClick={() => {
                     onApply(draft)

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -16,6 +16,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
 import { Alert } from '@/components/shared/Alert'
 import { EmptyState } from '@/components/shared/EmptyState'
@@ -624,9 +625,9 @@ function TreePane({
         {documents.map((document, i) => (
           <div key={i}>
             {documents.length > 1 && (
-              <div className="mt-2 text-2xs uppercase tracking-wide text-[var(--color-text-muted)]">
+              <SectionLabel as="div" className="mt-2">
                 Document {i + 1}
-              </div>
+              </SectionLabel>
             )}
             <YamlTree
               data={document}

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -16,6 +16,7 @@ import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Button } from '@/components/shared/Button'
@@ -378,9 +379,7 @@ export default function YamlTools() {
                 title="Format the document (⌘↵)"
               >
                 Format
-                <span className="ml-1 text-2xs opacity-70" aria-hidden="true">
-                  ⌘↵
-                </span>
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
               <Button
                 variant="secondary"


### PR DESCRIPTION
## Summary

An audit of all 30 cockpit tools' chrome — titles, toolbars, buttons, labels, pane headers, form
fields, keyboard hints — followed by five phases of convergence onto shared primitives. The audit
itself and its phased plan live in `documentation/TODO.md`; the contracts it settled are written
into `documentation/DESIGN_SYSTEM.md`.

The goal was not "make it prettier". It was to make the next tool cheap to build correctly, by
having exactly one way to express each piece of chrome and a linter that fails the build when a
tool invents a second.

## What changed, by phase

**P1 — foundation.** A type/icon/spacing scale, plus `scripts/lint-design-system.mjs` wired into
`bun run lint`. It blocks off-scale text and icon sizes, legacy focus rings, hardcoded colours and
raw Tailwind palette classes. Baseline was **153 violations**; it has been 0 since P2.

**P2/P3 — primitive adoption.** `SectionLabel`, `PaneHeader`, `Kbd`, `Field`, `Panel`. `Field`
turned up genuinely broken markup: several inputs had a styled `<span>` beside them and no `<label>`
at all, so screen readers announced them unnamed. The bracket-label idiom (`[Recent]`, `[Pinned]`)
is retired, and HTTP method colours moved to `lib/http-method.ts` — the two copies disagreed on POST
and PATCH, so the same request changed colour depending on which tool opened it.

**P4 — structural convergence.** Every tool now renders through `ToolLayout` or
`MasterDetailLayout`. `ToolLayout`'s `header` slot was **deleted**: it had reached zero consumers
while two tools hand-rolled the sidebar heading it couldn't express. The tab strip names the tool;
a tool body never repeats it.

**P5 — behaviour and polish.** Eight tools onto `SplitPane`, which gained `stackBelow` first —
four of them already stacked by hand at 900/1000px, and an inline ratio `width` beats any Tailwind
breakpoint, so adopting it without that prop would have silently deleted their responsive
behaviour. Then the primary-action rule, and `formatShortcut`.

## Two bugs found by writing the shared code

- **Shortcut hints lied off macOS.** 40 prose strings in `title=`/`aria-label`/descriptions
  hardcoded `⌘`, so a Windows user was told to press a key their keyboard doesn't have — while the
  `<kbd>` beside it correctly said Ctrl. Extracting `lib/shortcut-label.ts` then exposed the same
  bug in milder form inside `Kbd` itself: it emitted Mac glyphs everywhere, rendering `Ctrl+↵`. The
  symbol table is split by convention now — glyphs for macOS, words for everywhere else.
- **Unlabelled form inputs**, as above.

## Scope notes, stated plainly

- **Frontend only.** No Rust touched; `cargo check` is unchanged from baseline.
- **The audit's F11 said 5 tools had multiple primary actions. 3 were fixed.** The other two were a
  modal's confirm button and an `EmptyState` CTA — not tool chrome, and demoting them would have
  made those surfaces worse. The rule in `DESIGN_SYSTEM.md` carves them out explicitly rather than
  restating the count as five.
- **The screenshot diff is outstanding and blocked**, not skipped. Clicks and typing into the macOS
  Tauri WebView aren't scriptable, so no agent can drive a tool into the state worth photographing.
  It is marked as needing a human in `TODO.md` §5 P5, and it is the one claim in this PR that no
  automated check backs. **A visual pass before merge is worth the five minutes** — 1344 DOM
  assertions will cheerfully wave a layout regression through.

## Verification

All run from `apps/cockpit/`:

| Gate       | Command                          | Baseline         | Now              |
| ---------- | -------------------------------- | ---------------- | ---------------- |
| TypeScript | `npx tsc --noEmit`               | Pass             | Pass             |
| Tests      | `bunx vitest run`                | 109 files / 1314 | 115 files / 1344 |
| ESLint     | `bun run lint`                   | Pass, 0 warnings | Pass, 0 warnings |
| Design sys | `bun run lint:ds`                | 153 violations   | 0 violations     |
| Rust       | `cargo check`                    | Pass             | Pass (untouched) |

`bun run tauri build` also completed locally — `.app` and `.dmg` bundled clean at 0.1.66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)