### PR TITLE
feat(cockpit): JSON table generalization, motion pass, floating shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ pnpm-lock.yaml
 *.swo
 
 .grepai/
+
+# Playwright MCP session artifacts (snapshots, console logs)
+.playwright-mcp/

--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -21,13 +21,20 @@ Those need the real app.
 ## Setup
 
 The web bundle refuses to boot outside Tauri — the Tauri JS API reads `window.__TAURI_INTERNALS__`
-eagerly and throws `Cannot read properties of undefined (reading 'metadata')` before the shell
-mounts. [`scripts/tauri-browser-stub.js`](../scripts/tauri-browser-stub.js) provides the minimum
-stub to get past that.
+eagerly and throws `undefined is not an object (evaluating 'window.__TAURI_INTERNALS__.metadata')`
+before the shell mounts. [`scripts/tauri-browser-stub.js`](../scripts/tauri-browser-stub.js)
+provides the minimum stub to get past that.
 
 ```bash
 bun run dev   # from apps/cockpit — serves on http://localhost:1420
 ```
+
+The dev server installs the stub for you — [`scripts/vite-plugin-tauri-stub.js`](../scripts/vite-plugin-tauri-stub.js)
+inlines it at the top of `index.html` on `serve` only, so opening the URL in any browser boots.
+Under `tauri dev` the real IPC bridge is already there and the stub no-ops, and production builds
+never see it.
+
+A harness that navigates to a bundle the dev server did not serve still installs it itself:
 
 ```js
 import { installTauriStub } from './scripts/tauri-browser-stub.js'
@@ -38,6 +45,11 @@ await page.goto('http://localhost:1420')
 
 Every SQL read returns empty, so stores start blank and nothing persists across a reload. Seed
 state through the UI.
+
+Commands with no browser equivalent — file dialogs, `fs`, `http` — resolve to `null` and log a
+`[tauri-stub] unhandled command` warning. Two of those on boot (`plugin:http|fetch*`, the update
+check) are expected. A warning naming a command your feature depends on means you are testing a
+stub, not the app: run `bunx tauri dev` instead.
 
 ## Gotchas found the hard way
 

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -217,6 +217,35 @@ for this reason — one existed and reached zero consumers. The only heading a t
 **Tools must be `flex h-full flex-col` at the root** — `ToolLayout` handles this; hand-rolled roots
 without `h-full` silently collapse.
 
+### Shell layout modes
+
+The shell itself has two modes, set by `settings.shellStyle` and applied as `data-shell` on the app
+root. `floating` is the default; `flush` is the original edge-to-edge layout and costs nothing at
+runtime, since with `data-shell="flush"` not one rule in `styles/shell.css` matches.
+
+| Hook            | On                                    |
+| --------------- | ------------------------------------- |
+| `.shell-canvas` | app root — paints the recessed canvas |
+| `.shell-row`    | the sidebar/workspace/drawer row      |
+| `.shell-panel`  | each of the three panels              |
+| `.shell-chrome` | title bar and status bar              |
+
+All the geometry lives in `styles/shell.css`, not in the five shell components, and its selectors
+are attribute + class (specificity 0,2,0) so they beat Tailwind utilities without `!important`.
+Sidebar and notes-drawer tests assert the hook classes, because jsdom applies no stylesheet and a
+rename is otherwise silent.
+
+Two constraints worth knowing before changing it:
+
+- **Panels keep a 1px border in floating mode, not just a shadow.** Several light themes put
+  `--color-surface-sunken` within a couple of percent of `--color-bg` (github-light: `#fbfcfd`
+  against `#ffffff`), where a shadow-only card is invisible. The border carries those themes; the
+  shadow carries the dark ones.
+- **Gutters are margins, not flex `gap`.** The closed notes drawer is `width: 0` rather than
+  unmounted, so that opening it can animate — and flex `gap` would hold a gutter open beside
+  nothing. When `inert`, the panel also drops its border and shadow, both of which a zero-width box
+  still paints.
+
 ---
 
 ## Breakpoints

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -375,17 +375,50 @@ keyboard-first — every core action must be reachable without a mouse (`useGlob
 
 ---
 
-## Animation
+## Motion
 
-One shared animation:
+Two durations and two easings, in `tokens.css`. Everything stays under 200ms — this is a utility
+app, it should feel instant.
+
+| Token              | Value                           | Use                                           |
+| ------------------ | ------------------------------- | --------------------------------------------- |
+| `--duration-fast`  | `150ms`                         | hovers, colour changes, focus, small reveals  |
+| `--duration-panel` | `200ms`                         | panels opening/closing, layout-sized movement |
+| `--duration-spin`  | `700ms`                         | the loading spinner only                      |
+| `--ease-out`       | `cubic-bezier(0.16, 1, 0.3, 1)` | things entering — fast start, soft landing    |
+| `--ease-in-out`    | `cubic-bezier(0.4, 0, 0.2, 1)`  | things that move both ways (panel width)      |
 
 ```tsx
-className = 'animate-fade-in' // 150ms ease-out, 8px rise
+className = 'transition-colors duration-[var(--duration-fast)] ease-[var(--ease-out)]'
 ```
 
-Defined at `index.css:89`. Keep everything under 200ms — this is a utility app, it should feel
-instant. `index.css` disables animation under `prefers-reduced-motion` globally, so don't add
-per-component guards.
+Literal `duration-150` / `ease-in-out` are blocked by `lint:ds` — that is how a fourth duration
+gets in, and the same interaction then runs at two speeds depending on which file it lives in.
+
+Shared keyframe utilities, all defined in `index.css`:
+
+| Utility                 | Effect                                                 |
+| ----------------------- | ------------------------------------------------------ |
+| `animate-fade-in`       | opacity + 8px rise — menus, popovers, panels appearing |
+| `animate-pop-in`        | opacity + 0.98→1 scale — tooltips and flyouts          |
+| `animate-fade-in-place` | opacity only                                           |
+
+Use `animate-fade-in-place` on anything positioned with a transform (`-translate-x-1/2`, etc.).
+Keyframes that animate `transform` overwrite the utility's positioning transform outright, so a
+centred toolbar jumps to its untransformed corner for the length of the animation.
+
+Two rules that are not stylistic:
+
+- **Never transition a property a drag writes on every mousemove.** Setting an inline `width` does
+  not opt out of a `transition-[width]` class — each move re-aims a fresh eased animation at a
+  target that has already moved, so the edge trails the pointer and arrives in visible steps. Both
+  resizable panels drop the transition class while dragging and restore it on mouseup
+  (`Sidebar.tsx`, `NotesDrawer.tsx`); `NotesDrawer.test.tsx` pins it.
+- **Prefer `transform` and `opacity`.** They composite; `width`, `height` and `top` re-run layout
+  on every frame of the animation.
+
+`index.css` disables animation under `prefers-reduced-motion` globally, so don't add per-component
+guards.
 
 ---
 
@@ -416,13 +449,15 @@ and raw text `<input>` in `src/components/shell`. Per-line
 `lint:ds` walks raw source — including template literals, where most of the historical drift hid —
 and blocks:
 
-| Rule                | Blocks                                 |
-| ------------------- | -------------------------------------- |
-| `off-scale-text`    | `text-[Npx]`                           |
-| `off-scale-icon`    | `size={10\|11\|13\|15}`                |
-| `legacy-focus-ring` | `focus-visible:ring-*`                 |
-| `hardcoded-colour`  | hex / `rgb()` inside a class attribute |
-| `tailwind-palette`  | `bg-zinc-900` and friends              |
+| Rule                | Blocks                                             |
+| ------------------- | -------------------------------------------------- |
+| `off-scale-text`    | `text-[Npx]`                                       |
+| `off-scale-icon`    | `size={9\|10\|11\|13\|15}`                         |
+| `off-scale-motion`  | literal `duration-N` / `ease-out` — use the tokens |
+| `legacy-focus-ring` | `focus-visible:ring-*`                             |
+| `hardcoded-colour`  | hex / `rgb()` inside a class attribute             |
+| `tailwind-palette`  | `bg-zinc-900` and friends                          |
+| `dimmed-muted-text` | unprefixed `opacity-*` on `--color-text-muted`     |
 
 Escape hatch: `/* design-system-ignore: <reason> */` on the preceding line. The reason is required.
 

--- a/apps/cockpit/scripts/__tests__/lint-design-system.test.ts
+++ b/apps/cockpit/scripts/__tests__/lint-design-system.test.ts
@@ -76,6 +76,39 @@ describe('design-system lint rules', () => {
     })
   })
 
+  describe('off-scale-motion', () => {
+    // Motion had no scale at all until 2026-08-21: 100/150/200 were picked per component, so the
+    // same interaction ran at two speeds depending on which file it lived in.
+    it.each(['duration-100', 'duration-150', 'duration-200', 'duration-300'])(
+      'flags %s',
+      (utility) => {
+        expect(rulesFor(`className="transition-colors ${utility}"`)).toContain('off-scale-motion')
+      }
+    )
+
+    it.each(['ease-in-out', 'ease-out', 'ease-in', 'ease-linear'])(
+      'flags the literal easing %s',
+      (utility) => {
+        expect(rulesFor(`className="transition-transform ${utility}"`)).toContain(
+          'off-scale-motion'
+        )
+      }
+    )
+
+    it('allows the token form', () => {
+      expect(
+        rulesFor(
+          'className="transition-colors duration-[var(--duration-fast)] ease-[var(--ease-out)]"'
+        )
+      ).not.toContain('off-scale-motion')
+    })
+
+    // The token name contains the literal utility name, so a naive pattern flags the fix itself.
+    it('does not flag the easing token by its own name', () => {
+      expect(rulesFor('className="ease-[var(--ease-in-out)]"')).not.toContain('off-scale-motion')
+    })
+  })
+
   describe('escape hatch', () => {
     it('honours an ignore comment with a reason on the preceding line', () => {
       const text = ['/* design-system-ignore: third-party markup */', '<TagIcon size={9} />'].join(

--- a/apps/cockpit/scripts/lint-design-system.mjs
+++ b/apps/cockpit/scripts/lint-design-system.mjs
@@ -78,6 +78,16 @@ export const RULES = [
     message:
       'Opacity stacked on --color-text-muted composites to a WCAG AA failure. Drop the opacity utility (see DESIGN_SYSTEM.md § Colour).',
   },
+  {
+    id: 'off-scale-motion',
+    // Durations and easings drifted the same way sizes did: 100/150/200 chosen per component
+    // with no scale to point at. They are tokens now (--duration-fast/panel/spin,
+    // --ease-out/--ease-in-out), and a literal utility is how a fourth duration gets in.
+    // The lookbehind keeps `ease-[var(--ease-in-out)]` — the token form — from matching itself.
+    pattern: /\bduration-\d+\b|(?<!-)\bease-(?:linear|in|out|in-out)\b/g,
+    message:
+      'Off-scale duration or easing. Use duration-[var(--duration-fast|panel)] and ease-[var(--ease-out|in-out)] (see DESIGN_SYSTEM.md § Motion).',
+  },
 ]
 
 /**

--- a/apps/cockpit/scripts/lint-design-system.mjs
+++ b/apps/cockpit/scripts/lint-design-system.mjs
@@ -84,7 +84,9 @@ export const RULES = [
     // with no scale to point at. They are tokens now (--duration-fast/panel/spin,
     // --ease-out/--ease-in-out), and a literal utility is how a fourth duration gets in.
     // The lookbehind keeps `ease-[var(--ease-in-out)]` — the token form — from matching itself.
-    pattern: /\bduration-\d+\b|(?<!-)\bease-(?:linear|in|out|in-out)\b/g,
+    // `in-out` comes before `in`: alternation is first-match-wins, so the shorter
+    // alternative first would report `ease-in` as the match text for `ease-in-out`.
+    pattern: /\bduration-\d+\b|(?<!-)\bease-(?:linear|in-out|in|out)\b/g,
     message:
       'Off-scale duration or easing. Use duration-[var(--duration-fast|panel)] and ease-[var(--ease-out|in-out)] (see DESIGN_SYSTEM.md § Motion).',
   },

--- a/apps/cockpit/scripts/tauri-browser-stub.js
+++ b/apps/cockpit/scripts/tauri-browser-stub.js
@@ -11,6 +11,10 @@
  * stores start blank and nothing survives a reload. Not a substitute for
  * running the real app when testing anything that touches disk or the DB.
  *
+ * `bun run dev` installs this automatically (see scripts/vite-plugin-tauri-stub.js), so
+ * opening http://localhost:1420 in any browser just works. Scripted harnesses that
+ * navigate to a built bundle still install it themselves.
+ *
  * Usage with Playwright (must run before any page script):
  *
  *   import { installTauriStub } from './scripts/tauri-browser-stub.js'
@@ -24,11 +28,32 @@
  * See documentation/BROWSER_HARNESS.md for the full workflow.
  */
 export function installTauriStub() {
-  const invoke = async (cmd) => {
+  // Under the real app Tauri installs its own IPC bridge before any page script,
+  // so this is a no-op there and the dev server can inject it unconditionally.
+  if (window.__TAURI_INTERNALS__) return
+
+  const invoke = async (cmd, args) => {
     if (cmd === 'plugin:sql|load') return 'sqlite:cockpit.db'
     if (cmd === 'plugin:sql|select') return []
     if (cmd === 'plugin:sql|execute') return [0, 0]
+    // Custom Rust command: db.ts batches writes through it and ignores the result.
+    if (cmd === 'db_execute_batch') return null
     if (cmd === 'plugin:event|listen') return 1
+    // Custom Rust commands the shell calls on boot. Returning null here left the
+    // updater store parsing `undefined` and the MCP panel stuck on "checking".
+    if (cmd === 'get_platform_info') return ['macos', 'aarch64']
+    if (cmd === 'mcp_status' || cmd === 'mcp_apply_settings' || cmd === 'mcp_stop') {
+      const settings = args?.settings ?? {}
+      const host = settings.host ?? '127.0.0.1'
+      const port = settings.port ?? 17347
+      return {
+        running: false,
+        host,
+        port,
+        url: `http://${host}:${port}/mcp`,
+        lastError: null,
+      }
+    }
     if (cmd === 'window_is_maximized' || cmd === 'window_toggle_maximize') return false
     if (
       cmd === 'window_focus' ||
@@ -56,6 +81,9 @@ export function installTauriStub() {
     ) {
       return null
     }
+    // Everything else — file dialogs, fs, http — has no browser equivalent here.
+    // Resolving silently makes those look like they worked, so say so instead.
+    console.warn(`[tauri-stub] unhandled command "${cmd}" — resolved as null. Use the real app.`)
     return null
   }
 

--- a/apps/cockpit/scripts/vite-plugin-tauri-stub.d.ts
+++ b/apps/cockpit/scripts/vite-plugin-tauri-stub.d.ts
@@ -1,0 +1,4 @@
+import type { Plugin } from 'vite'
+
+/** Dev-server plugin that inlines the browser Tauri stub into index.html. */
+export function tauriStubPlugin(): Plugin

--- a/apps/cockpit/scripts/vite-plugin-tauri-stub.js
+++ b/apps/cockpit/scripts/vite-plugin-tauri-stub.js
@@ -1,0 +1,34 @@
+import { installTauriStub } from './tauri-browser-stub.js'
+
+/**
+ * Dev-only: inline the `window.__TAURI_INTERNALS__` stub at the top of index.html.
+ *
+ * Opening http://localhost:1420 in a normal browser used to die on
+ * `undefined is not an object (evaluating 'window.__TAURI_INTERNALS__.metadata')`
+ * because the stub existed but only scripted harnesses ever installed it. The
+ * page has no way to inject it for a human with a browser, so the dev server does.
+ *
+ * The script is injected head-prepend as a classic (non-module, non-deferred)
+ * script, so it runs before /src/main.tsx, which reaches for the Tauri API during
+ * module evaluation. Under `tauri dev` the real bridge is already installed and
+ * `installTauriStub` returns immediately, so the same HTML serves both.
+ *
+ * Dev only: a production bundle runs inside Tauri, where a stub would mask a real
+ * IPC failure as an app that boots and silently persists nothing.
+ */
+export function tauriStubPlugin() {
+  return {
+    name: 'cockpit:tauri-browser-stub',
+    apply: 'serve',
+    transformIndexHtml() {
+      return [
+        {
+          tag: 'script',
+          attrs: { 'data-tauri-stub': 'dev' },
+          children: `(${installTauriStub.toString()})()`,
+          injectTo: 'head-prepend',
+        },
+      ]
+    },
+  }
+}

--- a/apps/cockpit/src/app/App.tsx
+++ b/apps/cockpit/src/app/App.tsx
@@ -11,9 +11,11 @@ import { ShortcutsModal } from '@/components/shell/ShortcutsModal'
 import { UpdateNotification } from '@/components/shell/UpdateNotification'
 import { WindowResizeHandles } from '@/components/shell/WindowResizeHandles'
 import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts'
+import { useSettingsStore } from '@/stores/settings.store'
 
 export function App() {
   useGlobalShortcuts()
+  const shellStyle = useSettingsStore((s) => s.shellStyle)
 
   const [sendTo, setSendTo] = useState<{
     content: string
@@ -28,13 +30,15 @@ export function App() {
 
   return (
     <SendToContext.Provider value={{ showSendTo }}>
-      <div className="flex h-full flex-col">
+      {/* `data-shell` is the single switch for the shell's layout mode; everything it
+          changes is in styles/shell.css, scoped to the hook classes below. */}
+      <div data-shell={shellStyle} className="shell-canvas flex h-full flex-col">
         <TitleBar />
         <WindowResizeHandles />
         <UpdateNotification />
-        <div className="flex flex-1 overflow-hidden">
+        <div className="shell-row flex flex-1 overflow-hidden">
           <Sidebar />
-          <main className="flex-1 overflow-hidden">
+          <main className="shell-panel flex-1 overflow-hidden">
             <Workspace />
           </main>
           <NotesDrawer />

--- a/apps/cockpit/src/components/shared/Button.tsx
+++ b/apps/cockpit/src/components/shared/Button.tsx
@@ -59,7 +59,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || loading}
         aria-busy={loading || undefined}
         title={title ?? (variant === 'icon' ? props['aria-label'] : undefined)}
-        className={`font-ui relative inline-flex items-center justify-center gap-1.5 rounded-[var(--radius-sm)] transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${VARIANT_CLASSES[variant]} ${sizeClasses} ${className}`}
+        className={`font-ui relative inline-flex items-center justify-center gap-1.5 rounded-[var(--radius-sm)] transition-colors duration-[var(--duration-fast)] disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${VARIANT_CLASSES[variant]} ${sizeClasses} ${className}`}
         {...props}
       >
         {loading ? (

--- a/apps/cockpit/src/components/shared/Dialog.tsx
+++ b/apps/cockpit/src/components/shared/Dialog.tsx
@@ -151,7 +151,7 @@ export function Dialog({
             type="button"
             onClick={onClose}
             aria-label={closeLabel}
-            className="inline-flex min-h-8 min-w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
+            className="inline-flex min-h-8 min-w-8 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors duration-[var(--duration-fast)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
           >
             <XIcon size={16} aria-hidden="true" />
           </button>

--- a/apps/cockpit/src/components/shared/Input.tsx
+++ b/apps/cockpit/src/components/shared/Input.tsx
@@ -17,7 +17,7 @@ const SIZE_CLASSES: Record<InputSize, string> = {
 }
 
 const BASE_CLASSES =
-  'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-150 disabled:opacity-50'
+  'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-[var(--duration-fast)] disabled:opacity-50'
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ size = 'sm', className = '', ...props }, ref) => {

--- a/apps/cockpit/src/components/shared/MasterDetailLayout.tsx
+++ b/apps/cockpit/src/components/shared/MasterDetailLayout.tsx
@@ -53,7 +53,7 @@ export function MasterDetailLayout({
         // It's a viewport query rather than a container query because the workspace isn't a
         // `@container` — worth revisiting if one is ever introduced, since the app sidebar and
         // notes drawer both steal width this query can't see.
-        className={`flex min-h-0 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-[width,opacity] duration-200 ease-in-out ${
+        className={`flex min-h-0 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-surface)] transition-[width,opacity] duration-[var(--duration-panel)] ease-[var(--ease-in-out)] ${
           sidebarOpen
             ? 'w-64 opacity-100 max-[1000px]:w-52'
             : 'pointer-events-none w-0 overflow-hidden border-r-0 opacity-0'

--- a/apps/cockpit/src/components/shared/SegmentedControl.tsx
+++ b/apps/cockpit/src/components/shared/SegmentedControl.tsx
@@ -95,7 +95,7 @@ export function SegmentedControl<T extends string>({
             tabIndex={selected ? 0 : -1}
             onClick={() => onChange(option.value)}
             onKeyDown={(event) => handleKeyDown(event, index)}
-            className={`font-ui inline-flex items-center gap-1 rounded-[var(--radius-sm)] transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${SIZE_CLASSES[size]} ${
+            className={`font-ui inline-flex items-center gap-1 rounded-[var(--radius-sm)] transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${SIZE_CLASSES[size]} ${
               selected
                 ? 'bg-[var(--color-accent)] font-bold text-[var(--color-bg)]'
                 : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'

--- a/apps/cockpit/src/components/shared/Select.tsx
+++ b/apps/cockpit/src/components/shared/Select.tsx
@@ -12,7 +12,7 @@ const SIZE_CLASSES: Record<SelectSize, string> = {
 }
 
 const BASE_CLASSES =
-  'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none'
+  'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-[var(--duration-fast)] disabled:opacity-50 disabled:pointer-events-none'
 
 // A native <select> is the accessible choice here — it gets OS-native keyboard
 // navigation, screen-reader support, and mobile pickers for free. Styling is

--- a/apps/cockpit/src/components/shared/SelectionContextToolbar.tsx
+++ b/apps/cockpit/src/components/shared/SelectionContextToolbar.tsx
@@ -101,7 +101,7 @@ export function SelectionContextToolbar({
       ref={toolbarRef}
       role="toolbar"
       aria-label="Selection actions"
-      className="fixed z-[var(--z-popover)] flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-1.5 py-1 shadow-lg"
+      className="animate-fade-in-place fixed z-[var(--z-popover)] flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-1.5 py-1 shadow-lg"
       style={{ left, top }}
       onMouseDown={(event) => event.preventDefault()}
       onKeyDown={handleToolbarKeyDown}

--- a/apps/cockpit/src/components/shared/SplitPane.tsx
+++ b/apps/cockpit/src/components/shared/SplitPane.tsx
@@ -28,6 +28,10 @@ type SplitPaneProps = {
 }
 
 const STORAGE_PREFIX = 'cockpit.split.'
+
+/** Matches the sidebar and notes-drawer settle delay, so every resize in the app
+ *  persists on the same rhythm. */
+const PERSIST_DELAY_MS = 500
 const KEYBOARD_STEP = 0.02
 
 /** `null` disables the query entirely, so `stackBelow` stays optional without a conditional hook. */
@@ -94,18 +98,55 @@ export function SplitPane({
     [minRatio]
   )
 
-  const commit = useCallback(
-    (next: number) => {
-      const clamped = clamp(next)
-      setRatio(clamped)
+  const persist = useCallback(
+    (value: number) => {
       if (!storageKey) return
       try {
-        window.localStorage.setItem(STORAGE_PREFIX + storageKey, clamped.toFixed(4))
+        window.localStorage.setItem(STORAGE_PREFIX + storageKey, value.toFixed(4))
       } catch {
         // Ratio still applies for this session; persistence is a nicety, not a requirement.
       }
     },
-    [clamp, storageKey]
+    [storageKey]
+  )
+
+  // localStorage is synchronous and serialises through the main thread, and a drag
+  // commits on every mousemove — writing there per move puts a blocking disk-backed
+  // call between the pointer and the next frame. The ratio the user ends on is the
+  // only one worth remembering, so the write waits for the settle.
+  const persistTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const pendingRatio = useRef<number | null>(null)
+  const persistSoon = useCallback(
+    (value: number) => {
+      pendingRatio.current = value
+      clearTimeout(persistTimer.current)
+      persistTimer.current = setTimeout(() => {
+        pendingRatio.current = null
+        persist(value)
+      }, PERSIST_DELAY_MS)
+    },
+    [persist]
+  )
+
+  // Closing the tool inside the debounce window must not throw the drag away —
+  // flush what is pending instead of cancelling it.
+  const persistRef = useRef(persist)
+  persistRef.current = persist
+  useEffect(
+    () => () => {
+      clearTimeout(persistTimer.current)
+      if (pendingRatio.current !== null) persistRef.current(pendingRatio.current)
+    },
+    []
+  )
+
+  const commit = useCallback(
+    (next: number) => {
+      const clamped = clamp(next)
+      setRatio(clamped)
+      persistSoon(clamped)
+    },
+    [clamp, persistSoon]
   )
 
   // Listeners go on window, not the divider: the pointer routinely outruns a 4px target mid-drag,

--- a/apps/cockpit/src/components/shared/TabBar.tsx
+++ b/apps/cockpit/src/components/shared/TabBar.tsx
@@ -77,7 +77,7 @@ export function TabBar({
           disabled={tab.disabled}
           onClick={() => onTabChange(tab.id)}
           onKeyDown={(event) => handleKeyDown(event, index)}
-          className={`shrink-0 px-4 py-2 text-xs transition-colors duration-150 disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
+          className={`shrink-0 px-4 py-2 text-xs transition-colors duration-[var(--duration-fast)] disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
             activeTab === tab.id
               ? 'border-b-2 border-[var(--color-accent)] bg-[var(--color-accent-dim)]/30 font-bold text-[var(--color-accent)]'
               : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'

--- a/apps/cockpit/src/components/shared/TextArea.tsx
+++ b/apps/cockpit/src/components/shared/TextArea.tsx
@@ -13,7 +13,7 @@ const SIZE_CLASSES: Record<TextAreaSize, string> = {
 }
 
 const BASE_CLASSES =
-  'w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] outline-none transition-colors duration-150 focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] disabled:pointer-events-none disabled:opacity-50'
+  'w-full rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] outline-none transition-colors duration-[var(--duration-fast)] focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] disabled:pointer-events-none disabled:opacity-50'
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ size = 'sm', monospace = false, className = '', ...props }, ref) => (

--- a/apps/cockpit/src/components/shared/Toggle.tsx
+++ b/apps/cockpit/src/components/shared/Toggle.tsx
@@ -18,12 +18,12 @@ export function Toggle({ checked, onChange, label, disabled = false }: TogglePro
         aria-checked={checked}
         disabled={disabled}
         onClick={() => onChange(!checked)}
-        className={`relative h-[18px] w-8 shrink-0 rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
+        className={`relative h-[18px] w-8 shrink-0 rounded-full transition-colors duration-[var(--duration-panel)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
           checked ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-border)]'
         } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
       >
         <span
-          className={`absolute top-[2px] left-[2px] h-[14px] w-[14px] rounded-full bg-[var(--color-surface-raised)] shadow-sm transition-transform duration-200 ${
+          className={`absolute top-[2px] left-[2px] h-[14px] w-[14px] rounded-full bg-[var(--color-surface-raised)] shadow-sm transition-transform duration-[var(--duration-panel)] ${
             checked ? 'translate-x-[14px]' : 'translate-x-0'
           }`}
         />

--- a/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SplitPane.test.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { SplitPane } from '@/components/shared/SplitPane'
 
@@ -55,13 +55,43 @@ describe('SplitPane', () => {
   })
 
   it('persists the ratio under the storage key and restores it', () => {
+    vi.useFakeTimers()
     const { unmount } = renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
     fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+
+    // The write waits for the resize to settle — a drag commits on every
+    // mousemove, and localStorage is a synchronous main-thread call.
+    expect(window.localStorage.getItem('cockpit.split.demo')).toBeNull()
+    act(() => void vi.advanceTimersByTime(500))
     expect(window.localStorage.getItem('cockpit.split.demo')).toBe('0.5200')
     unmount()
+    vi.useRealTimers()
 
     renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
     expect(screen.getByRole('separator')).toHaveAttribute('aria-valuenow', '52')
+  })
+
+  it('flushes a pending ratio when the split unmounts mid-settle', () => {
+    vi.useFakeTimers()
+    const { unmount } = renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+    // Closing the tool inside the debounce window must not discard the resize.
+    unmount()
+    vi.useRealTimers()
+
+    expect(window.localStorage.getItem('cockpit.split.demo')).toBe('0.5200')
+  })
+
+  it('does not write again after the pending ratio is flushed', () => {
+    vi.useFakeTimers()
+    const { unmount } = renderSplit({ defaultRatio: 0.5, storageKey: 'demo' })
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+    act(() => void vi.advanceTimersByTime(500))
+    window.localStorage.setItem('cockpit.split.demo', 'sentinel')
+    unmount()
+    vi.useRealTimers()
+
+    expect(window.localStorage.getItem('cockpit.split.demo')).toBe('sentinel')
   })
 
   it('does not persist without a storage key', () => {

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -596,7 +596,7 @@ export function NotesDrawer() {
       // re-aiming an eased 200ms animation at a target that had already moved —
       // the edge trailed the cursor and arrived in visible steps. Same fix, and
       // same reason, as the sidebar.
-      className={`relative flex shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
+      className={`shell-panel relative flex shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
         resizing ? '' : 'transition-[width,opacity] duration-[var(--duration-panel)]'
       } ${
         drawerOpen ? 'opacity-100' : 'pointer-events-none w-0 overflow-hidden border-l-0 opacity-0'

--- a/apps/cockpit/src/components/shell/NotesDrawer.tsx
+++ b/apps/cockpit/src/components/shell/NotesDrawer.tsx
@@ -392,6 +392,7 @@ export function NotesDrawer() {
   const setPendingSendTo = useUiStore((state) => state.setPendingSendTo)
 
   const [width, setWidth] = useState(() => clampWidth(savedWidth))
+  const [resizing, setResizing] = useState(false)
   const [activeTab, setActiveTab] = useState('notes')
   const [search, setSearch] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -456,6 +457,7 @@ export function NotesDrawer() {
     (event: React.MouseEvent) => {
       event.preventDefault()
       dragState.current = { startX: event.clientX, startWidth: width }
+      setResizing(true)
       const onMove = (moveEvent: MouseEvent) => {
         if (!dragState.current) return
         setWidth(
@@ -468,6 +470,7 @@ export function NotesDrawer() {
           dragState.current.startWidth + dragState.current.startX - upEvent.clientX
         )
         dragState.current = null
+        setResizing(false)
         document.removeEventListener('mousemove', onMove)
         document.removeEventListener('mouseup', onUp)
         document.body.style.cursor = ''
@@ -588,7 +591,14 @@ export function NotesDrawer() {
       // order, so a screen reader still announces a search field and a note list that aren't
       // there. `inert` is the one switch that covers focus, activation and AT together.
       inert={!drawerOpen}
-      className={`relative flex shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] transition-[width,opacity] duration-200 ease-in-out ${
+      // The open/close slide is animated; a drag is not. Setting an inline width
+      // does not opt out of a `transition-[width]` class, so every mousemove was
+      // re-aiming an eased 200ms animation at a target that had already moved —
+      // the edge trailed the cursor and arrived in visible steps. Same fix, and
+      // same reason, as the sidebar.
+      className={`relative flex shrink-0 flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
+        resizing ? '' : 'transition-[width,opacity] duration-[var(--duration-panel)]'
+      } ${
         drawerOpen ? 'opacity-100' : 'pointer-events-none w-0 overflow-hidden border-l-0 opacity-0'
       }`}
       style={drawerOpen ? { width } : undefined}

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -37,6 +37,7 @@ import { Dialog } from '@/components/shared/Dialog'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Toggle } from '@/components/shared/Toggle'
 import { Select } from '@/components/shared/Select'
+import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ThemePicker } from '@/components/shell/ThemePicker'
 import { ALL_THEMES } from '@/lib/theme'
 import { getVersion } from '@tauri-apps/api/app'
@@ -238,6 +239,7 @@ function GeneralTab() {
   const update = useSettingsStore((s) => s.update)
   const theme = useSettingsStore((s) => s.theme)
   const alwaysOnTop = useSettingsStore((s) => s.alwaysOnTop)
+  const shellStyle = useSettingsStore((s) => s.shellStyle)
   const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed)
   const checkForUpdatesAutomatically = useSettingsStore((s) => s.checkForUpdatesAutomatically)
   const downloadUpdatesAutomatically = useSettingsStore((s) => s.downloadUpdatesAutomatically)
@@ -278,6 +280,23 @@ function GeneralTab() {
           Appearance mode for the app — hover or focus a swatch to preview it
         </p>
         <ThemePicker value={theme} onChange={(v) => void update('theme', v).catch(() => {})} />
+      </div>
+
+      <div>
+        <h4 className="mb-1 text-xs text-[var(--color-text)]">Shell layout</h4>
+        <p className="mb-2 text-2xs text-[var(--color-text-muted)]">
+          Floating insets the panels into cards; flush packs them edge to edge and gives you back
+          about 16px in each direction
+        </p>
+        <SegmentedControl
+          aria-label="Shell layout"
+          value={shellStyle}
+          options={[
+            { value: 'floating', label: 'Floating' },
+            { value: 'flush', label: 'Flush' },
+          ]}
+          onChange={(v) => void update('shellStyle', v).catch(() => {})}
+        />
       </div>
 
       <div className="space-y-1">
@@ -439,6 +458,7 @@ function DataTab() {
       const state = useSettingsStore.getState()
       const data: AppSettings = {
         theme: state.theme,
+        shellStyle: state.shellStyle,
         alwaysOnTop: state.alwaysOnTop,
         sidebarCollapsed: state.sidebarCollapsed,
         collapsedSidebarGroups: state.collapsedSidebarGroups,

--- a/apps/cockpit/src/components/shell/Sidebar.tsx
+++ b/apps/cockpit/src/components/shell/Sidebar.tsx
@@ -264,7 +264,7 @@ export function Sidebar() {
       // animating towards a target that moves every mousemove makes the edge
       // lag the cursor.
       style={{ width: sidebarCollapsed ? 40 : width }}
-      className={`font-ui relative flex shrink-0 flex-col overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
+      className={`shell-panel font-ui relative flex shrink-0 flex-col overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
         resizing ? '' : 'transition-[width] duration-[var(--duration-fast)]'
       }`}
     >

--- a/apps/cockpit/src/components/shell/Sidebar.tsx
+++ b/apps/cockpit/src/components/shell/Sidebar.tsx
@@ -264,8 +264,8 @@ export function Sidebar() {
       // animating towards a target that moves every mousemove makes the edge
       // lag the cursor.
       style={{ width: sidebarCollapsed ? 40 : width }}
-      className={`font-ui relative flex shrink-0 flex-col overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-surface)] ease-in-out ${
-        resizing ? '' : 'transition-[width] duration-150'
+      className={`font-ui relative flex shrink-0 flex-col overflow-hidden border-r border-[var(--color-border)] bg-[var(--color-surface)] ease-[var(--ease-in-out)] ${
+        resizing ? '' : 'transition-[width] duration-[var(--duration-fast)]'
       }`}
     >
       {/* Only one of the two layouts is ever mounted. Rendering both at once

--- a/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarCollapsedGroup.tsx
@@ -110,7 +110,7 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
         onClick={() => setFlyoutOpen(!flyoutOpen)}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className={`flex h-8 w-8 items-center justify-center rounded-sm border-l-2 transition-colors duration-150 focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
+        className={`flex h-8 w-8 items-center justify-center rounded-sm border-l-2 transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
           isActiveGroup
             ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)] text-[var(--color-accent)]'
             : flyoutOpen
@@ -131,7 +131,7 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
         createPortal(
           <div
             style={tooltipStyle}
-            className="font-ui pointer-events-none rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[var(--color-text)] shadow-md"
+            className="font-ui animate-pop-in pointer-events-none rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[var(--color-text)] shadow-md"
           >
             {group.label}
           </div>,
@@ -144,7 +144,7 @@ export function SidebarCollapsedGroup({ group, tools, isActiveGroup }: Props) {
           <div
             ref={flyoutRef}
             style={flyoutStyle}
-            className="font-ui min-w-[160px] overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] py-1 shadow-lg"
+            className="font-ui animate-pop-in min-w-[160px] overflow-hidden rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] py-1 shadow-lg"
           >
             <SectionLabel as="div" className="px-2.5 pb-1 pt-1">
               {group.label}

--- a/apps/cockpit/src/components/shell/SidebarGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarGroup.tsx
@@ -106,7 +106,7 @@ export function SidebarGroup({
         onKeyDown={handleKeyDown}
         aria-expanded={!collapsed}
         data-sidebar-group={group.id}
-        className="w-full rounded px-2 py-1 transition-colors duration-150 hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)]"
+        className="w-full rounded px-2 py-1 transition-colors duration-[var(--duration-fast)] hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring-inset)]"
       >
         {/* SectionLabel rather than a bespoke type treatment, so group headers
             and the Pinned/Recent headers above them are one style instead of
@@ -117,7 +117,7 @@ export function SidebarGroup({
         >
           <CaretRightIcon
             size={12}
-            className={`shrink-0 transition-transform duration-200 ease-in-out ${collapsed ? '' : 'rotate-90'}`}
+            className={`shrink-0 transition-transform duration-[var(--duration-panel)] ease-[var(--ease-in-out)] ${collapsed ? '' : 'rotate-90'}`}
           />
           <span className="flex-1 text-left">{group.label}</span>
         </SectionLabel>
@@ -125,7 +125,7 @@ export function SidebarGroup({
 
       {/* CSS grid trick: animates height without knowing the exact pixel value */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'}`}
+        className={`grid transition-[grid-template-rows] duration-[var(--duration-panel)] ease-[var(--ease-in-out)] ${collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'}`}
       >
         <div className="overflow-hidden">
           <div className="flex flex-col gap-1 px-1 pb-0.5 pt-0.5">

--- a/apps/cockpit/src/components/shell/StatusBar.tsx
+++ b/apps/cockpit/src/components/shell/StatusBar.tsx
@@ -71,7 +71,7 @@ export function StatusBar() {
   const themeLabel = theme === 'system' ? 'System' : (THEME_META[theme]?.shortLabel ?? theme)
 
   return (
-    <div className="font-ui flex h-7 shrink-0 items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-xs">
+    <div className="shell-chrome font-ui flex h-7 shrink-0 items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-xs">
       {/* Left: active tool + last action */}
       <div className="flex items-center gap-3">
         <span className="font-medium text-[var(--color-text-muted)]">{tool?.name ?? ''}</span>

--- a/apps/cockpit/src/components/shell/ThemePicker.tsx
+++ b/apps/cockpit/src/components/shell/ThemePicker.tsx
@@ -122,7 +122,7 @@ function ThemeChip({
           onArrow(e.key)
         }
       }}
-      className="font-ui flex flex-col gap-1 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 text-left outline-none transition-colors duration-150 hover:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)]"
+      className="font-ui flex flex-col gap-1 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 text-left outline-none transition-colors duration-[var(--duration-fast)] hover:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)]"
     >
       <span className="relative">
         {theme === 'system' ? <SystemSwatch /> : <Swatch effective={getEffectiveTheme(theme)} />}

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -47,7 +47,7 @@ export function TitleBar() {
 
   return (
     <div
-      className={`font-ui relative flex h-11 shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] ${isMac ? 'pl-[78px]' : 'pl-2'} pr-2`}
+      className={`shell-chrome font-ui relative flex h-11 shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] ${isMac ? 'pl-[78px]' : 'pl-2'} pr-2`}
     >
       <div
         data-tauri-drag-region

--- a/apps/cockpit/src/components/shell/WindowControls.tsx
+++ b/apps/cockpit/src/components/shell/WindowControls.tsx
@@ -82,7 +82,7 @@ function TrafficLight({
       className={`flex h-3 w-3 items-center justify-center rounded-full text-black/60 ${FOCUS_RING}`}
       style={{ backgroundColor: dimmed ? 'var(--color-border)' : color }}
     >
-      <span className="opacity-0 transition-opacity duration-100 group-hover:opacity-100">
+      <span className="opacity-0 transition-opacity duration-[var(--duration-fast)] group-hover:opacity-100">
         {glyph}
       </span>
     </button>

--- a/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceEmptyState.tsx
@@ -31,7 +31,7 @@ function ChipRow({ label, tools, onSelect }: ChipRowProps) {
             type="button"
             onClick={() => onSelect(tool.id)}
             aria-label={`Open ${tool.name}`}
-            className="flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-3)] py-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text)] transition-colors duration-150 hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
+            className="flex items-center gap-[var(--space-1)] rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] px-[var(--space-3)] py-[var(--space-1)] text-[var(--text-xs)] text-[var(--color-text)] transition-colors duration-[var(--duration-fast)] hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
           >
             <span className="flex items-center" aria-hidden="true">
               {tool.icon}

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -88,6 +88,24 @@ describe('NotesDrawer', () => {
     )
   })
 
+  // The width transition is for the open/close slide. An inline width does not opt out of it, so
+  // while it was left on during a drag every mousemove re-aimed a 200ms eased animation at a
+  // target that had already moved: the edge trailed the cursor and arrived in steps. Measured in
+  // Chromium the computed transition-duration was 0.2s throughout the drag and the drawer lagged
+  // the pointer; suppressed, it tracks exactly. jsdom computes no transitions, hence the class
+  // assertion rather than a style one.
+  it('drops the width transition while the drawer is being dragged', () => {
+    render(<NotesDrawer />)
+    const drawer = screen.getByRole('complementary', { name: 'Notes and history' })
+    expect(drawer.className).toContain('transition-[width,opacity]')
+
+    fireEvent.mouseDown(screen.getByRole('separator', { name: 'Resize notes drawer' }))
+    expect(drawer.className).not.toContain('transition-[width,opacity]')
+
+    fireEvent.mouseUp(document)
+    expect(drawer.className).toContain('transition-[width,opacity]')
+  })
+
   it('uses labelled, larger color swatches while editing', () => {
     render(<NotesDrawer />)
 

--- a/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/NotesDrawer.test.tsx
@@ -88,6 +88,16 @@ describe('NotesDrawer', () => {
     )
   })
 
+  // The floating shell layout is applied entirely from styles/shell.css, keyed on this
+  // class. jsdom applies no stylesheet, so a rename here would otherwise only surface
+  // as "the notes drawer stopped being a card" in a running app.
+  it('carries the shell-panel hook the floating layout is keyed on', () => {
+    render(<NotesDrawer />)
+    expect(screen.getByRole('complementary', { name: 'Notes and history' })).toHaveClass(
+      'shell-panel'
+    )
+  })
+
   // The width transition is for the open/close slide. An inline width does not opt out of it, so
   // while it was left on during a drag every mousemove re-aimed a 200ms eased animation at a
   // target that had already moved: the edge trailed the cursor and arrived in steps. Measured in

--- a/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/SettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SettingsPanel } from '@/components/shell/SettingsPanel'
 import { useHistoryStore } from '@/stores/history.store'
@@ -29,9 +29,13 @@ vi.mock('@tauri-apps/api/window', () => ({
   }),
 }))
 
+// The store is a module singleton and one test below swaps `update` for a spy. Without
+// restoring it here, the next test's "real" update call is the previous test's mock.
+const realSettingsUpdate = useSettingsStore.getState().update
+
 beforeEach(() => {
   vi.clearAllMocks()
-  useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: true })
+  useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: true, update: realSettingsUpdate })
   useNotesStore.setState({
     notes: [
       {
@@ -152,6 +156,20 @@ describe('SettingsPanel', () => {
 
     expect(screen.getByText('MCP server stopped unexpectedly')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Start' })).toBeEnabled()
+  })
+
+  it('switches the shell layout between floating and flush', async () => {
+    const update = vi.fn().mockResolvedValue(true)
+    useSettingsStore.setState({ update })
+
+    render(<SettingsPanel />)
+
+    // SegmentedControl exposes its segments as a radiogroup, not buttons.
+    const group = screen.getByRole('radiogroup', { name: 'Shell layout' })
+    expect(within(group).getByRole('radio', { name: 'Floating' })).toBeChecked()
+
+    fireEvent.click(within(group).getByRole('radio', { name: 'Flush' }))
+    await waitFor(() => expect(update).toHaveBeenCalledWith('shellStyle', 'flush'))
   })
 
   it('imports settings that use newer registered themes', async () => {

--- a/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
@@ -347,6 +347,13 @@ describe('Sidebar — only one tree is live at a time', () => {
       expect(document.querySelectorAll(`[data-sidebar-item="${tool.id}"]`)).toHaveLength(0)
     }
   })
+
+  // styles/shell.css keys the whole floating layout on this class, and jsdom applies no
+  // stylesheet — without this, renaming it fails silently everywhere but the running app.
+  it('carries the shell-panel hook the floating layout is keyed on', () => {
+    render(<Sidebar />)
+    expect(document.querySelector('aside')).toHaveClass('shell-panel')
+  })
 })
 
 // ── Sidebar filter box ────────────────────────────────────────────

--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -87,7 +87,41 @@ body,
   }
 }
 .animate-fade-in {
-  animation: fade-in 150ms ease-out;
+  animation: fade-in var(--duration-fast) var(--ease-out);
+}
+
+/* The counterpart for a surface that opens from a trigger rather than over the
+   whole app — flyouts, hover tooltips, dropdowns. It scales from 98% instead of
+   sliding 8px, so the surface reads as growing out of its trigger, and it stays
+   on transform/opacity, which the compositor animates without layout. */
+@keyframes pop-in {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.animate-pop-in {
+  animation: pop-in var(--duration-fast) var(--ease-out);
+}
+
+/* Opacity only, for a surface whose position already depends on a transform
+   (e.g. a toolbar centred with -translate-x-1/2). A keyframe that sets
+   `transform` replaces that utility for the length of the animation and the
+   surface flies in from the wrong place. */
+@keyframes fade-in-place {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.animate-fade-in-place {
+  animation: fade-in-place var(--duration-fast) var(--ease-out);
 }
 
 @keyframes spin {
@@ -96,7 +130,7 @@ body,
   }
 }
 .animate-spin {
-  animation: spin 700ms linear infinite;
+  animation: spin var(--duration-spin) linear infinite;
 }
 /* Markdown & Syntax Highlighting */
 .prose {

--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -20,6 +20,7 @@
 @import 'tailwindcss';
 @import './styles/tokens.css';
 @import './styles/highlight-themes.css';
+@import './styles/shell.css';
 
 @theme {
   --font-pixel: 'Silkscreen', monospace;

--- a/apps/cockpit/src/stores/settings.store.ts
+++ b/apps/cockpit/src/stores/settings.store.ts
@@ -17,6 +17,7 @@ type SettingsStore = AppSettings & {
 // object — that keeps the persisted payload and the type in permanent sync.
 const APP_SETTINGS_KEY_MAP: Record<keyof AppSettings, true> = {
   theme: true,
+  shellStyle: true,
   alwaysOnTop: true,
   sidebarCollapsed: true,
   collapsedSidebarGroups: true,

--- a/apps/cockpit/src/styles/shell.css
+++ b/apps/cockpit/src/styles/shell.css
@@ -1,0 +1,65 @@
+/* ─── Shell layout modes ───────────────────────────────────────────────────
+ *
+ * `flush` (the original): sidebar, workspace and notes drawer meet edge to edge and
+ * are separated by 1px borders. Densest option, and the default for anyone who wants
+ * every pixel to be content.
+ *
+ * `floating`: the same three panels inset from the window edge with a gutter between
+ * them, each with a radius, a hairline border and a shadow, sitting on a recessed
+ * canvas. Costs ~16px of width and ~16px of height.
+ *
+ * The whole layout lives in this one file rather than as ternaries across five shell
+ * components, for two reasons. Flush mode then costs nothing at all — with
+ * `data-shell="flush"` not one rule below matches — and the shell's geometry is one
+ * file to read instead of five.
+ *
+ * Selectors are attribute + class (specificity 0,2,0), which beats Tailwind's
+ * single-class utilities without a single `!important`.
+ */
+
+[data-shell='floating'] .shell-canvas {
+  background: var(--color-surface-sunken);
+}
+
+/* Spacing is margin, not `gap`, deliberately: flex `gap` applies between items
+   whatever their size, so a closed notes drawer — which is `width: 0`, not unmounted,
+   so that opening it can animate — would still hold a gutter open next to nothing. */
+[data-shell='floating'] .shell-row {
+  padding: var(--space-2);
+}
+
+[data-shell='floating'] .shell-panel + .shell-panel {
+  margin-left: var(--space-2);
+}
+
+[data-shell='floating'] .shell-panel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  /* Required, not cosmetic: Monaco and the tool panes paint opaque square corners
+     that otherwise sit outside the radius. */
+  overflow: hidden;
+  /* The hairline border is doing load-bearing work and shouldn't be dropped for a
+     shadow-only card, however much better that looks in Midnight. Several light
+     themes put --color-surface-sunken within a couple of percent of --color-bg
+     (github-light is #fbfcfd against #ffffff), and there the shadow alone is
+     invisible — the card silently stops existing on maybe a third of the 23 themes.
+     The border carries those; the shadow carries the dark ones. */
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--color-shadow) 22%, transparent),
+    0 12px 32px -14px var(--color-shadow);
+}
+
+/* A closed panel must contribute nothing — no gutter, no 2px of border, and no
+   shadow, which a zero-width box still paints. */
+[data-shell='floating'] .shell-panel[inert] {
+  margin-left: 0;
+  border-width: 0;
+  box-shadow: none;
+}
+
+/* Title bar and status bar stop drawing their own surface and dividers, and just let
+   the canvas through. */
+[data-shell='floating'] .shell-chrome {
+  background: transparent;
+  border-color: transparent;
+}

--- a/apps/cockpit/src/styles/tokens.css
+++ b/apps/cockpit/src/styles/tokens.css
@@ -63,6 +63,10 @@
   --radius-sm: 0.125rem;
   --radius-md: 0.25rem;
   --radius-lg: 0.5rem;
+  /* Shell panels in the floating layout only. At 8px a full-height panel still reads
+     as a clipped rectangle rather than a card; nothing smaller than a panel should
+     use this. */
+  --radius-xl: 0.75rem;
 
   --text-2xs: 0.625rem;
   --text-xs: 0.75rem;

--- a/apps/cockpit/src/styles/tokens.css
+++ b/apps/cockpit/src/styles/tokens.css
@@ -83,6 +83,49 @@
   --focus-ring-inset: inset 0 0 0 1px var(--color-bg), inset 0 0 0 3px var(--color-accent);
 }
 
+/* ─── Motion ───────────────────────────────────────────────────────────────
+   Three durations and two easings, global like the other base scales. The
+   values are the ones the app had already converged on by hand (150ms for
+   feedback, 200ms for structure, 700ms for the spinner); naming them stops
+   the next component from inventing a fourth.
+
+     --duration-fast   150ms  Hover, focus, colour and opacity feedback.
+                              Also the enter animation for every overlay.
+     --duration-panel  200ms  A surface changing size or position: drawer
+                              open/close, accordion, toggle knob, chevron.
+     --duration-spin   700ms  The one continuous loop (loading spinners).
+
+     --ease-out        Anything entering, opening or growing — decelerates
+                       into place, so the surface feels caught rather than
+                       driven.
+     --ease-in-out     Reversible state a user can drive both ways (toggle
+                       knob, chevron rotation).
+
+   Use them through Tailwind arbitrary values:
+   `duration-[var(--duration-fast)] ease-[var(--ease-out)]`.
+
+   Two rules that are not stylistic:
+
+   1. Never transition a property a drag writes on every mousemove. A live
+      drag re-aims the animation each frame and the surface trails the
+      cursor in visible steps. Suppress the transition class while
+      `resizing` is true — see Sidebar.tsx and NotesDrawer.tsx.
+   2. Prefer transform/opacity over width/height/top/left. Where a layout
+      property is unavoidable (drawer width, accordion rows) keep it at
+      --duration-panel or shorter.
+
+   Reduced motion is handled globally in index.css; nothing here needs to
+   repeat that check.
+   ────────────────────────────────────────────────────────────────────── */
+:root {
+  --duration-fast: 150ms;
+  --duration-panel: 200ms;
+  --duration-spin: 700ms;
+
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .midnight {
   --color-bg: #0a0f1c;
   --color-surface: #1a1f3a;

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -148,12 +148,55 @@ describe('JsonTools', () => {
     expect(screen.getByText('No match for this path')).toBeInTheDocument()
   })
 
-  it('explains why the table view is unavailable instead of showing an empty grid', () => {
+  it('tabulates an array of primitives by index instead of refusing to render', () => {
     renderTool(JsonTools)
     typeJson('[1,2,3]')
     showView('Table')
 
-    expect(screen.getByText('Table view needs an array of objects')).toBeInTheDocument()
+    const table = within(screen.getByRole('region', { name: 'Table view' }))
+    expect(table.getAllByRole('rowheader').map((h) => h.textContent)).toEqual(['0', '1', '2'])
+    expect(table.getAllByRole('cell').map((c) => c.textContent)).toEqual(['1', '2', '3'])
+  })
+
+  it('tabulates a nested object document all the way down', () => {
+    renderTool(JsonTools)
+    typeJson(
+      '{"properties":{"age":{"minimum":0,"type":"integer"},"name":{"type":"string"}},"required":["name"],"type":"object"}'
+    )
+    showView('Table')
+
+    const table = within(screen.getByRole('region', { name: 'Table view' }))
+    // Top-level keys become row headers, and so do the keys of every nested object.
+    const headers = table.getAllByRole('rowheader').map((h) => h.textContent)
+    expect(headers).toEqual(
+      expect.arrayContaining(['properties', 'required', 'type', 'age', 'name', 'minimum'])
+    )
+    expect(screen.getByText('3 fields')).toBeInTheDocument()
+  })
+
+  it('copies a leaf value from a nested table with the keyboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    renderTool(JsonTools)
+    typeJson('{"type":"object"}')
+    showView('Table')
+
+    const table = within(screen.getByRole('region', { name: 'Table view' }))
+    fireEvent.click(table.getByRole('button', { name: 'Copy value object' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('object'))
+  })
+
+  it('marks a key missing from one record apart from a null value', () => {
+    renderTool(JsonTools)
+    // A mixed array is not a record list, so it lands in the nested renderer.
+    typeJson('[{"a":1},[{"a":null},{"b":2}]]')
+    showView('Table')
+
+    const table = within(screen.getByRole('region', { name: 'Table view' }))
+    // Row 0 has no "b", row 1 has no "a".
+    expect(table.getAllByText('—')).toHaveLength(2)
+    expect(table.getByText('null')).toBeInTheDocument()
   })
 
   it('sorts table columns and exposes the direction to assistive tech', () => {

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -199,6 +199,38 @@ describe('JsonTools', () => {
     expect(table.getByText('null')).toBeInTheDocument()
   })
 
+  it('asks before rendering a table for a document too large to open collapsed', () => {
+    renderTool(JsonTools)
+    // The tree opens collapsed above 500 keys; the table has no equivalent, so it
+    // would otherwise mount a DOM node per key the instant the view is selected.
+    const rows = Array.from({ length: 300 }, (_, i) => ({ a: i, b: i }))
+    typeJson(JSON.stringify(rows))
+    showView('Table')
+
+    const pane = within(screen.getByRole('region', { name: 'Table view' }))
+    expect(pane.getByText('Large document')).toBeInTheDocument()
+    expect(pane.queryByRole('table')).not.toBeInTheDocument()
+
+    fireEvent.click(pane.getByRole('button', { name: 'Render anyway' }))
+    expect(pane.getByRole('table')).toBeInTheDocument()
+  })
+
+  it('stops nesting tables at a fixed depth instead of recursing without a bound', () => {
+    renderTool(JsonTools)
+    // 40 levels of nesting: unbounded, this recurses once per level during render,
+    // and a deep enough document takes the app down rather than just the pane.
+    let deep = JSON.stringify({ leaf: 1 })
+    for (let i = 0; i < 40; i += 1) deep = `{"a":${deep}}`
+    typeJson(deep)
+    showView('Table')
+
+    // Deep but narrow: 41 keys, so the large-document prompt does not apply.
+    const pane = within(screen.getByRole('region', { name: 'Table view' }))
+    // The tail below the cap is printed as compact JSON, so nothing is hidden.
+    expect(pane.getAllByRole('table')).toHaveLength(20)
+    expect(pane.getByRole('button', { name: /^Copy value \{"a":/ })).toBeInTheDocument()
+  })
+
   it('sorts table columns and exposes the direction to assistive tech', () => {
     renderTool(JsonTools)
     typeJson('[{"name":"b","qty":2},{"name":"a","qty":10}]')

--- a/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
+++ b/apps/cockpit/src/tools/hash-generator/HashGenerator.tsx
@@ -272,7 +272,7 @@ export default function HashGenerator() {
               }}
               onDragLeave={() => setIsDragOver(false)}
               onDrop={handleDrop}
-              className={`flex flex-col items-center justify-center gap-2 rounded-[var(--radius-md)] border border-dashed p-6 transition-colors duration-150 ${
+              className={`flex flex-col items-center justify-center gap-2 rounded-[var(--radius-md)] border border-dashed p-6 transition-colors duration-[var(--duration-fast)] ${
                 isDragOver
                   ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)]/30'
                   : 'border-[var(--color-border)]'
@@ -305,7 +305,7 @@ export default function HashGenerator() {
                       className="h-1 w-48 overflow-hidden rounded-full bg-[var(--color-surface-sunken)]"
                     >
                       <div
-                        className="h-full bg-[var(--color-accent)] transition-[width] duration-150"
+                        className="h-full bg-[var(--color-accent)] transition-[width] duration-[var(--duration-fast)]"
                         style={{ width: `${fileProgress * 100}%` }}
                       />
                     </div>

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -284,11 +284,21 @@ export function queryJsonPath(data: unknown, path: string): JsonPathResult {
   return { found: true, value: current }
 }
 
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 export function isTabularJsonArray(data: unknown): data is Record<string, unknown>[] {
-  return (
-    Array.isArray(data) &&
-    data.every((item) => item !== null && typeof item === 'object' && !Array.isArray(item))
-  )
+  return Array.isArray(data) && data.every(isJsonRecord)
+}
+
+/** Column order is first-seen across every row, so sparse records still line up. */
+function unionKeys(rows: Record<string, unknown>[]): string[] {
+  const keys = new Set<string>()
+  for (const row of rows) {
+    for (const key of Object.keys(row)) keys.add(key)
+  }
+  return Array.from(keys)
 }
 
 function toText(value: unknown): string {
@@ -775,10 +785,8 @@ function InspectorPane({
                 )}
               </>
             )}
-            {view === 'table' && parsed.status === 'valid' && tabular && (
-              <span className="text-2xs text-[var(--color-text-muted)]">
-                {data.length} row{data.length === 1 ? '' : 's'}
-              </span>
+            {view === 'table' && parsed.status === 'valid' && tableSummary(data) && (
+              <span className="text-2xs text-[var(--color-text-muted)]">{tableSummary(data)}</span>
             )}
           </>
         }
@@ -808,11 +816,12 @@ function InspectorPane({
           ) : tabular ? (
             <JsonTable data={data} onCopy={onCopy} />
           ) : (
-            <EmptyState
-              size="sm"
-              title="Table view needs an array of objects"
-              description="This document is not a list of records — the tree view shows it in full."
-            />
+            // Anything that is not a list of records still has a table shape:
+            // objects become key/value rows and arrays become indexed rows,
+            // nested the whole way down.
+            <div className="p-3">
+              <NestedJsonValue value={data} />
+            </div>
           ))}
       </div>
     </section>
@@ -991,13 +1000,7 @@ function JsonTable({ data, onCopy }: { data: Record<string, unknown>[]; onCopy: 
   const cellRefs = useRef(new Map<string, HTMLTableCellElement>())
   const focusPending = useRef(false)
 
-  const columns = useMemo(() => {
-    const keys = new Set<string>()
-    for (const row of data) {
-      for (const key of Object.keys(row)) keys.add(key)
-    }
-    return Array.from(keys)
-  }, [data])
+  const columns = useMemo(() => unionKeys(data), [data])
 
   const rows = useMemo(() => {
     if (!sort) return data
@@ -1141,6 +1144,147 @@ function JsonTable({ data, onCopy }: { data: Record<string, unknown>[]; onCopy: 
                 </td>
               )
             })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Nested Table View
+//
+// A document that is not a list of records is still tabular: an object is a
+// key/value table and an array is an indexed one, with every value recursing.
+// The flat grid above stays in charge of record arrays because it owns the
+// sorting and the roving cell cursor, neither of which nests.
+// ---------------------------------------------------------------------------
+
+const NESTED_TABLE_CLASS = 'w-full border-collapse text-xs font-mono'
+const NESTED_CELL_CLASS = 'border border-[var(--color-border)] px-2 py-1 align-top'
+const NESTED_HEADER_CLASS = `${NESTED_CELL_CLASS} bg-[var(--color-surface)] text-left font-bold whitespace-nowrap text-[var(--color-accent)]`
+
+function tableSummary(data: unknown): string | null {
+  if (Array.isArray(data)) return `${data.length} row${data.length === 1 ? '' : 's'}`
+  if (isJsonRecord(data)) {
+    const count = Object.keys(data).length
+    return `${count} field${count === 1 ? '' : 's'}`
+  }
+  return null
+}
+
+function JsonLeaf({ value }: { value: unknown }) {
+  const copy = useCopyToClipboard()
+  const text = toText(value)
+  const className =
+    value === null
+      ? 'text-[var(--color-text-muted)]'
+      : typeof value === 'boolean'
+        ? 'text-[var(--color-warning)]'
+        : typeof value === 'number'
+          ? 'text-[var(--color-accent)]'
+          : 'text-[var(--color-success)]'
+
+  return (
+    <TreeValueButton
+      className={className}
+      onClick={() => void copy(text, { success: 'Copied value' })}
+      label={`Copy value ${text}`}
+    >
+      {/* An empty string would otherwise render as a cell with no target to click. */}
+      {text === '' ? '""' : text}
+    </TreeValueButton>
+  )
+}
+
+function EmptyContainer({ children }: { children: string }) {
+  return <span className="text-[var(--color-text-muted)]">{children}</span>
+}
+
+function NestedJsonValue({ value }: { value: unknown }) {
+  if (value === null || typeof value !== 'object') return <JsonLeaf value={value} />
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <EmptyContainer>[]</EmptyContainer>
+    return isTabularJsonArray(value) && unionKeys(value).length > 0 ? (
+      <RecordArrayTable rows={value} />
+    ) : (
+      <IndexedArrayTable items={value} />
+    )
+  }
+
+  const entries = Object.entries(value)
+  if (entries.length === 0) return <EmptyContainer>{'{}'}</EmptyContainer>
+
+  return (
+    <table className={NESTED_TABLE_CLASS}>
+      <tbody>
+        {entries.map(([key, child]) => (
+          <tr key={key}>
+            <th scope="row" className={NESTED_HEADER_CLASS}>
+              {key}
+            </th>
+            <td className={NESTED_CELL_CLASS}>
+              <NestedJsonValue value={child} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function RecordArrayTable({ rows }: { rows: Record<string, unknown>[] }) {
+  const columns = unionKeys(rows)
+  return (
+    <table className={NESTED_TABLE_CLASS}>
+      <thead>
+        <tr>
+          <th scope="col" className={NESTED_HEADER_CLASS}>
+            #
+          </th>
+          {columns.map((col) => (
+            <th key={col} scope="col" className={NESTED_HEADER_CLASS}>
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={index}>
+            <th scope="row" className={NESTED_HEADER_CLASS}>
+              {index}
+            </th>
+            {columns.map((col) => (
+              <td key={col} className={NESTED_CELL_CLASS}>
+                {/* A key absent from this record is not the same as one holding null. */}
+                {col in row ? (
+                  <NestedJsonValue value={row[col]} />
+                ) : (
+                  <EmptyContainer>—</EmptyContainer>
+                )}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function IndexedArrayTable({ items }: { items: unknown[] }) {
+  return (
+    <table className={NESTED_TABLE_CLASS}>
+      <tbody>
+        {items.map((item, index) => (
+          <tr key={index}>
+            <th scope="row" className={NESTED_HEADER_CLASS}>
+              {index}
+            </th>
+            <td className={NESTED_CELL_CLASS}>
+              <NestedJsonValue value={item} />
+            </td>
           </tr>
         ))}
       </tbody>

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -59,6 +59,22 @@ type JsonToolsState = {
 /** Above this many keys the tree starts collapsed — expanding is one click. */
 const LARGE_DOCUMENT_KEYS = 500
 
+/**
+ * Table view has no collapsing to fall back on: every key becomes a DOM node the
+ * moment the view opens, and the nested renderer recurses once per level. Above
+ * this many keys it asks first rather than freezing the pane on a document the
+ * user only meant to glance at.
+ */
+const LARGE_TABLE_KEYS = LARGE_DOCUMENT_KEYS
+
+/**
+ * Nested tables stop nesting here and print the remaining subtree as compact
+ * JSON. Two reasons: past ~20 levels each cell is a few pixels wide and unreadable
+ * anyway, and a hand-built document can nest deeply enough to overflow the render
+ * stack, which takes the whole app down rather than just the pane.
+ */
+const MAX_NESTED_TABLE_DEPTH = 20
+
 const VIEW_OPTIONS = [
   { value: 'source' as const, label: 'Source' },
   { value: 'tree' as const, label: 'Tree' },
@@ -739,6 +755,12 @@ function InspectorPane({
   const autoExpanded = keyCount <= LARGE_DOCUMENT_KEYS
   const expanded = expandAll ?? autoExpanded
 
+  // Deliberately not reset when the document changes: the key count moves on every
+  // keystroke, so re-asking on each edit would put the prompt back in the way of
+  // someone who has already said they want to see this document.
+  const [tableConfirmed, setTableConfirmed] = useState(false)
+  const tableTooLarge = keyCount > LARGE_TABLE_KEYS && !tableConfirmed
+
   const setExpansion = (next: boolean) => {
     setExpandAll(next)
     setTreeKey((k) => k + 1)
@@ -813,6 +835,20 @@ function InspectorPane({
             <div className="p-3 font-mono text-xs">
               <JsonTree key={treeKey} data={data} path="$" defaultExpanded={expanded} />
             </div>
+          ) : tableTooLarge ? (
+            // The tree can open collapsed; a table cannot, so this is the equivalent
+            // brake — every key would become a DOM node the moment the view opens.
+            <EmptyState
+              size="sm"
+              icon={WarningCircleIcon}
+              title="Large document"
+              description={`${keyCount} keys will all render at once. Tree view opens this instantly.`}
+              action={
+                <Button variant="secondary" size="sm" onClick={() => setTableConfirmed(true)}>
+                  Render anyway
+                </Button>
+              }
+            />
           ) : tabular ? (
             <JsonTable data={data} onCopy={onCopy} />
           ) : (
@@ -1201,15 +1237,32 @@ function EmptyContainer({ children }: { children: string }) {
   return <span className="text-[var(--color-text-muted)]">{children}</span>
 }
 
-function NestedJsonValue({ value }: { value: unknown }) {
+/** The tail of a subtree too deep to keep tabulating, still copyable in full. */
+function DeepValue({ value }: { value: unknown }) {
+  const copy = useCopyToClipboard()
+  const text = JSON.stringify(value)
+
+  return (
+    <TreeValueButton
+      className="text-[var(--color-text-muted)]"
+      onClick={() => void copy(text, { success: 'Copied value' })}
+      label={`Copy value ${text}`}
+    >
+      {text}
+    </TreeValueButton>
+  )
+}
+
+function NestedJsonValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
   if (value === null || typeof value !== 'object') return <JsonLeaf value={value} />
+  if (depth >= MAX_NESTED_TABLE_DEPTH) return <DeepValue value={value} />
 
   if (Array.isArray(value)) {
     if (value.length === 0) return <EmptyContainer>[]</EmptyContainer>
     return isTabularJsonArray(value) && unionKeys(value).length > 0 ? (
-      <RecordArrayTable rows={value} />
+      <RecordArrayTable rows={value} depth={depth} />
     ) : (
-      <IndexedArrayTable items={value} />
+      <IndexedArrayTable items={value} depth={depth} />
     )
   }
 
@@ -1225,7 +1278,7 @@ function NestedJsonValue({ value }: { value: unknown }) {
               {key}
             </th>
             <td className={NESTED_CELL_CLASS}>
-              <NestedJsonValue value={child} />
+              <NestedJsonValue value={child} depth={depth + 1} />
             </td>
           </tr>
         ))}
@@ -1234,7 +1287,7 @@ function NestedJsonValue({ value }: { value: unknown }) {
   )
 }
 
-function RecordArrayTable({ rows }: { rows: Record<string, unknown>[] }) {
+function RecordArrayTable({ rows, depth }: { rows: Record<string, unknown>[]; depth: number }) {
   const columns = unionKeys(rows)
   return (
     <table className={NESTED_TABLE_CLASS}>
@@ -1260,7 +1313,7 @@ function RecordArrayTable({ rows }: { rows: Record<string, unknown>[] }) {
               <td key={col} className={NESTED_CELL_CLASS}>
                 {/* A key absent from this record is not the same as one holding null. */}
                 {col in row ? (
-                  <NestedJsonValue value={row[col]} />
+                  <NestedJsonValue value={row[col]} depth={depth + 1} />
                 ) : (
                   <EmptyContainer>—</EmptyContainer>
                 )}
@@ -1273,7 +1326,7 @@ function RecordArrayTable({ rows }: { rows: Record<string, unknown>[] }) {
   )
 }
 
-function IndexedArrayTable({ items }: { items: unknown[] }) {
+function IndexedArrayTable({ items, depth }: { items: unknown[]; depth: number }) {
   return (
     <table className={NESTED_TABLE_CLASS}>
       <tbody>
@@ -1283,7 +1336,7 @@ function IndexedArrayTable({ items }: { items: unknown[] }) {
               {index}
             </th>
             <td className={NESTED_CELL_CLASS}>
-              <NestedJsonValue value={item} />
+              <NestedJsonValue value={item} depth={depth + 1} />
             </td>
           </tr>
         ))}

--- a/apps/cockpit/src/types/models.ts
+++ b/apps/cockpit/src/types/models.ts
@@ -26,8 +26,16 @@ export type Theme =
   | 'tomorrow-night'
   | 'oceanic-next'
 
+/**
+ * `flush` packs the shell panels edge to edge, separated by 1px borders. `floating`
+ * insets them into cards on a recessed canvas, which costs about 16px in each
+ * direction — worth offering rather than imposing, in an app this dense.
+ */
+export type ShellStyle = 'flush' | 'floating'
+
 export type AppSettings = {
   theme: Theme
+  shellStyle: ShellStyle
   alwaysOnTop: boolean
   sidebarCollapsed: boolean
   collapsedSidebarGroups: ToolGroup[]
@@ -58,6 +66,7 @@ export type AppSettings = {
 
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'system',
+  shellStyle: 'floating',
   alwaysOnTop: false,
   sidebarCollapsed: false,
   collapsedSidebarGroups: [],

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -3,9 +3,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import nodeStdlibBrowser from 'vite-plugin-node-stdlib-browser'
 import { resolve } from 'path'
+import { tauriStubPlugin } from './scripts/vite-plugin-tauri-stub.js'
 
 export default defineConfig({
-  plugins: [nodeStdlibBrowser(), react(), tailwindcss()],
+  plugins: [tauriStubPlugin(), nodeStdlibBrowser(), react(), tailwindcss()],
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
Three related pieces of work on `apps/cockpit`, all on this branch.

## 1. JSON tools — recursive table view (`e109734`)

`Table view needs an array of objects` / `This document is not a list of records` is gone. Any JSON now renders as a table, json2table.de style: nested objects become nested tables, record arrays get an index column, sparse rows line up on a first-seen union of keys, and leaves keep their copy button. The reported case — a JSON Schema document — renders as a table rather than an empty state.

## 2. Systematic motion pass (`79d84cf`)

The notes-drawer resize was choppy. An inline `width` does not opt out of a `transition-[width]` class, so every mousemove re-aimed a 200ms eased animation at a target that had already moved. Measured in Chromium: frame timing was clean (avg 8.3ms, 0 frames >32ms), so it was never dropped frames. `Sidebar.tsx` already had the fix; `NotesDrawer.tsx` never got it. After: computed duration 0.2s → 0s during drag → 0.2s on release, width tracking the pointer with 0px lag.

Motion had no scale at all — 100/150/200ms picked per component, so the same interaction ran at two speeds depending on the file. Now tokenised (`--duration-fast|panel|spin`, `--ease-out|in-out`) across 16 components, with an `off-scale-motion` lint rule and `DESIGN_SYSTEM.md § Motion` behind it.

Also: pop-in on the collapsed-sidebar tooltip and flyout (previously instant), `fade-in-place` for transform-positioned elements (transform keyframes clobber the positioning transform), and `SplitPane` now debounces its localStorage write with a flush on unmount — a drag was committing a synchronous disk-backed write per mousemove.

## 3. Floating shell layout (`cc08c81`)

The three shell panels can inset into cards on a recessed canvas. `settings.shellStyle` switches it, defaulting to floating; flush is the original and costs nothing at runtime — with `data-shell="flush"` not one rule in `styles/shell.css` matches.

Two things the visual mockup got wrong that measurement caught:

- Shadow-only cards look better in Midnight but disappear on about a third of the themes — several light ones put `--color-surface-sunken` within a couple of percent of `--color-bg` (github-light: `#fbfcfd` on `#ffffff`). Panels keep a 1px border, which carries those.
- Gutters are margins, not flex `gap`. The closed notes drawer is `width: 0` rather than unmounted so the open can animate, and `gap` would hold a gutter open beside nothing.

No migration: settings are one JSON blob merged over `DEFAULT_SETTINGS`, so the new key backfills itself.

## Gates

`npx tsc --noEmit` clean · `bun run lint` clean (ESLint + design-system) · 1582/1582 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)