### PR TITLE
feat(cockpit): app-wide UI consistency pass

### DIFF
--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -1,427 +1,246 @@
-# TODO — Cockpit UI Audit Backlog
+# TODO — Cockpit UI Elevation Backlog
 
 Last updated: 2026-08-21
-Branch: `chore/ui-audit-todo-refresh`
-Baseline commit: `2137e4e`
+Branch: `feat/ui-consistency-pass`
+Baseline commit: `86df84b`
 
-This file was reset on 2026-08-21. The previous document tracked the **Tool UI Consistency
-Programme** (P0–P5), which is **complete** — all six primitives landed, every tool renders through
-`ToolLayout` or `MasterDetailLayout`, the design scale is enforced by `bun run lint:ds`, and
-`DESIGN_SYSTEM.md` was re-verified against source. See git history for `documentation/TODO.md` at
-`8f4798f` for the closure notes. One item from it survives here as **S3** (screenshot baseline,
-still blocked on manual capture).
+This file was reset on 2026-08-21. The previous document tracked the **UI Audit Backlog** (C1–C6,
+G1–G6, S1–S4), which is **complete** apart from **S3** (screenshot baseline, blocked on manual
+capture) — that item is carried forward here as **S3** unchanged. See git history for
+`documentation/TODO.md` at `86df84b` for the closure notes.
 
-**Scope of this document:** a fresh audit covering what the consistency programme deliberately
-excluded — behaviour, correctness, accessibility, and missing capability — across all 30 tools plus
-the app shell.
+**Scope of this document:** the first audit of this app conducted at **runtime** rather than
+statically. The previous two programmes were both source reads; this one drove the running app in
+the browser harness and found a different class of problem — things that only appear once the app
+is under load (ten tabs open), once two panels compete for width, or once a dialog's content
+outgrows its box. Static analysis cannot see any of these.
 
 ---
 
 ## 1. Method
 
-Eight parallel static audits on 2026-08-21 at `2137e4e`, one per tool group (`code`, `data`, `web`,
-`convert`, `test`, `network`, `write`) plus one for the shell (`src/app`, `src/components`,
-`src/stores`, `src/hooks`, `src/styles`). Each read its scoped tools in full alongside
-`src/components/shared/**`, `src/styles/tokens.css`, `STYLE_GUIDE.md` and `DESIGN_SYSTEM.md`.
+Driven through the browser harness (`bun run dev`, `http://localhost:1420`, Chromium with the
+`__TAURI_INTERNALS__` stub injected by `scripts/vite-plugin-tauri-stub.js`) at two viewports —
+1440×900 and 1024×700. jsdom cannot certify any of this; see `BROWSER_HARNESS.md` for why the
+harness is the only honest verification surface for layout work.
 
-Raw agent output was then **triaged by hand**. Findings that survived verification appear below;
-findings that did not are recorded in §6 so they are not re-raised. Roughly a quarter of the raw
-findings were false positives — treat §6 as the more useful half of this document.
+Walked: JSON Tools, API Client, Regex Tester, Color Converter, Diff Viewer, the command palette,
+the Settings dialog, the Keyboard Shortcuts dialog, the notes drawer, and collapsed-sidebar mode.
+Each finding below was observed on screen before being written down.
 
-Like the previous audit, this is static analysis. No runtime or visual inspection was performed —
-see **S3**.
+The findings were then mapped across the whole app by four parallel scoped explorations (tab strip,
+empty states, tool shell/toolbar, chrome dialogs) so that each fix lands **holistically** rather
+than only in the tool where it was spotted. That mapping is the difference between this document
+and a bug list.
 
 ---
 
 ## 2. Baseline gates
 
-All four green at `2137e4e`, run from `apps/cockpit` (never the monorepo root).
+Run from `apps/cockpit`, never the monorepo root.
 
-| Gate       | Command                          | At `2137e4e`           | After batches 1–4         |
-| ---------- | -------------------------------- | ---------------------- | ------------------------- |
-| TypeScript | `npx tsc --noEmit`               | Pass, no errors        | Pass, no errors           |
-| Tests      | `bunx vitest run`                | 118 files / 1432 tests | 123 files / 1558 tests    |
-| ESLint     | `bun run lint`                   | Pass, 0 warnings       | Pass, 0 warnings          |
-| Design sys | `bun run lint:ds`                | 0 violations           | 0 violations              |
-| Rust       | `cargo check` (from `src-tauri`) | Untouched              | Untouched — frontend only |
-
-Re-run and update after each phase.
-
-**Delivered in this branch:** all of §3 (C1–C6), all capability gaps in §4 (G1–G6), and the
-S1/S2/S4 items of §5. **Not delivered:** **S3**, still blocked on manual capture.
+| Gate       | Command                           | At `86df84b`   | After this branch |
+| ---------- | --------------------------------- | -------------- | ----------------- |
+| TypeScript | `npx tsc --noEmit`                | Pass           | _pending_         |
+| Tests      | `bunx vitest run`                 | _see §7_       | _pending_         |
+| ESLint     | `bun run lint`                    | Pass           | _pending_         |
+| Design sys | `bun run lint:ds`                 | 0 violations   | _pending_         |
+| Harness    | manual walk at 1440×900, 1024×700 | Findings U1–U6 | _pending_         |
+| Rust       | `cargo check` (from `src-tauri`)  | Untouched      | Untouched         |
 
 ---
 
-## 3. P1 — Correctness and accessibility
+## 3. P1 — Layout defects under load
 
-These are defects. Each was verified against source before being written down.
+These are the two findings a user would feel every day. Both are invisible at rest and only appear
+once the app is actually being used.
 
-### C1 — `EmptyState` descriptions render at ~36% opacity (app-wide contrast failure)
+### U1 — The tab strip collapses past ~6 open tools — **done (partly rejected)**
 
-`src/components/shared/EmptyState.tsx:34,39` — the container sets
-`text-[var(--color-text-muted)]`, which is already `rgba(…, 0.6)` in `tokens.css:10`. The
-description `<p>` then adds `opacity-60` on top. Effective alpha is **0.36**, which fails WCAG AA
-against every one of the 22 themes.
+Observed at 1024×700 with ten tools open: labels truncate to `Case …`, `Hash …`, `Markd…`; the
+leftmost tab is clipped mid-word (`olor …`); a native horizontal scrollbar renders **on top of** the
+tab row, eating vertical space and overlapping the labels; and — worst — opening the notes drawer
+scrolled the **active** tab out of view with nothing to bring it back.
 
-This is the shared primitive, so it affects **every** empty state in the app. Four tools also
-hand-roll the same compounding in their own empty bodies:
+The active-tab-out-of-view case is the real defect. Every other symptom is cosmetic; that one loses
+the user's place in response to an unrelated action.
 
-- `code-formatter/CodeFormatter.tsx:425`
-- `ts-playground/TsPlayground.tsx:420`
-- `refactoring-toolkit/RefactoringToolkit.tsx:587`
-- `shell/CommandPalette.tsx:674`
+- [x] Scroll the active tab into view whenever the strip's available width changes — not just on
+      tab activation. Done by routing the reveal through the strip's existing `ResizeObserver`
+      (`WorkspaceTabStrip.tsx`). The old effect keyed on `[activeTabId, tabs]` only, so nothing that
+      changed the strip's _width_ — notes drawer, sidebar collapse, resize-drag, window resize —
+      ever re-triggered it. Resize-driven reveals use `behavior: 'auto'`; activation keeps `smooth`,
+      because a resize-drag fires this on every frame and overlapping smooth scrolls fight.
+- [x] Hide the native scrollbar on the strip. The root cause was subtler than "no hiding": the strip
+      already carried `[scrollbar-width:none]`, which is a **Firefox-only** property, while
+      `index.css` sets `::-webkit-scrollbar { height: 8px }` globally — and the app ships in
+      WKWebView and WebView2. Added a `.no-scrollbar` utility covering both engines and switched the
+      strip to it. Use that class, not the bare Tailwind arbitrary property.
+- [x] ~~Give tabs a `min-width` that preserves icon + ~10 characters~~ — **rejected.** The existing
+      112px minimum is already the outcome of this exercise; the code comment records that 52px was
+      tried and rejected. Nothing to change.
+- [x] ~~Never clip the first tab mid-word~~ — **rejected.** The "clipping" is the deliberate mask
+      fade marking overflow, chosen over gradient overlays because those seam against the active
+      tab. Working as designed.
 
-Plus `shell/NotesDrawer.tsx:701`, where the drag handle stacks `opacity-60` on muted text but
-recovers on focus/hover — lower severity, same root cause.
+**Acceptance:** met — the active tab survives every layout change, and no native scrollbar overlaps
+the tab row on any engine.
 
-- [x] ~~Introduce a `--color-text-subtle` token (a genuinely dimmer _solid_ value per theme).~~
-      **Rejected on measurement.** Ratios were computed for all 23 theme blocks: muted-on-bg is
-      5.21–7.37:1 (passes AA everywhere) and muted+`opacity-60` is 2.42–3.55:1 (fails everywhere).
-      A token dimmer than muted would recreate the failure by design. Hierarchy now comes from the
-      title being `--color-text` instead, which needs no new token and no per-theme judgement.
-- [x] Remove `opacity-60` from `EmptyState` and the five sites above, plus three more the sweep
-      surfaced (`Base64Tool` ×2, `MermaidPreview`).
-- [x] Extend `scripts/lint-design-system.mjs` with a `dimmed-muted-text` rule. Variant-prefixed
-      opacity (`disabled:`, `group-hover:`, `opacity-0`) is exempt — see `DESIGN_SYSTEM.md`.
+### U2 — Empty states compete with the workspace instead of replacing it — **done for Diff Viewer**
 
-**Acceptance:** ✅ contrast ≥ 4.5:1 on all 23 themes, computed rather than eyeballed; ✅ linter
-rejects a deliberate re-introduction, covered by unit tests over the rule itself.
+Diff Viewer renders two empty Monaco editors squeezed into the top half of the pane **and** a full
+"Nothing to compare / Load sample" panel occupying the bottom ~40%. The panel instructs the user to
+paste into the editors it is crowding out. It is the only sizeable region on screen and it is
+telling you to use the small one.
 
-**Note:** the linter is line-based, so it catches same-line compounding only. The `EmptyState` case
-— muted on the parent, `opacity-60` on the child — is invisible to it and was found by reading.
-That limit is why the component test asserts the absence directly.
+JSON Tools already gets this right — its empty state renders _inside_ the editor region and vanishes
+on first keystroke. That is the pattern to generalise.
 
-### C2 — `css-to-tailwind` emits invalid classes for `!important` values
+- [x] Diff Viewer: the comparison pane now collapses to a single prompt line (with `Load sample`)
+      until there is a real result, via `grid-rows-[1fr_auto]` → `grid-rows-2`. The full `EmptyState`
+      is kept for the **diff-only** view, where the pane is all there is — the principle is "an empty
+      state must not shrink the input it points at", not "never use `EmptyState`".
+- [x] Sweep every tool for the same shape. The cross-app map found Diff Viewer to be the only tool
+      rendering an empty state as a _sibling block_ competing with a live input; every other empty
+      state either owns its whole pane or renders inside the input region.
+- [ ] `Load sample` coverage is still inconsistent across tools. **Not addressed in this branch** —
+      it is a content question (which tools deserve a sample, and what it should be) rather than a
+      layout one, and deciding it tool-by-tool is its own piece of work.
 
-`src/tools/css-to-tailwind/CssToTailwind.tsx:292,296,300,310` — values are interpolated verbatim
-into arbitrary-value brackets. `color: red !important` becomes `text-[red !important]`, which is not
-a valid Tailwind class. Grep confirms the string `important` appears **nowhere** in the tool, so
-there is no stripping path anywhere.
-
-- [x] `!important` is now stripped before anything else looks at the value, and re-applied as
-      Tailwind **v4**'s _trailing_ `!` (`text-[red]!`). The finding above says `!text-[red]`, which
-      is the v3 syntax — v4 moved it to a suffix, so check the installed version before touching
-      this.
-- [x] Scope correction: this affects **every** property, not the four listed. `!important` corrupts
-      the value before any `PROPERTY_MAP` lookup or size/spacing equality check, so
-      `width: 100% !important` missed the `w-full` shortcut too.
-- [x] The unconvertible list still echoes the user's original declaration, `!important` included —
-      echoing the stripped value back would misrepresent their input in the one list they read to
-      find out what went wrong.
-- [x] Seven fixture tests: mapped class, arbitrary colour, size value, keyword shortcut, whitespace
-      before `important`, an ordinary declaration left unmarked, and the unconvertible echo.
-
-**Acceptance:** ✅ every emitted class parses as valid Tailwind; ✅ `!important` intent is preserved
-rather than silently dropped.
-
-### C3 — Off-scale icons at `size={9}`
-
-P1 of the previous programme retired 10/11/13/15 and declared the scale 12/14/16. Four `size={9}`
-sites survived because the design-system linter checks class strings, not JSX props:
-
-- `src/components/shell/NotesDrawer.tsx:806` (tag chip)
-- `src/components/shell/ThemePicker.tsx:134` (selected check)
-- `src/tools/snippets/SnippetsManager.tsx:788,1001` (folder, clear)
-
-- [x] Moved all four to `size={12}`, the documented dense/inline value.
-- [x] Added `9` to the existing `off-scale-icon` rule. The rule already covered 10/11/13/15 — `9`
-      was simply missing from the alternation, which is the whole reason these four survived.
-
-**Acceptance:** ✅ zero `size={9|10|11|13|15}` in `src/`; ✅ linter enforces it, with unit tests
-covering both the rejected and the allowed sizes.
-
-Landed in Batch 1 rather than Batch 2: the new rule turns these four into gate failures, so they
-had to move in the same commit that added it.
-
-### C4 — Live regions missing on regex match results
-
-`src/tools/regex-tester/RegexTester.tsx:384-386,392-431` — the highlighted-match pane and match
-detail list update as the user types, with no `aria-live`. A screen-reader user gets no feedback
-that the match count changed.
-
-- [x] Added one `sr-only` `role="status" aria-live="polite"` region at the top of the tool, fed by a
-      new exported `describeMatches()`. Both existing visual counts stay non-live.
-- [x] Announced as a sentence, not a number: "2 matches, 4 capture groups", "No matches", "Pattern
-      error: …". A bare `2` tells a listener nothing about what changed.
-
-Deviation from the plan above: `aria-live` went on a dedicated hidden region rather than on the
-match-details container, because that container only renders when `matchCount > 0` — a live region
-that unmounts cannot announce the transition to zero matches, which is exactly the case a user
-needs to hear. The error and no-match paths announced nothing at all before.
-
-**Acceptance:** ✅ exactly one live region announces match count, asserted directly
-(`document.querySelectorAll('[aria-live]')` has length 1); `describeMatches` unit-tested across all
-six branches.
-
-### C5 — Accessibility gaps in `api-client` and the shell
-
-- [x] ~~`api-client/ApiClient.tsx:1096-1101` — bare checkbox announced unnamed.~~ **Rejected — it
-      already carries `aria-label={`Send header ${h.key || i + 1}`}`.** Swept all eight
-      `type="checkbox"` sites in `src/` while verifying: every other one is wrapped in a `<label>`,
-      and `RefactoringToolkit`'s takes an `ariaLabel` prop. There is no unnamed checkbox in the
-      codebase. Left as native inputs — `Toggle` is a 32px `role="switch"`, wrong for a dense
-      per-row enable.
-- [x] `app/providers.tsx` — the top-level error state's bare `<button>` is now
-      `<Button variant="secondary">`, and the error text is now an `Alert variant="error"`, so the
-      whole-app failure case has `role="alert"` instead of being a silent, empty-looking window.
-- [x] `shell/Workspace.tsx:60` — Suspense fallback now uses `<Spinner size="md">`. The loading state
-      at `app/providers.tsx` was not in fact a hand-rolled spinner, just unlabelled text; it now
-      pairs a `Spinner` with it so the state has a `role="status"`.
-- [x] `tools/timestamp-converter/TimestampConverter.tsx` — `aria-label` on the `datetime-local`
-      picker, and on the free-text input beside it, which was relying on its placeholder.
-
-**Acceptance:** ✅ no unnamed form control in the tool or shell layer; ✅ `Spinner` is the only
-hand-rolled spinner remaining — every other `animate-spin` in `src/` is a Phosphor `SpinnerIcon`,
-which is an icon rather than a competing primitive.
-
-### C6 — Silent error swallowing in `ui.store`
-
-`src/stores/ui.store.ts` — `.catch(() => {})` handlers. Persistence failures vanish, so a workspace
-that fails to save looks identical to one that saved.
-
-Count corrected on inspection: **three**, not five — `persistTabs` held two and `discardClosedState`
-one. The other two line numbers in the original finding were stale.
-
-- [x] The two in `persistTabs` now report through `addToast`, the same path the other eight stores
-      already use, with the message naming the consequence ("Open tabs may not be restored") rather
-      than just the failure.
-- [x] Coalesced: every tab click persists, so an outage would have raised a toast per click. One
-      report per outage, re-armed by the next successful write.
-- [x] `discardClosedState`'s handler logs rather than toasts. Deliberate — a leftover row keyed to a
-      tab id that can never recur is invisible to the user, so a toast would be noise; a silent
-      `catch` was still wrong.
-
-**Acceptance:** ✅ a forced persistence rejection surfaces to the user; four tests cover the toast,
-the coalescing, the re-arm after recovery, and the silence of the happy path.
+**Acceptance:** met for the layout half; `Load sample` coverage remains open and is called out above
+rather than quietly dropped.
 
 ---
 
-## 4. P2 — Capability gaps
+## 4. P2 — Consistency
 
-Ranked by how often a working developer hits them. Each was grep-verified as genuinely absent, not
-merely unfound.
+### U3 — Tools do not share a layout grammar — **done, finding partly corrected**
 
-### G1 — `jwt-decoder` cannot verify a signature
+Three tools, three different shells:
 
-No `verify`, `subtle`, or `HMAC` reference exists in the tool. It decodes and displays the
-signature but cannot tell the user whether it is valid — which is the question most people open a
-JWT tool to answer.
+- **JSON Tools** — full-bleed, dense toolbar, live status strip (`Valid JSON · 11 keys · depth 3 ·
+160 B`), view switcher, primary action. Exemplary.
+- **Regex Tester** — _correction:_ it does have a toolbar (a plain `Toolbar`) and a `StatusBadge`
+  match count. The original note said "no toolbar, no status strip"; that was an artefact of
+  observing it with no pattern entered, when both are empty. The real gap was narrower.
+- **Color Converter** — centered max-width column, no header chrome at all, seven stacked full-width
+  rows each carrying its own identical `Copy` button.
 
-- [x] Optional secret input; verify HS256/384/512 via WebCrypto `subtle.verify`.
-- [x] `alg: "none"` warning — currently accepted silently, and it is a genuine security footgun.
-- [x] Validate `nbf` the way `exp` is already validated (live, with a status badge).
+- [x] Color Converter now has a `DocumentToolbar` + `DocumentIdentity` header with a live status
+      (`#39FF14 · 7 formats`, or `Unrecognised color`). Before this it reported nothing: an
+      unparseable input showed up only as the rest of the page silently not being there.
+- [x] Color Converter's seven `Copy` buttons are gone. Each format row _is_ the copy target, with a
+      hover/focus-revealed icon and an aria-label naming the format (`Copy RGB value rgb(…)`) —
+      seven buttons all labelled "Copy" told a screen-reader user nothing about which was which.
+- [x] Regex Tester's match badge now reads `2 matches` plus a `4 groups` suffix instead of a bare
+      `2`. The capture-group total previously existed only in the sr-only live region, so a sighted
+      user had to count parentheses.
+- [x] ~~Move centered-column tools to full-bleed~~ — **not done, deliberately.** Color Converter's
+      content is a form-style column of labelled rows, which is exactly the case `ToolLayout`'s
+      `maxWidth` exists for. It gained the header grammar without the body restructure; converting
+      it to full-bleed would be change for symmetry's sake.
 
-### G2 — `hash-generator` is text-only
+**Acceptance:** met in the sense that matters — the tools that reported nothing about their state
+now do.
 
-No `File` or drop handling in the tool. Hashing a downloaded artefact — the common case — is
-impossible.
+### U4 — Cryptic controls with no labels — **finding was mostly wrong**
 
-- [x] File drop + streaming hash, mirroring the pattern `base64` already implements.
-- [x] Add SHA-3-256/512 and BLAKE2b. MD5 and SHA-1 ship today and are both broken; offering only
-      broken-or-SHA-2 is a thin menu.
+**Correction.** Regex Tester's flag pills are _not_ unlabelled: each already carries
+`title={FLAG_TITLES[flag]}` (`Global — find all matches`), a matching `aria-label`, and
+`aria-pressed`. The original observation was a failure to wait out the native tooltip delay, not a
+defect. Recorded here so it is not "fixed" again.
 
-### G3 — `timestamp-converter` has no timezone picker
+- [x] The one genuine gap: the `Ref` ghost button had no title. It now has one, plus `aria-expanded`
+      so its toggle state is exposed.
+- [x] Flag pills: nothing to do — already labelled to both screen reader and sighted user.
 
-`TimestampConverter.tsx:54` resolves the _local_ zone via `Intl` and nothing else. Converting a
-timestamp into another zone — the reason the tool exists for anyone on a distributed team — is not
-possible.
+### U5 — Settings and Shortcuts dialogs are undersized for their content — **done (dialogs)**
 
-- [x] Timezone selector driving the output list, defaulting to local.
-- [x] ISO week format (`YYYY-Www`) in the output list.
+The theme grid holds 15+ swatches in a fixed ~830px-tall modal, so a 3-wide grid is scrolled through
+a keyhole. The Shortcuts dialog is a long unfiltered list, clipped at the bottom.
 
-### G4 — `markdown-editor` has no find/replace
+- [x] Both dialogs now fill the `Dialog` primitive's existing `max-h-[90vh]` instead of stopping at
+      a hardcoded `60vh` / `70vh`. The panel was already a flex column; the bodies just weren't
+      participating in it, so ~30vh of available height went unused.
+- [x] Shortcuts dialog has a pinned filter input; only the table below it scrolls. The filter is
+      **substring, not Fuse** — deliberately. On ~25 two-word entries at the palette's 0.4 threshold,
+      Fuse matches "tab" against "Toggle sidebar", and on a reference table a wrong row is worse than
+      no row. It matches the rendered shortcut too, so `⌘K` and `cmd` both find the palette.
+- [ ] Theme swatches as miniature app previews — **not done.** This is a visual-design task of a
+      different kind from the rest of this branch, and it is not blocked by anything here.
 
-No `mod+f`, `mod+h`, or find UI anywhere in the tool. For a full document editor this is a
-conspicuous absence.
+### U6 — Collapsed sidebar is a dead end — **finding overstated; the real gap is fixed**
 
-- [x] Find/replace panel with `mod+f` / `mod+h`, scoped to the editor pane.
+**Correction.** The rail was not label-free: `SidebarCollapsedGroup` already had `aria-label`, a
+portal-rendered hover tooltip, _and_ a full flyout tool list with keyboard dismissal. The original
+"six ambiguous glyphs with no labels" is wrong.
 
-### G5 — `api-client` body modes are narrower than the importer
+The genuine gap was reachability: every tool cost two clicks (open flyout, pick tool), including the
+ones you had explicitly pinned.
 
-`lib/api-import.ts` recognises `form-data` and `x-www-form-urlencoded`, but `BODY_MODES` in the UI
-exposes only JSON/Text/None. An imported collection can therefore hold a body the UI cannot
-represent or edit.
+- [x] Pinned tools now get their own buttons at the top of the collapsed rail, above the groups, and
+      activate on the first click (`SidebarCollapsedTool.tsx`). Stale pin ids — a tool that no longer
+      exists — are skipped rather than rendering a hole, matching `SidebarPinned`.
+- [x] The rail's arrow-key run includes them; a selector matching only groups would have let `Down`
+      skip past the pins, which is exactly the wrong thing to skip.
+- [x] Rail tooltips: already present, nothing to do.
 
-- [x] Add both modes to `BODY_MODES` with a key/value editor.
-- [x] File upload in multipart bodies.
-- [x] Export request as cURL — the inverse of `curl-to-fetch`, which already exists in the app.
-
-### G6 — Smaller, well-scoped additions
-
-- [x] `url-codec` — recursive decode ("decode all levels") for double-encoded input, and bulk
-      line-separated encode/decode.
-- [x] `csv-tools` — delimiter override reachable from Convert/Analyze views without returning to
-      Table view first.
-- [x] `uuid-generator` — v5 (namespace/name) alongside the existing v1/v4/v7.
-- [x] `color-converter` — LAB/LCH output; OKLCH already ships.
-- [x] `image-tool` — rotate and flip.
-- [x] `refactoring-toolkit` — undo history beyond the single `lastApply` snapshot
-      (`RefactoringToolkit.tsx:214`), with `mod+z`.
-- [x] `regex-tester` — a sample in `lib/tool-samples.ts`; it is one of the few tools without one.
-
----
-
-## 5. P3 — Polish and convergence
-
-Low risk, high volume. Batch by finding, not by tool — the same lesson as P3 of the last programme.
-
-### S1 — Residual hand-rolled primitives
-
-The consistency programme converted chrome; these are the stragglers it did not reach.
-
-- [x] `ts-playground/TsPlayground.tsx` — both hand-rolled pane headers are now `PaneHeader`, with
-      the line count folded into `hint` exactly as `diff-viewer/DiffViewer.tsx:200` does.
-- [x] `regex-tester/RegexTester.tsx` — match-count badge → `StatusBadge`. Colour moves from accent
-      to `info`, and to `warning` when the count is truncated, which the accent version could not
-      express at all.
-- [x] ~~`case-converter/CaseConverter.tsx` result cards → `Panel`.~~ **Rejected.** `Panel` is a
-      titled, padded container; these cards are a single label/value/actions row, so the conversion
-      needs `padded={false}` plus a className re-adding the padding — and `Panel` hardcodes
-      `border-[var(--color-border)]`, so the selected card's accent border would have to win by
-      className override, which is exactly the silent-loss trap documented in `DESIGN_SYSTEM.md`.
-      **A real bug turned up while looking:** the card used a bare `border` with no colour utility.
-      Tailwind v4's preflight is `border: 0 solid` with no colour set, so that resolves to
-      `currentColor` — every unselected card was drawing a full-strength text-coloured outline
-      instead of `--color-border`. Fixed by picking the colour in the existing ternary rather than
-      listing both (two arbitrary border-colour utilities have equal specificity; the winner is
-      generation order, not string order). Swept the rest of `src/` for the same shape — 21
-      candidates, all others legitimate (`border-0`, `border-current`, or a colour supplied by a
-      sibling variant map).
-- [x] ~~`image-tool/ImageTool.tsx` raw `<button>` → `Button variant="ghost" size="xs"`.~~
-      **Rejected.** All three already carry an `eslint-disable no-restricted-syntax` with the
-      reasoning: they are 10px (`text-2xs`) annotations and `Button`'s smallest size is `text-xs`,
-      which would outweigh the fields they label. The audit agent flagged them without reading the
-      comment directly above each. They did lack a focus ring and `type="button"` — both added, so
-      they now behave like `Button` where it matters.
-- [x] `markdown-editor/modals/LinkModal.tsx` — checkbox → `Toggle`. A modal settings row has the
-      space for a switch, unlike the dense per-row checkboxes in the validators.
-- [x] `refactoring-toolkit` — `SAFETY_COLORS` (raw `var(...)` strings for an inline `style`) is now
-      `SAFETY_TEXT_CLASSES`, className-only. The inline style bought nothing, since the values were
-      already CSS variables, and cost variant states.
-
-### S2 — Modal and breakpoint inconsistency in the Write group
-
-Four tools, four different hardcoded widths and three different stacking breakpoints:
-
-- Modal widths: `w-[400px]` (`LinkModal:44`), `w-[340px]` (`CodeBlockModal:61`),
-  `w-[420px]` (`TableModal:47`) — none responsive, all break on a narrow window.
-- Stack breakpoints: `max-[900px]` (`mermaid-editor:526`, `prompt-templates:526`),
-  `max-[1000px]` (`snippets:834,960,1149`), `max-[900px]` (`xml-tools:511`).
-
-- [x] **Done, and wider than written.** The audit named three modals; the real count was **18
-      callers spending nine different width expressions**, because `Dialog` had no width of its own
-      and every caller therefore had to invent one. Fixing the call sites would have left the hole
-      open, so the width moved into the primitive: `Dialog` gained a `size` prop
-      (`sm`/`md`/`lg`/`xl`/`none`, default `sm`) over a `w-[min(Xrem,calc(100vw-2rem))]` scale where
-      every step subtracts the same gutter, so no dialog can exceed the viewport. All 18 callers
-      migrated; 14 simply deleted their width. `none` exists for the two dialogs that size against
-      the viewport in both axes (`EnvironmentModal`, the `HtmlValidator` popout) and manage it
-      themselves. `className` now carries a doc comment saying not to set a width there — two
-      arbitrary width utilities have equal specificity, so the winner is stylesheet _generation_
-      order, not string order. Three tests in `Dialog.test.tsx` cover the default, the shared
-      gutter across all four steps, and `none` setting no width at all.
-- [x] **Done.** Recorded in `DESIGN_SYSTEM.md` § Breakpoints: **900px** stacks a split into a
-      column, **1000px** is density (rows wrap, panes narrow, padding tightens). 900px was already
-      consistent across 18 sites and needed no change. The only real drift was one site:
-      `MasterDetailLayout.tsx:56` narrowed at **1100px** while its own line-50 comment claimed the
-      value matched SnippetsManager — which has always used 1000px. The comment was the accurate
-      half; the code was fixed to 1000px and the comment corrected to say so. Unifying downward was
-      the safe direction: holding a pane at full width for an extra 100px band is never a
-      regression, whereas wrapping rows earlier could be, and S3 blocks visual confirmation either
-      way.
-      Two departures are documented rather than flattened: `MarkdownEditor` and `ApiClient` stack at
-      1000px on purpose (prose needs line length; a request/response pair is two forms), and the
-      `min-[1100px]:grid-cols-N` in `CssValidator:609` / `HtmlValidator:768` is a rule-grid _column
-      count_, not a layout mode, so it stays off the scale. `stackBelow` is now stated as the
-      preferred form over a raw `max-[900px]:flex-col` — it keeps the query in one place and
-      disables the drag handle with it, rather than leaving a dead 6px strip.
-
-### S3 — Screenshot baseline (carried over, still blocked)
-
-Inherited unchanged from the previous programme's P0 and P5. The Tauri WebView on macOS can be
-screenshotted and resized by script but **not clicked or typed into**
-(`documentation/NATIVE_UI_HARNESS.md`), so an agent cannot drive a tool into the state worth
-photographing. This audit is static for the same reason.
-
-- [ ] **Needs a human.** Capture all 30 tools at 1280×800 and 900×700, and again after C1 lands —
-      C1 is a contrast change across every theme and is precisely what a screenshot diff would
-      confirm and no automated gate will.
-
-### S4 — Assorted single-site polish
-
-- [x] `base64/Base64Tool.tsx` — Unicode `↺` → `ArrowCounterClockwiseIcon size={12}`.
-- [x] `code-formatter/CodeFormatter.tsx` — save icon 16 → 14, matching its three toolbar siblings.
-      The remaining 16 in that file is the `DocumentIdentity` icon, which is at navigation scale on
-      purpose.
-- [x] Both validators now use the conditional `aria-controls`. It was `html-validator` that was
-      wrong, in **two** places, not one — both its panels are conditionally rendered, so the
-      unconditional attribute pointed at a non-existent id whenever the disclosure was closed.
-- [x] `yaml-tools/YamlTools.tsx` — expand/collapse-all now carry the same icons as their
-      `json-tools` counterparts. Correction to the finding: the icons were _not_ already imported;
-      lines 4-5 held different arrows. Added the imports.
-- [x] `csv-tools/CsvTools.tsx` — `CopyButton` now names what it copies per view ("Copy JSON",
-      "Copy SQL", "Copy CSV") instead of "Copy output" across all three.
-- [x] `docs-browser/DocsBrowser.tsx` — a new exported `siteLabel()` derives the name from
-      `frameSrc`, and the label, the "Open externally" href, the iframe `title` and all four copy
-      strings now follow it. Previously only `src` did, so pointing the tool anywhere else produced
-      chrome naming the wrong site — which the old test enshrined by asserting "DevDocs.io" while
-      rendering `about:blank`.
+**Acceptance:** met — a pinned tool is one click away from the collapsed rail.
 
 ---
 
-## 6. Rejected findings
+## 5. P3 — Small wins
 
-Raised by the audit, checked against source, **not real**. Recorded so they are not re-raised.
+### S1 — Command palette rows show no shortcut hints — **done**
 
-- **"`jwt-decoder` leaks a `setInterval` on unmount"** — False. `JwtDecoder.tsx:130-132` returns
-  `clearInterval`.
-- **"`api-client` history breaks on URLs containing spaces"** — False.
-  `CollectionsSidebar.tsx:492-493` destructures with a rest spread then `urlParts.join(' ')`, which
-  round-trips correctly.
-- **"`api-client` history throws when the `·` delimiter is absent"** — False. `:514` reads
-  `split('·')[1]?.trim() ?? ''` — optional chaining plus a fallback.
-- **"`docs-browser` slow-load timeout leaks on error"** — False. `DocsBrowser.tsx:23-29` has correct
-  cleanup and dependencies.
-- **"`regex-tester` has no catastrophic-backtracking protection"** — False. A timeout guard exists;
-  `RegexTester.tsx:119` reads `evaluation.status === 'timeout'`.
-- **"`Panel` and `Field` are dead primitives"** — Stale. True before P4; `Panel` now has 2
-  consumers, `Field` has 11.
-- **"`diff-viewer` lacks word-level intra-line diff"** — Unfounded. It renders Monaco's
-  `DiffEditor`, which does intra-line diffing itself.
-- **Wrong path, right findings** — several agent findings cited `api-client/CollectionsSidebar.tsx`.
-  The file is `api-client/components/CollectionsSidebar.tsx`; the line numbers were accurate.
+`⌘1`–`⌘9` switch to tabs by position and the palette never said so.
 
----
+- [x] Tool rows for tools that are open in one of the first nine tabs now render that digit binding,
+      built with `formatShortcut` (which owns the `⌘` symbol). A tool open in two tabs shows the
+      leftmost, which is what the key actually does.
 
-## 7. Sequencing
+### S2 — The status bar is nearly empty — **decided**
 
-1. **C1** first and alone. It touches a shared primitive and every theme, and it is the only item
-   here that is a live accessibility failure rather than a latent one.
-2. **C2, C3, C4, C5, C6** — independent, parallelisable, one commit each.
-3. **S1, S4** — mechanical; batch by finding across tools so each diff is one substitution repeated.
-4. **G1–G5** — one PR per tool. These change behaviour and each deserves its own tests.
-5. **S2** needs a decision recorded in `DESIGN_SYSTEM.md` before any code moves.
-6. **G6** is a grab-bag; pull items off it opportunistically when already inside the tool.
+- [x] Dropped the active tool's name from the status bar. The tab strip names the tool one strip
+      above and each tool now carries its own live status in its document toolbar, so this was a
+      third copy of the least informative of the three — permanently occupying the one slot where a
+      transient message needs to be noticed. The remaining contents (last action, run count,
+      keybinding mode, theme, pin, clock) all say something the rest of the chrome does not.
+- Reclaiming the 28px was considered and rejected: the last-action slot is the only place transient
+  feedback lands, and it has to exist somewhere.
 
-Both linter extensions (C1, C3) are worth landing with their findings rather than after — a scale
-nothing enforces is a scale that drifts back, which is how the `size={9}` sites survived P1.
+### S3 — Screenshot baseline (carried forward, still blocked)
+
+Unchanged from the previous document: no committed visual baseline exists, so regressions of exactly
+the kind in §3 can only be caught by a human driving the harness. Blocked on manual capture.
 
 ---
 
-## 8. Out of scope
+## 6. Rejected / not doing
 
-- New tools. The **Cron Parser** gap remains open and is unaffected by any of this.
-- Theming and the token set, except C1's `--color-text-subtle` addition.
-- The legacy T4 apps (`apps/next`, `apps/expo`, `apps/tauri`, `apps/docs`, `apps/cli`,
-  `apps/vscode`, `packages/*`). See root `AGENTS.md`.
-- Rust/`src-tauri`. This backlog is frontend-only.
+Recorded so they are not re-raised.
 
-## 9. Risks
+- **Tab `min-width` of 52px** — tried and rejected before this branch; the 112px minimum is the
+  result. See the comment in `WorkspaceTabStrip.tsx`.
+- **Removing the tab-strip mask fade** — it is the deliberate overflow affordance, chosen over
+  gradient overlays because those seam against the active tab.
+- **Tooltips on regex flag pills** — already there (U4).
+- **Tooltips on collapsed sidebar group icons** — already there (U6).
+- **Replacing the native scrollbar with custom arrows on the tab strip** — the overflow menu already
+  covers this need. Two affordances for one job is worse than one.
+- **Fuse.js for the shortcuts filter** — substring matching is correct for a 25-row reference table
+  (U5).
 
-- **C1 changes contrast in all 22 themes.** The one change here that most wants a visual diff is
-  the one S3 blocks. Mitigation: compute contrast ratios numerically against the token values
-  rather than trusting the eye.
-- **G1's WebCrypto path is async** in a tool that is currently fully synchronous. Expect the
-  loading-state and error-path work to exceed the verification logic itself.
-- **Tests assert on class strings in places.** C1 and C3 will break some. Prefer fixing the test to
-  assert on role/text over re-asserting the new class string — same guidance as last time.
+---
+
+## 7. Status
+
+Delivered: U1 (both real items), U2 (layout), U3, U4, U5 (dialogs), U6, S1, S2.
+
+Open and explicitly not done in this branch:
+
+- U2 — `Load sample` coverage sweep.
+- U5 — theme swatches as miniature app previews.
+- S3 — screenshot baseline (blocked on manual capture, carried forward).
+
+See §2 for the gate table.

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -103,12 +103,56 @@ on first keystroke. That is the pattern to generalise.
 - [x] Sweep every tool for the same shape. The cross-app map found Diff Viewer to be the only tool
       rendering an empty state as a _sibling block_ competing with a live input; every other empty
       state either owns its whole pane or renders inside the input region.
-- [ ] `Load sample` coverage is still inconsistent across tools. **Not addressed in this branch** —
-      it is a content question (which tools deserve a sample, and what it should be) rather than a
-      layout one, and deciding it tool-by-tool is its own piece of work.
+- [x] `Load sample` coverage swept across all 30 tools. This was deferred once as "a content
+      question rather than a layout one", which was true — so it was answered as one. The rule
+      applied, and the outcome per tool, is §3.1 below.
 
-**Acceptance:** met for the layout half; `Load sample` coverage remains open and is called out above
-rather than quietly dropped.
+**Acceptance:** met.
+
+### U2.1 — `Load sample` coverage: the rule and the outcome
+
+A tool earns a sample when **its input is a structured format the user may not have to hand, and a
+worked example teaches both the syntax and what the tool does with it**. That excludes three whole
+categories, which is why the affordance was never going to reach 30 tools and should not have been
+read as "inconsistent" without one.
+
+**Added (4):**
+
+| Tool           | Sample                                                   | Why                                                                                                                                                                                                           |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Regex Tester   | pattern + flags + subject                                | The tool shows nothing until _both_ a pattern and a subject exist; a cold start meant inventing two things at once, and the tax falls hardest on the user who came here unsure of the syntax.                 |
+| cURL → fetch   | POST with two headers, a body and a query string         | Exercises every branch of the converter. A bare `curl https://example.com` converts fine and demonstrates none of it.                                                                                         |
+| CSS → Tailwind | a rule that is half convertible                          | The `unconvertible` list is the half of the output that matters most, and a cleanly-converting sample hides it.                                                                                               |
+| Code Formatter | one deliberately mis-formatted snippet per language (12) | Keyed to the selector, because loading JS into a buffer set to SQL formats it as SQL and makes the tool look broken. One JS sample would leave the button missing for eleven languages, which reads as a bug. |
+
+Every added sample is deliberately imperfect, matching the existing `html-validator` and
+`css-validator` samples: one that arrives already correct makes the tool appear to do nothing.
+
+**Not added, by category:**
+
+- **Input is arbitrary text the user brings** — Base64, URL Codec, Case Converter, Hash Generator.
+  Any string works; a sample teaches nothing.
+- **Generates without input** — UUID Generator, Placeholder, Timestamp Converter (defaults to now).
+- **Manages the user's own content** — Snippets, Prompt Templates, Markdown Editor, Notes. A sample
+  here is not a demo, it is someone else's document in your library.
+- **Equivalent affordance already exists under another name** — Mermaid Editor (`Load template`, a
+  picker over several), CSS Specificity (inline examples), JSON Schema Validator (7 templates).
+- **Would require a network call** — API Client. Its empty states are already well-formed, and a
+  sample that reached a real endpoint would contradict "everything stays on this machine".
+- **Empty state already teaches the tool** — Color Converter (the placeholder is the syntax), Image
+  Tool, Docs Browser (both take files or navigation, not typed input).
+
+**Also normalised:** the label. Three spellings existed for one gesture — `Load sample`,
+`Load Sample` (JWT Decoder) and `Load example` (TS Playground, Refactoring Toolkit). All 16 sites now
+read `Load sample`; Code Formatter's names the language (`Load SQL sample`) because there the sample
+genuinely depends on it. A test asserts every formatter language has a sample, so adding a language
+without one fails the suite rather than silently dropping the button.
+
+**Watch out:** `scripts/lint-design-system.mjs` reads raw source text and cannot tell a CSS _sample_
+from a `className` — nor does it spare comments. A sample containing a bare easing keyword or a hex
+colour near the word `class` fails the gate even though it styles nothing, and the documented
+escape-hatch comment does not help, because inside a template literal it would become part of the
+sample. Pick properties that do not collide. This is recorded in `tool-samples.ts` too.
 
 ---
 
@@ -166,8 +210,22 @@ a keyhole. The Shortcuts dialog is a long unfiltered list, clipped at the bottom
       **substring, not Fuse** — deliberately. On ~25 two-word entries at the palette's 0.4 threshold,
       Fuse matches "tab" against "Toggle sidebar", and on a reference table a wrong row is worse than
       no row. It matches the rendered shortcut too, so `⌘K` and `cmd` both find the palette.
-- [ ] Theme swatches as miniature app previews — **not done.** This is a visual-design task of a
-      different kind from the rest of this branch, and it is not blocked by anything here.
+- [x] Theme swatches are miniature app previews. Each swatch now renders the real shell in
+      miniature — title bar, sidebar rail with an accented active item, tab strip with one active
+      tab, content, status bar — where it previously showed three abstract blocks. The mechanism was
+      already right and is unchanged: the theme's class is applied to a scoped wrapper exactly as
+      `tokens.css` applies it to `<html>`, so every band resolves `var(--color-*)` against that
+      theme and **no colour is read or hardcoded in JS**. Only the geometry changed.
+
+      The three blocks could not answer the questions that actually decide a theme: whether its
+      surface separates from its background at all, whether its accent survives against its own
+      active tab (the one place the accent meets `--color-bg` rather than `--color-surface`), and
+      how loud its borders are. All three are legible now. Height went `h-8` → `h-12` to fit five
+      bands; the dialog gained ~30vh earlier in this branch, so there is room.
+
+      One incidental fix: `Swatch`'s `className` now _replaces_ the default instead of appending to
+      it. `SystemSwatch` passes `h-full` for its half-width split, which previously left two height
+      utilities on one element with the winner decided by Tailwind's emit order.
 
 ### U6 — Collapsed sidebar is a dead end — **finding overstated; the real gap is fixed**
 
@@ -235,12 +293,12 @@ Recorded so they are not re-raised.
 
 ## 7. Status
 
-Delivered: U1 (both real items), U2 (layout), U3, U4, U5 (dialogs), U6, S1, S2.
+Delivered: U1, U2 (layout **and** the `Load sample` sweep, §3.1), U3, U4, U5 (dialogs **and** the
+theme previews), U6, S1, S2.
 
-Open and explicitly not done in this branch:
+Open:
 
-- U2 — `Load sample` coverage sweep.
-- U5 — theme swatches as miniature app previews.
-- S3 — screenshot baseline (blocked on manual capture, carried forward).
+- S3 — screenshot baseline (blocked on manual capture, carried forward). This is now the only item
+  left in this document, and it is the one that would have caught every defect in §3 automatically.
 
 See §2 for the gate table.

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -343,13 +343,35 @@ jumped on every tab switch. The tallest control in the app measures 31px, so `mi
 puts the natural height (43px) _under_ the floor and the floor decides. Every non-wrapping toolbar
 is now exactly 44px — and 44 is the title bar's `h-11`, so the chrome stack shares one rhythm.
 
-### C4 — The toolbar divider was decided 13 times — **done**
+### C4 — The toolbar divider was decided 13 times — **done, after a correction**
 
 Eight of thirteen `DocumentToolbar` call sites had independently passed `border={false}`, leaving a
 third of the app with a seam under its toolbar and two-thirds without. The default moved into the
 primitive (`border = false`), the eight overrides were deleted, and the five toolbars that _lost_ a
 divider were re-checked in the harness — the `--color-surface` → canvas transition separates them on
-its own. Tools that genuinely stack two rows can still opt in with `border`.
+its own.
+
+**The first attempt did not actually fix this**, and code review caught it. Removing the `border`
+prop only unified the _prop_; eight tools re-express the same seam as a `border-b` on the `<header>`
+or `<div>` that wraps the toolbar, which the sweep never looked at. So the app stayed split 8/5 on
+whether a seam appears under the toolbar — the exact inconsistency C4 claimed to close, relocated
+one element outwards.
+
+The rule, stated properly: **the seam marks the bottom of the chrome block, not the bottom of a
+toolbar row.** A wrapper gets `border-b` only when something genuinely stacks under the toolbar
+inside it.
+
+- Kept (a second row really is there): `JsonTools`, `CodeFormatter`, `TsPlayground` — collapsible
+  options/query rows inside the wrapper.
+- Made conditional: `CssValidator` and `HtmlValidator` now border the header only while `showRules`
+  is open. Closed, they were single-row toolbars carrying a divider.
+- Removed: `MermaidEditor`, `MarkdownEditor`, `YamlTools` — nothing stacks under the toolbar inside
+  the wrapper. (`MarkdownEditor`'s formatting bar is a _sibling_ of the header with its own
+  `border-b`, so the block still ends in one seam; the two chrome rows just no longer have a line
+  between them.)
+
+All five re-verified in the harness, including CSS Validator with the rules panel both open and
+closed.
 
 ### C5 — The selected segment competed with primary actions — **done**
 

--- a/apps/cockpit/documentation/TODO.md
+++ b/apps/cockpit/documentation/TODO.md
@@ -41,11 +41,11 @@ Run from `apps/cockpit`, never the monorepo root.
 
 | Gate       | Command                           | At `86df84b`   | After this branch |
 | ---------- | --------------------------------- | -------------- | ----------------- |
-| TypeScript | `npx tsc --noEmit`                | Pass           | _pending_         |
-| Tests      | `bunx vitest run`                 | _see §7_       | _pending_         |
-| ESLint     | `bun run lint`                    | Pass           | _pending_         |
-| Design sys | `bun run lint:ds`                 | 0 violations   | _pending_         |
-| Harness    | manual walk at 1440×900, 1024×700 | Findings U1–U6 | _pending_         |
+| TypeScript | `npx tsc --noEmit`                | Pass           | Pass              |
+| Tests      | `bunx vitest run`                 | _see §7_       | 1618 pass, 0 fail |
+| ESLint     | `bun run lint`                    | Pass           | Pass              |
+| Design sys | `bun run lint:ds`                 | 0 violations   | 0 violations      |
+| Harness    | manual walk at 1440×900, 1024×700 | Findings U1–U6 | Re-walked, clean  |
 | Rust       | `cargo check` (from `src-tauri`)  | Untouched      | Untouched         |
 
 ---
@@ -294,11 +294,88 @@ Recorded so they are not re-raised.
 ## 7. Status
 
 Delivered: U1, U2 (layout **and** the `Load sample` sweep, §3.1), U3, U4, U5 (dialogs **and** the
-theme previews), U6, S1, S2.
+theme previews), U6, S1, S2, and the chrome pass C1–C11 in §8.
 
 Open:
 
 - S3 — screenshot baseline (blocked on manual capture, carried forward). This is now the only item
-  left in this document, and it is the one that would have caught every defect in §3 automatically.
+  left in this document, and it is the one that would have caught every defect in §3 and §8
+  automatically.
 
 See §2 for the gate table.
+
+---
+
+## 8. Chrome pass — title bar and toolbars
+
+Added 2026-08-21, after §3–§5 landed. Same method as §1: driven in the harness, geometry measured
+with DevTools rather than eyeballed, at 800px (the `minWidth` in `tauri.conf.json`), 1024px and
+1512px.
+
+### C1 — The command palette painted over the title-bar buttons — **done**
+
+The palette was centred by a full-width `pointer-events-none` overlay. At 480px wide, its left edge
+crosses x=170 below a window width of ~820px — over the icon cluster. Because the overlay does not
+take pointer events, the buttons stayed **clickable while invisible**, which is worse than plain
+occlusion. `minWidth` is 800, so this was reachable at the smallest window the app allows.
+
+Fix: keep the overlay — true window-centring is the point — but give it a symmetric `SIDE_RESERVE`
+gutter sized to the widest cluster on each platform (`px-[120px]` mac, `px-[224px]` elsewhere). The
+palette now shrinks below 480px rather than overlapping. Verified at 800px: palette centre 400 =
+window centre, 44px clear left, 88px clear right.
+
+Equal-flex side columns were tried first and **rejected**: the macOS traffic-light allowance is
+padding on one side only, and `flex-basis: 0` sizes the _content_ box, so the padding is added on
+top and slides all three columns left (measured: palette centre 794 against a window centre of 756).
+
+### C2 — Three icon buttons on the leading edge read as a fourth window control — **done**
+
+14px separated them from the macOS traffic lights. Settings and Shortcuts moved to the trailing
+edge — both are modal, rarely used, and reachable from the palette. Notes stays: it is the one
+control with state worth glancing at (the badge). Locked by a test asserting DOM order around the
+palette slot.
+
+### C3 — Toolbar heights were ragged — **done**
+
+`min-h-10` was a floor almost nothing reached: measured at 1024px, toolbars came out 42, 43, 46 and
+47px depending purely on which controls a tool happened to contain, so the line under the tab strip
+jumped on every tab switch. The tallest control in the app measures 31px, so `min-h-11` + `py-1.5`
+puts the natural height (43px) _under_ the floor and the floor decides. Every non-wrapping toolbar
+is now exactly 44px — and 44 is the title bar's `h-11`, so the chrome stack shares one rhythm.
+
+### C4 — The toolbar divider was decided 13 times — **done**
+
+Eight of thirteen `DocumentToolbar` call sites had independently passed `border={false}`, leaving a
+third of the app with a seam under its toolbar and two-thirds without. The default moved into the
+primitive (`border = false`), the eight overrides were deleted, and the five toolbars that _lost_ a
+divider were re-checked in the harness — the `--color-surface` → canvas transition separates them on
+its own. Tools that genuinely stack two rows can still opt in with `border`.
+
+### C5 — The selected segment competed with primary actions — **done**
+
+`SegmentedControl` filled the selected segment with solid `--color-accent`, making a _view mode_
+as loud as a button. JSON Tools showed "Format" and "Source" fighting for the same emphasis. Now
+`--color-accent-dim` + `font-semibold`: state reads as state.
+
+### C6 — The active-tab indicator read as a divider artifact — **done**
+
+A 40px centred pill (20px when pinned) sat on the title bar's divider line with empty tab either
+side, so it looked like a flaw in the divider rather than a marker for its tab. Now full tab width
+(`inset-x-0`), square. The existing rationale for keeping it at `top-0` — don't sever the seam — was
+honoured; only the width changed.
+
+### C7 — JSON Tools buried its primary actions on wrap — **done**
+
+The bar wraps to two rows at 1024px. With view options first, the wrap put Indent/Path/view-mode on
+row one and every primary action underneath. Groups reordered so the least important row sheds last.
+
+### C8–C11 — Unlabelled Save buttons — **done**
+
+Seven tools had an icon-only floppy disk sitting among five labelled buttons, which reads as a
+different class of control: CSV, XML, YAML, Code Formatter, TS Playground, Refactoring Toolkit,
+JSON Schema Validator (plus JSON Tools under C7). All now `variant="secondary"` with a visible
+`Save` label, keeping their existing `aria-label` (more specific, and WCAG 2.5.3-compliant since the
+accessible name contains the visible one).
+
+**Not changed:** Mermaid Editor, CSS Validator and HTML Validator pair an icon-only Open with an
+icon-only Save. That reads as a coherent icon group; labelling only one half would break it.

--- a/apps/cockpit/src/components/shared/SegmentedControl.tsx
+++ b/apps/cockpit/src/components/shared/SegmentedControl.tsx
@@ -25,6 +25,12 @@ const SIZE_CLASSES: Record<SegmentedControlSize, string> = {
 
 // Single-select mode toggle (Match/Replace, Edit/Split/Preview, Formats/Shades/Harmony/CSS Var).
 //
+// The selected segment is an accent *tint* (`--color-accent-dim`, defined for every theme), not a
+// solid accent fill. A saturated fill made the selected segment as loud as a primary button, so a
+// toolbar like JSON Tools' showed two maximally-emphatic controls at once — "Format" and "Source"
+// — with nothing to say which was the action and which was the current state. A view mode is
+// state; it should read as selected, not as the thing to press.
+//
 // role="radiogroup" + role="radio" rather than tablist/tab/tabpanel: these
 // segments switch a *view mode*, not independently-addressable document
 // sections with their own tabpanel — there's exactly one mutually exclusive
@@ -97,7 +103,7 @@ export function SegmentedControl<T extends string>({
             onKeyDown={(event) => handleKeyDown(event, index)}
             className={`font-ui inline-flex items-center gap-1 rounded-[var(--radius-sm)] transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${SIZE_CLASSES[size]} ${
               selected
-                ? 'bg-[var(--color-accent)] font-bold text-[var(--color-bg)]'
+                ? 'bg-[var(--color-accent-dim)] font-semibold text-[var(--color-text)]'
                 : 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
             }`}
           >

--- a/apps/cockpit/src/components/shared/Toolbar.tsx
+++ b/apps/cockpit/src/components/shared/Toolbar.tsx
@@ -16,6 +16,13 @@ type ToolbarProps = {
 // Horizontal control bar — codifies the
 // `flex items-center gap-2 border-b border-[var(--color-border)] px-4 py-2`
 // row hand-rolled at the top of most tools (CsvTools, ApiClient, CodeFormatter, ...).
+//
+// `min-h-11` matches the title bar's `h-11`, so the chrome stack reads as a rhythm rather than a
+// ragged edge. `min-h-10` with `py-2` was a floor that almost nothing reached: measured live at
+// 1024px, toolbars came out 42, 43, 46 and 47px tall depending purely on which controls a tool
+// happened to contain, so the line under the tab strip jumped every time you switched tabs. The
+// tallest control in the app measures 31px, which `py-1.5` leaves at 43px — under the floor — so
+// the floor now decides, and every non-wrapping toolbar is exactly 44px.
 export function Toolbar({
   children,
   className = '',
@@ -29,7 +36,7 @@ export function Toolbar({
       id={id}
       role="toolbar"
       aria-label={ariaLabel}
-      className={`flex min-h-10 items-center gap-2 bg-[var(--color-surface)] px-4 py-2 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
+      className={`flex min-h-11 items-center gap-2 bg-[var(--color-surface)] px-4 py-1.5 ${wrap ? 'flex-wrap' : 'overflow-x-auto'} ${border ? 'border-b border-[var(--color-border)]' : ''} ${className}`}
     >
       {children}
     </div>
@@ -70,10 +77,23 @@ type DocumentToolbarProps = ToolbarProps
  * Compact, wrapping chrome for document-oriented tools. Identity, view controls,
  * and primary actions share one row at normal widths and wrap as groups when the
  * workspace narrows.
+ *
+ * No bottom border by default, where `Toolbar` has one. A document toolbar is chrome *for* the
+ * document directly beneath it and should look continuous with it — the same argument the tab
+ * strip's top pill indicator is built on. Eight of the thirteen call sites had already reached
+ * that conclusion independently and passed `border={false}`, which left a third of the app with a
+ * seam under its toolbar and two-thirds without, decided tool by tool. Stating it once here makes
+ * it a rule; a document toolbar that genuinely stacks above another row can still pass
+ * `border` explicitly.
  */
-export function DocumentToolbar({ children, className = '', ...props }: DocumentToolbarProps) {
+export function DocumentToolbar({
+  children,
+  className = '',
+  border = false,
+  ...props
+}: DocumentToolbarProps) {
   return (
-    <Toolbar {...props} className={`gap-x-3 gap-y-2 ${className}`}>
+    <Toolbar {...props} border={border} className={`gap-x-3 gap-y-2 ${className}`}>
       {children}
     </Toolbar>
   )

--- a/apps/cockpit/src/components/shared/__tests__/SegmentedControl.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SegmentedControl.test.tsx
@@ -76,4 +76,15 @@ describe('SegmentedControl', () => {
     expect(screen.getByRole('radio', { name: 'Replace' })).toHaveAttribute('tabIndex', '-1')
     expect(screen.getByRole('radio', { name: 'Extra' })).toHaveAttribute('tabIndex', '-1')
   })
+
+  // A view mode is state, not the thing to press. A solid accent fill made the selected segment
+  // as loud as a primary button, so JSON Tools' toolbar showed "Format" and "Source" competing
+  // for the same emphasis with nothing to distinguish action from state.
+  it('marks the selected segment with an accent tint, not a solid accent fill', () => {
+    render(<Harness />)
+    const selected = screen.getByRole('radio', { name: 'Match' })
+
+    expect(selected.className).toContain('bg-[var(--color-accent-dim)]')
+    expect(selected.className).not.toContain('bg-[var(--color-accent)]')
+  })
 })

--- a/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Toolbar.test.tsx
@@ -27,6 +27,20 @@ describe('Toolbar', () => {
     expect(noBorder.firstElementChild?.className).not.toContain('border-b')
   })
 
+  // The divider rule lives in the primitives, not in each tool. Eight of thirteen call sites had
+  // independently passed `border={false}` to a DocumentToolbar, leaving a third of the app with a
+  // seam under its toolbar and two-thirds without.
+  it('gives a document toolbar no divider by default, unlike a plain toolbar', () => {
+    const { container: plain } = render(<Toolbar>content</Toolbar>)
+    const { container: doc } = render(<DocumentToolbar>content</DocumentToolbar>)
+    const { container: docForced } = render(<DocumentToolbar border>content</DocumentToolbar>)
+
+    expect(plain.firstElementChild?.className).toContain('border-b')
+    expect(doc.firstElementChild?.className).not.toContain('border-b')
+    // A document toolbar that genuinely stacks above another row can still opt in.
+    expect(docForced.firstElementChild?.className).toContain('border-b')
+  })
+
   it('labels related action groups and provides a flexible spacer', () => {
     const { container } = render(
       <Toolbar aria-label="Editor actions">
@@ -55,7 +69,8 @@ describe('Toolbar', () => {
       </DocumentToolbar>
     )
 
-    expect(screen.getByRole('toolbar', { name: 'Document actions' })).toHaveClass('min-h-10')
+    // `min-h-11` matches the title bar's `h-11` — the chrome stack shares one height.
+    expect(screen.getByRole('toolbar', { name: 'Document actions' })).toHaveClass('min-h-11')
     expect(screen.getByText('styles.css')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('No problems')
     expect(screen.getByText('Modified')).toHaveClass('text-[var(--color-accent)]')

--- a/apps/cockpit/src/components/shell/CommandPalette.tsx
+++ b/apps/cockpit/src/components/shell/CommandPalette.tsx
@@ -28,6 +28,7 @@ import {
 } from '@phosphor-icons/react'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 import { Kbd } from '@/components/shared/Kbd'
+import { formatShortcut } from '@/lib/shortcut-label'
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -232,6 +233,19 @@ export function CommandPalette() {
   )
 
   const allItems = useMemo(() => [...toolItems, ...actions], [toolItems, actions])
+
+  // mod+1..9 switch to the workspace tab at that position (useGlobalShortcuts),
+  // but nothing in the UI ever said so, so the binding was invisible unless you
+  // read the shortcuts modal. Surfacing it on the palette row teaches it at the
+  // moment you're about to click the row instead. Only the first nine tabs get a
+  // digit; a tool open in two tabs gets the leftmost, which is what the key does.
+  const tabShortcuts = useMemo(() => {
+    const map = new Map<string, string>()
+    tabs.slice(0, 9).forEach((tab, i) => {
+      if (!map.has(tab.toolId)) map.set(tab.toolId, formatShortcut(`mod+${i + 1}`))
+    })
+    return map
+  }, [tabs])
 
   const fuseOpts: IFuseOptions<PaletteItem> = useMemo(
     () => ({
@@ -610,6 +624,10 @@ export function CommandPalette() {
                 const isActive = item.kind === 'tool' && item.id === activeTool
                 const isOpenInTab =
                   item.kind === 'tool' && !isActive && tabs.some((t) => t.toolId === item.id)
+                // Actions carry their own `shortcut`; tools borrow the digit of the
+                // tab they're open in, if any.
+                const shortcut =
+                  item.shortcut ?? (item.kind === 'tool' ? tabShortcuts.get(item.id) : undefined)
 
                 return (
                   <button
@@ -654,9 +672,9 @@ export function CommandPalette() {
                         {item.description}
                       </div>
                     </div>
-                    {item.shortcut && (
+                    {shortcut && (
                       <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
-                        {item.shortcut}
+                        {shortcut}
                       </span>
                     )}
                   </button>

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -1078,7 +1078,11 @@ export function SettingsPanel() {
       onClose={() => setOpen(false)}
       closeLabel="Close settings"
       size="lg"
-      bodyClassName="p-0"
+      // The dialog is already a flex column capped at 90vh, so the body only has
+      // to opt into filling it. It previously carried a hard `max-h-[60vh]` on the
+      // tab content, which scrolled a three-wide theme grid of 20+ swatches
+      // through a keyhole while ~30vh of the dialog sat unused below it.
+      bodyClassName="flex min-h-0 flex-col p-0"
       titleClassName="text-[var(--color-accent)]"
       footer={
         <div className="flex w-full items-center justify-between">
@@ -1091,8 +1095,8 @@ export function SettingsPanel() {
         </div>
       }
     >
-      {/* Tab bar */}
-      <div className="flex border-b border-[var(--color-border)]">
+      {/* Tab bar — pinned; only the panel below it scrolls */}
+      <div className="flex shrink-0 border-b border-[var(--color-border)]">
         {TABS.map((tab) => (
           <button
             key={tab.id}
@@ -1111,7 +1115,7 @@ export function SettingsPanel() {
       </div>
 
       {/* Tab content */}
-      <div className="max-h-[60vh] overflow-y-auto px-4 py-3">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
         {activeTab === 'general' && <GeneralTab />}
         {activeTab === 'editor' && <EditorTab />}
         {activeTab === 'data' && <DataTab />}

--- a/apps/cockpit/src/components/shell/ShortcutsModal.tsx
+++ b/apps/cockpit/src/components/shell/ShortcutsModal.tsx
@@ -1,6 +1,10 @@
+import { useMemo, useState } from 'react'
 import { Dialog } from '@/components/shared/Dialog'
+import { EmptyState } from '@/components/shared/EmptyState'
+import { Input } from '@/components/shared/Input'
 import { Kbd } from '@/components/shared/Kbd'
 import { SectionLabel } from '@/components/shared/SectionLabel'
+import { formatShortcut } from '@/lib/shortcut-label'
 import { useUiStore } from '@/stores/ui.store'
 
 type ShortcutEntry = {
@@ -64,6 +68,22 @@ const CATEGORIES: ShortcutCategory[] = [
 export function ShortcutsModal() {
   const open = useUiStore((s) => s.shortcutsModalOpen)
   const setOpen = useUiStore((s) => s.setShortcutsModalOpen)
+  const [query, setQuery] = useState('')
+
+  // Substring, not fuzzy. The list is ~25 entries of two or three words, and
+  // Fuse at the palette's 0.4 threshold matches "tab" against "Toggle sidebar"
+  // — on a reference table, a wrong row is worse than no row. Matching the
+  // rendered shortcut too means "⌘K" and "cmd" both find the palette.
+  const categories = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return CATEGORIES
+    return CATEGORIES.map((cat) => ({
+      ...cat,
+      shortcuts: cat.shortcuts.filter((s) =>
+        `${s.action} ${s.keys} ${formatShortcut(s.keys)}`.toLowerCase().includes(q)
+      ),
+    })).filter((cat) => cat.shortcuts.length > 0)
+  }, [query])
 
   if (!open) return null
 
@@ -73,24 +93,47 @@ export function ShortcutsModal() {
       onClose={() => setOpen(false)}
       closeLabel="Close shortcuts"
       size="lg"
-      bodyClassName="max-h-[70vh] px-4 py-3"
+      // Fills the dialog's 90vh rather than stopping at 70vh, and lets the search
+      // row stay put while only the table below it scrolls.
+      bodyClassName="flex min-h-0 flex-col p-0"
       titleClassName="text-[var(--color-accent)]"
     >
-      {CATEGORIES.map((cat) => (
-        <div key={cat.label} className="mb-4 last:mb-0">
-          <SectionLabel as="h3" className="mb-2">
-            {cat.label}
-          </SectionLabel>
-          <div className="flex flex-col gap-1">
-            {cat.shortcuts.map((s) => (
-              <div key={s.action} className="flex items-center justify-between py-1.5">
-                <span className="text-xs text-[var(--color-text)]">{s.action}</span>
-                <Kbd keys={s.keys} />
+      <div className="shrink-0 border-b border-[var(--color-border)] px-4 py-3">
+        <Input
+          type="search"
+          aria-label="Filter shortcuts"
+          placeholder="Filter shortcuts…"
+          className="w-full"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        {categories.length === 0 ? (
+          <EmptyState
+            size="sm"
+            title="No matching shortcuts"
+            description={`Nothing matches “${query.trim()}”.`}
+          />
+        ) : (
+          categories.map((cat) => (
+            <div key={cat.label} className="mb-4 last:mb-0">
+              <SectionLabel as="h3" className="mb-2">
+                {cat.label}
+              </SectionLabel>
+              <div className="flex flex-col gap-1">
+                {cat.shortcuts.map((s) => (
+                  <div key={s.action} className="flex items-center justify-between py-1.5">
+                    <span className="text-xs text-[var(--color-text)]">{s.action}</span>
+                    <Kbd keys={s.keys} />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        </div>
-      ))}
+            </div>
+          ))
+        )}
+      </div>
     </Dialog>
   )
 }

--- a/apps/cockpit/src/components/shell/Sidebar.tsx
+++ b/apps/cockpit/src/components/shell/Sidebar.tsx
@@ -11,6 +11,7 @@ import { SidebarGroup } from './SidebarGroup'
 import { SidebarRecent } from './SidebarRecent'
 import { SidebarPinned } from './SidebarPinned'
 import { SidebarCollapsedGroup } from './SidebarCollapsedGroup'
+import { SidebarCollapsedTool } from './SidebarCollapsedTool'
 import { CaretLeftIcon, CaretRightIcon } from '@phosphor-icons/react'
 import { SearchInput } from '@/components/shared/SearchInput'
 
@@ -35,6 +36,17 @@ export function Sidebar() {
   const activeTool = useUiStore((s) => s.activeTool)
 
   const savedWidth = useSettingsStore((s) => s.sidebarWidth)
+  const pinnedToolIds = useSettingsStore((s) => s.pinnedToolIds)
+
+  // Same resolution as `SidebarPinned`: pin order, skipping ids whose tool no
+  // longer exists (a stale pin from a removed tool must not render a hole).
+  const collapsedPinnedTools = useMemo(
+    () =>
+      pinnedToolIds
+        .map((id) => TOOLS.find((tool) => tool.id === id))
+        .filter((tool): tool is (typeof TOOLS)[number] => tool != null),
+    [pinnedToolIds]
+  )
 
   const [filterQuery, setFilterQuery] = useState('')
   const [width, setWidth] = useState(() => clampSidebarWidth(savedWidth))
@@ -228,8 +240,13 @@ export function Sidebar() {
   const handleCollapsedNavKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
     const container = e.currentTarget
+    // Pinned tools sit in the same rail and above the groups, so they are part of
+    // the same arrow-key run — a selector matching only groups would let Down
+    // skip straight past them, which is exactly the wrong thing to skip.
     const items = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-sidebar-collapsed-group]')
+      container.querySelectorAll<HTMLElement>(
+        '[data-sidebar-collapsed-tool], [data-sidebar-collapsed-group]'
+      )
     )
     if (items.length === 0) return
 
@@ -302,6 +319,22 @@ export function Sidebar() {
             className="flex flex-1 flex-col items-center gap-0.5"
             onKeyDown={handleCollapsedNavKeyDown}
           >
+            {/* Pinned tools first, one click each. Everything below is a group
+                flyout costing two, which is the wrong price for the tools the
+                user has explicitly said they keep coming back to. Omitted
+                entirely when nothing is pinned, so the rail is unchanged for
+                anyone who has never used the pin. */}
+            {collapsedPinnedTools.length > 0 && (
+              <>
+                {collapsedPinnedTools.map((tool) => (
+                  <SidebarCollapsedTool key={tool.id} tool={tool} />
+                ))}
+                <span
+                  aria-hidden="true"
+                  className="my-1 h-px w-5 shrink-0 bg-[var(--color-border)]"
+                />
+              </>
+            )}
             {TOOL_GROUPS.map((group, index) => {
               const tools = TOOLS.filter((t) => t.group === group.id)
               return (

--- a/apps/cockpit/src/components/shell/SidebarCollapsedTool.tsx
+++ b/apps/cockpit/src/components/shell/SidebarCollapsedTool.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { ToolDefinition } from '@/types/tools'
+import { useUiStore } from '@/stores/ui.store'
+
+type Props = {
+  tool: ToolDefinition
+}
+
+/**
+ * A single pinned tool in the collapsed rail.
+ *
+ * The rail otherwise lists tool *groups*, which cost two clicks to reach a tool —
+ * open the flyout, then pick. A pin is a statement that this is a tool you return
+ * to, so in the rail it gets its own button and opens on the first click. The
+ * tooltip is the same portal-rendered one `SidebarCollapsedGroup` uses, for the
+ * same reason: the rail is 40px wide and a tooltip inside it would be clipped.
+ */
+export function SidebarCollapsedTool({ tool }: Props) {
+  const [tooltipVisible, setTooltipVisible] = useState(false)
+  const [tooltipStyle, setTooltipStyle] = useState<React.CSSProperties>({})
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const setActiveTool = useUiStore((s) => s.setActiveTool)
+  const activeTool = useUiStore((s) => s.activeTool)
+
+  const isActive = tool.id === activeTool
+
+  const handleMouseEnter = useCallback(() => {
+    if (!triggerRef.current) return
+    const rect = triggerRef.current.getBoundingClientRect()
+    setTooltipStyle({
+      position: 'fixed',
+      left: rect.right + 8,
+      top: rect.top + rect.height / 2,
+      transform: 'translateY(-50%)',
+      zIndex: 'var(--z-tooltip)',
+    })
+    setTooltipVisible(true)
+  }, [])
+
+  const handleMouseLeave = useCallback(() => setTooltipVisible(false), [])
+
+  // The pointer can still be over the button when the sidebar expands and this
+  // unmounts, in which case mouseleave never fires and the tooltip is orphaned.
+  useEffect(() => {
+    return () => setTooltipVisible(false)
+  }, [])
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        onClick={() => setActiveTool(tool.id)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        className={`flex h-8 w-8 items-center justify-center rounded-sm border-l-2 transition-colors duration-[var(--duration-fast)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${
+          isActive
+            ? 'border-[var(--color-accent)] bg-[var(--color-accent-dim)] text-[var(--color-accent)]'
+            : 'border-transparent text-[var(--color-text-muted)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
+        }`}
+        aria-label={`${tool.name} (pinned)`}
+        aria-current={isActive ? 'true' : undefined}
+        data-sidebar-collapsed-tool={tool.id}
+      >
+        <span className="flex w-5 shrink-0 items-center justify-center">{tool.icon}</span>
+      </button>
+
+      {tooltipVisible &&
+        createPortal(
+          <div
+            style={tooltipStyle}
+            className="font-ui animate-pop-in pointer-events-none rounded border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[var(--color-text)] shadow-md"
+          >
+            {tool.name}
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}

--- a/apps/cockpit/src/components/shell/StatusBar.tsx
+++ b/apps/cockpit/src/components/shell/StatusBar.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { useUiStore } from '@/stores/ui.store'
 import { useSettingsStore } from '@/stores/settings.store'
 import { useHistoryStore } from '@/stores/history.store'
-import { getToolById } from '@/app/tool-registry'
 import { THEME_META } from '@/lib/theme'
 import { PushPinIcon, ClockIcon } from '@phosphor-icons/react'
 
@@ -53,8 +52,6 @@ export function StatusBar() {
     void updateSetting('notesDrawerOpen', true)
   }
 
-  const tool = getToolById(activeTool)
-
   // Clear stale last action when switching tools
   useEffect(() => {
     if (lastAction) clearLastAction()
@@ -72,9 +69,15 @@ export function StatusBar() {
 
   return (
     <div className="shell-chrome font-ui flex h-7 shrink-0 items-center justify-between border-t border-[var(--color-border)] bg-[var(--color-surface)] px-3 text-xs">
-      {/* Left: active tool + last action */}
+      {/* Left: last action.
+       *
+       * The tool's name used to sit here too. The tab strip already names the
+       * active tool one strip above, and each tool now carries its own live
+       * status in its document toolbar — so this was a third copy of the least
+       * informative of the three, permanently occupying the one slot where a
+       * transient message needs to be noticed. Quiet when there's nothing to
+       * say is the right behaviour for a status bar. */}
       <div className="flex items-center gap-3">
-        <span className="font-medium text-[var(--color-text-muted)]">{tool?.name ?? ''}</span>
         {lastAction && lastAction.message && (
           <span
             key={`${lastAction.message}-${lastAction.timestamp}`}

--- a/apps/cockpit/src/components/shell/ThemePicker.tsx
+++ b/apps/cockpit/src/components/shell/ThemePicker.tsx
@@ -41,15 +41,65 @@ const LAST_THEME: Theme = FLAT[FLAT.length - 1] ?? 'system'
 // for the real <html> element, just scoped to this swatch instead. No JS
 // color values are read or hardcoded; the browser resolves var(--color-*)
 // against whichever class is nearest.
-function Swatch({ effective, className = '' }: { effective: EffectiveTheme; className?: string }) {
+//
+// The bands mirror the real shell — title bar, sidebar rail, tab strip with one
+// active tab, content, status bar — rather than the three abstract blocks that
+// were here before. What a user is choosing is how the app will look, and three
+// blocks could not answer the questions that actually decide it: whether this
+// theme's surface separates from its background at all, whether its accent
+// survives against its own active tab, and how loud its borders are. All three
+// are legible here and none were before.
+//
+// `className` replaces the default rather than appending to it, so a caller
+// overriding the height (SystemSwatch's half-width split) doesn't end up with
+// two competing height utilities whose winner depends on Tailwind's emit order.
+function Swatch({
+  effective,
+  className = 'h-12',
+}: {
+  effective: EffectiveTheme
+  className?: string
+}) {
   return (
     <span
       aria-hidden="true"
-      className={`${effective} relative block h-8 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-bg)] ${className}`}
+      data-theme-preview={effective}
+      className={`${effective} flex flex-col overflow-hidden rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-bg)] ${className}`}
     >
-      <span className="absolute inset-x-1 bottom-1 top-3 rounded-[2px] bg-[var(--color-surface)]" />
-      <span className="absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full bg-[var(--color-accent)]" />
-      <span className="absolute inset-x-1.5 bottom-1.5 h-1 w-4 rounded-full bg-[var(--color-text)] opacity-70" />
+      {/* Title bar */}
+      <span className="flex h-[5px] shrink-0 items-center gap-[2px] border-b border-[var(--color-border)] bg-[var(--color-surface)] pl-[3px]">
+        <span className="h-[2px] w-[2px] rounded-full bg-[var(--color-text-muted)]" />
+        <span className="h-[2px] w-[2px] rounded-full bg-[var(--color-text-muted)]" />
+      </span>
+
+      <span className="flex min-h-0 flex-1">
+        {/* Sidebar rail, with the active item accented as it is in the real one */}
+        <span className="flex w-[9px] shrink-0 flex-col items-center gap-[3px] border-r border-[var(--color-border)] bg-[var(--color-surface)] pt-[4px]">
+          <span className="h-[2px] w-[5px] rounded-full bg-[var(--color-accent)]" />
+          <span className="h-[2px] w-[5px] rounded-full bg-[var(--color-text-muted)]" />
+          <span className="h-[2px] w-[5px] rounded-full bg-[var(--color-text-muted)]" />
+        </span>
+
+        <span className="flex min-w-0 flex-1 flex-col">
+          {/* Tab strip. The active tab sits on --color-bg under an accent underline,
+              which is the one place a theme's accent has to hold up against its own
+              background rather than against its surface. */}
+          <span className="flex h-[7px] shrink-0 items-end gap-[2px] border-b border-[var(--color-border)] bg-[var(--color-surface)] px-[2px]">
+            <span className="h-[6px] w-[12px] rounded-t-[2px] border-b border-[var(--color-accent)] bg-[var(--color-bg)]" />
+            <span className="h-[4px] w-[9px] rounded-t-[2px] border border-b-0 border-[var(--color-border)]" />
+          </span>
+
+          {/* Content */}
+          <span className="flex min-h-0 flex-1 flex-col justify-center gap-[3px] px-[4px]">
+            <span className="h-[2px] w-[70%] rounded-full bg-[var(--color-text)] opacity-70" />
+            <span className="h-[2px] w-[42%] rounded-full bg-[var(--color-accent)]" />
+            <span className="h-[2px] w-[58%] rounded-full bg-[var(--color-text)] opacity-40" />
+          </span>
+        </span>
+      </span>
+
+      {/* Status bar */}
+      <span className="h-[4px] shrink-0 border-t border-[var(--color-border)] bg-[var(--color-surface)]" />
     </span>
   )
 }
@@ -58,7 +108,7 @@ function SystemSwatch() {
   return (
     <span
       aria-hidden="true"
-      className="relative flex h-8 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--color-border)]"
+      className="relative flex h-12 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--color-border)]"
     >
       <Swatch effective="midnight" className="h-full w-1/2 rounded-none border-0" />
       <Swatch effective="soft-focus" className="h-full w-1/2 rounded-none border-0" />

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -10,6 +10,21 @@ const FOCUS_RING = 'focus-visible:outline-none focus-visible:shadow-[var(--focus
 
 const ICON_BUTTON_CLASS = `flex items-center justify-center rounded p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-hover)] transition-colors ${FOCUS_RING}`
 
+const SIDE_CLUSTER_CLASS = 'relative z-10 flex items-center gap-1'
+
+/**
+ * Horizontal space the centred palette overlay keeps clear on *both* sides, so it can never reach
+ * a cluster no matter how narrow the window gets. Symmetric by construction — an asymmetric
+ * reserve would decentre the palette, which is the whole reason the overlay exists.
+ *
+ * Sized to the widest cluster on each platform, since the reserve has to clear both:
+ *   macOS   — leading is 12px gutter + 76px traffic-light allowance + a 28px button = 116px;
+ *             trailing is 12 + two 28px buttons + gap = 72px. Reserve 120.
+ *   others  — leading is 12 + 28 = 40px; trailing adds the 3×46px window controls to the two
+ *             buttons and their gaps = ~218px. Reserve 224.
+ */
+const SIDE_RESERVE_CLASS = { mac: 'px-[120px]', other: 'px-[224px]' } as const
+
 /**
  * Unified client-side-decorated title bar (Safari-style). Replaces the native titlebar removed
  * by `decorations: false` in tauri.conf.json.
@@ -31,6 +46,20 @@ const ICON_BUTTON_CLASS = `flex items-center justify-center rounded p-1.5 text-[
  * overlay scale in styles/tokens.css — layering must not depend on DOM position — and keeps this
  * bar safe to reorder. Both tiers stay below the `z-[39]` window resize handles and the `--z-scrim`
  * overlay tiers, which must still win over the title bar.
+ *
+ * The palette used to be centred by an absolutely-positioned full-width overlay, which kept it
+ * centred but let it centre *through* the left cluster: it is 480px wide, so below a window width
+ * of 820px its left edge crossed x=170 and painted over the icon buttons. The overlay was
+ * `pointer-events-none`, so those buttons stayed clickable while being invisible — worse than
+ * plain occlusion. `minWidth` in tauri.conf.json is 800, so this was reachable at the smallest
+ * window the app allows.
+ *
+ * The overlay stays — true window-centring is the point of the design, and equal-flex side columns
+ * cannot deliver it here, because the macOS traffic-light allowance is padding on one side only
+ * and slides all three columns left (measured: palette centre 794 against a window centre of 756).
+ * Instead the overlay reserves a symmetric `SIDE_RESERVE` gutter wide enough for the *widest*
+ * cluster, so the palette is centred on the window and still cannot reach either cluster. It
+ * shrinks below its 480px maximum rather than overlapping.
  */
 export function TitleBar() {
   const { isMac } = usePlatform()
@@ -47,7 +76,7 @@ export function TitleBar() {
 
   return (
     <div
-      className={`shell-chrome font-ui relative flex h-11 shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] ${isMac ? 'pl-[78px]' : 'pl-2'} pr-2`}
+      className={`shell-chrome font-ui relative flex h-11 shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3`}
     >
       <div
         data-tauri-drag-region
@@ -64,7 +93,11 @@ export function TitleBar() {
         </div>
       )}
 
-      <div className="relative z-10 flex items-center gap-1">
+      {/* Left: the one control with state worth glancing at. Settings and Shortcuts moved to the
+          trailing edge — both are modal, rarely-used and reachable from the palette, and keeping
+          three buttons here left only 14px between them and the macOS traffic lights, so the
+          cluster read as a fourth window control. */}
+      <div className={`${SIDE_CLUSTER_CLASS} ${isMac ? 'pl-[76px]' : ''}`}>
         <button
           type="button"
           onClick={toggleNotes}
@@ -79,6 +112,18 @@ export function TitleBar() {
             )}
           </span>
         </button>
+      </div>
+
+      <div
+        data-testid="titlebar-palette-slot"
+        className={`pointer-events-none absolute inset-0 z-10 flex items-center justify-center ${
+          isMac ? SIDE_RESERVE_CLASS.mac : SIDE_RESERVE_CLASS.other
+        }`}
+      >
+        <CommandPalette />
+      </div>
+
+      <div className={`${SIDE_CLUSTER_CLASS} ml-auto`}>
         <button
           type="button"
           onClick={toggleSettingsPanel}
@@ -97,23 +142,12 @@ export function TitleBar() {
         >
           <KeyboardIcon size={16} />
         </button>
+        {!isMac && (
+          <div data-testid="titlebar-right-controls" className="ml-1 flex items-center">
+            <WindowControls />
+          </div>
+        )}
       </div>
-
-      {/* Absolutely centred on the full bar width (Safari-style) — stays centred regardless of
-          how wide the left cluster or right-side window controls are, rather than merely sitting
-          between two flex siblings. */}
-      <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-2">
-        <CommandPalette />
-      </div>
-
-      {!isMac && (
-        <div
-          data-testid="titlebar-right-controls"
-          className="relative z-10 ml-auto flex items-center"
-        >
-          <WindowControls />
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
@@ -509,18 +509,23 @@ export function WorkspaceTabStrip() {
                 </button>
               )}
 
-              {/* Top pill indicator for the active tab.
+              {/* Top bar indicator for the active tab.
                   The strip sits above the panel, so the active tab's job is to
                   look continuous with the content below it. A bottom pill drew
                   a bright line across exactly the seam that should disappear;
-                  on the top edge it marks the tab without severing it. */}
+                  on the top edge it marks the tab without severing it.
+
+                  Full tab width rather than a centred 40px pill. The pill sat
+                  directly against the title bar's bottom border with empty tab
+                  either side of it, so it read as a stray 3px artifact of that
+                  divider rather than as a deliberate marker — the top edge of
+                  the tab is the thing being marked, so the marker should span
+                  it. */}
               {isActive && (
                 <span
                   aria-hidden="true"
                   data-testid="tab-pill"
-                  className={`pointer-events-none absolute top-0 left-1/2 h-[3px] -translate-x-1/2 rounded-b-full bg-[var(--color-accent)] ${
-                    isPinned ? 'w-5' : 'w-10'
-                  }`}
+                  className="pointer-events-none absolute inset-x-0 top-0 h-[3px] bg-[var(--color-accent)]"
                 />
               )}
 

--- a/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
@@ -68,6 +68,25 @@ export function WorkspaceTabStrip() {
     return `linear-gradient(to right, ${stops.join(', ')})`
   }, [showLeftFade, showRightFade])
 
+  // Keep the active tab on screen.
+  //
+  // The strip scrolls, but nothing scrolled it: mod+1..9, Ctrl+Tab, the
+  // overflow menu and closing a tab can all select a tab that is scrolled out
+  // of view, leaving a strip with no visible active tab and no clue which way
+  // to scroll to find it. `block: 'nearest'` so a tab that is already visible
+  // is left exactly where it is rather than being centred on every switch.
+  const revealActiveTab = useCallback(
+    (behavior: ScrollBehavior) => {
+      if (!activeTabId) return
+      const el = scrollRef.current?.querySelector<HTMLElement>(`[data-tab-id="${activeTabId}"]`)
+      // jsdom has no layout and so no scrollIntoView; feature-detect rather than
+      // stub it globally, so the tests exercise the same code path as the app.
+      if (typeof el?.scrollIntoView !== 'function') return
+      el.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior })
+    },
+    [activeTabId]
+  )
+
   // Listen for scroll and container resize
   useEffect(() => {
     const el = scrollRef.current
@@ -75,13 +94,26 @@ export function WorkspaceTabStrip() {
     if (typeof ResizeObserver === 'undefined') return
     updateFades()
     el.addEventListener('scroll', updateFades, { passive: true })
-    const ro = new ResizeObserver(updateFades)
+    // Selecting a tab is not the only thing that can push it out of view — so can
+    // anything that narrows the strip, and none of those go through `activeTabId`:
+    // opening the notes drawer, collapsing the sidebar, dragging the sidebar
+    // resizer, resizing the window. Observed live, opening the drawer scrolled the
+    // active tab off the left edge and nothing brought it back.
+    //
+    // `auto` rather than `smooth` here: a sidebar resize-drag fires this on every
+    // frame, and queuing a smooth animation per frame reads as the strip lagging
+    // behind the pointer. Activation keeps `smooth`, where there is one event and
+    // the motion explains where the tab went.
+    const ro = new ResizeObserver(() => {
+      updateFades()
+      revealActiveTab('auto')
+    })
     ro.observe(el)
     return () => {
       el.removeEventListener('scroll', updateFades)
       ro.disconnect()
     }
-  }, [updateFades])
+  }, [updateFades, revealActiveTab])
 
   // Re-check when tabs are added/removed (scroll width changes without a scroll event)
   useEffect(() => {
@@ -96,13 +128,8 @@ export function WorkspaceTabStrip() {
   // to scroll to find it. `block: 'nearest'` so a tab that is already visible
   // is left exactly where it is rather than being centred on every switch.
   useEffect(() => {
-    if (!activeTabId) return
-    const el = scrollRef.current?.querySelector<HTMLElement>(`[data-tab-id="${activeTabId}"]`)
-    // jsdom has no layout and so no scrollIntoView; feature-detect rather than
-    // stub it globally, so the tests exercise the same code path as the app.
-    if (typeof el?.scrollIntoView !== 'function') return
-    el.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' })
-  }, [activeTabId, tabs])
+    revealActiveTab('smooth')
+  }, [revealActiveTab, tabs])
 
   // A vertical wheel over a horizontal strip should scroll it — trackpads emit
   // deltaY for the gesture that visually reads as "along the tabs". Ignored
@@ -318,7 +345,7 @@ export function WorkspaceTabStrip() {
         role="tablist"
         aria-label="Open tools"
         style={maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined}
-        className="flex flex-1 items-stretch overflow-x-auto [scrollbar-width:none]"
+        className="no-scrollbar flex flex-1 items-stretch overflow-x-auto"
         onWheel={handleWheel}
         onKeyDown={(e) => {
           if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return

--- a/apps/cockpit/src/components/shell/__tests__/CommandPalette.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/CommandPalette.test.tsx
@@ -142,6 +142,32 @@ describe('CommandPalette', () => {
     expect(lastOption()).toHaveAttribute('aria-selected', 'true')
   })
 
+  it('shows the mod+digit tab binding on rows for tools that are open in a tab', () => {
+    useUiStore.setState({
+      tabs: [
+        { id: 't1', toolId: 'json-tools' },
+        { id: 't2', toolId: 'base64' },
+      ],
+    })
+
+    render(<CommandPalette />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'base64' } })
+
+    // Second tab → the second digit. The binding exists in useGlobalShortcuts but
+    // was invisible everywhere except the shortcuts modal.
+    const option = screen.getByRole('option', { name: /Base64/ })
+    expect(option.textContent).toMatch(/2$/)
+  })
+
+  it('leaves rows for tools with no open tab unbadged', () => {
+    useUiStore.setState({ tabs: [] })
+
+    render(<CommandPalette />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'base64' } })
+
+    expect(screen.getByRole('option', { name: /Base64/ }).textContent).not.toMatch(/[1-9]$/)
+  })
+
   it('does not persist always-on-top when the window pin call fails', async () => {
     windowApi.setAlwaysOnTop.mockRejectedValueOnce(new Error('blocked'))
     useSettingsStore.setState({ alwaysOnTop: false })

--- a/apps/cockpit/src/components/shell/__tests__/ShortcutsModal.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/ShortcutsModal.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ShortcutsModal } from '@/components/shell/ShortcutsModal'
+import { useUiStore } from '@/stores/ui.store'
+
+beforeEach(() => {
+  useUiStore.setState({ shortcutsModalOpen: true })
+})
+
+afterEach(() => {
+  cleanup()
+  useUiStore.setState({ shortcutsModalOpen: false })
+})
+
+describe('ShortcutsModal — filter', () => {
+  it('shows every category before anything is typed', () => {
+    render(<ShortcutsModal />)
+
+    expect(screen.getByRole('heading', { name: 'Navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Tabs' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Window' })).toBeInTheDocument()
+  })
+
+  it('narrows to matching rows and drops categories that end up empty', () => {
+    render(<ShortcutsModal />)
+
+    fireEvent.change(screen.getByLabelText('Filter shortcuts'), { target: { value: 'notes' } })
+
+    expect(screen.getByText('Toggle notes drawer')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Window' })).not.toBeInTheDocument()
+  })
+
+  it('matches the rendered shortcut, not just the action name', () => {
+    render(<ShortcutsModal />)
+
+    // "palette" is not in the combo and "mod+k" is not in the action text — the
+    // filter has to look at both for either query to work.
+    fireEvent.change(screen.getByLabelText('Filter shortcuts'), { target: { value: 'mod+k' } })
+
+    expect(screen.getByText('Command palette')).toBeInTheDocument()
+    expect(screen.queryByText('Toggle sidebar')).not.toBeInTheDocument()
+  })
+
+  it('says so when nothing matches instead of showing a blank panel', () => {
+    render(<ShortcutsModal />)
+
+    fireEvent.change(screen.getByLabelText('Filter shortcuts'), { target: { value: 'zzzz' } })
+
+    expect(screen.getByText('No matching shortcuts')).toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/components/shell/__tests__/ThemePicker.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/ThemePicker.test.tsx
@@ -8,7 +8,7 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ThemePicker } from '@/components/shell/ThemePicker'
-import { getEffectiveTheme } from '@/lib/theme'
+import { ALL_THEMES, getEffectiveTheme } from '@/lib/theme'
 
 beforeEach(() => {
   document.documentElement.className = 'midnight'
@@ -146,5 +146,51 @@ describe('ThemePicker — focus preview', () => {
 
     expect(document.documentElement.classList.contains('midnight')).toBe(true)
     expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe('ThemePicker — swatch previews', () => {
+  it('scopes each preview to its own theme class rather than the active one', () => {
+    document.documentElement.className = 'midnight'
+    const { container } = render(<ThemePicker value="midnight" onChange={vi.fn()} />)
+
+    // The preview resolves var(--color-*) against the nearest theme class, so
+    // the class on the swatch is the entire mechanism — no colour is read or
+    // hardcoded in JS. A Dracula preview under a Midnight <html> only looks
+    // like Dracula because this class is here.
+    const dracula = container.querySelector('[data-theme-preview="dracula"]')
+    expect(dracula).not.toBeNull()
+    expect(dracula).toHaveClass('dracula')
+  })
+
+  it('renders a preview for every selectable theme', () => {
+    const { container } = render(<ThemePicker value="midnight" onChange={vi.fn()} />)
+
+    // System renders two half-width previews of its own, so the count is
+    // ALL_THEMES plus those two rather than an exact match.
+    const previews = container.querySelectorAll('[data-theme-preview]')
+    expect(previews.length).toBe(ALL_THEMES.length + 2)
+  })
+
+  it('mirrors the shell rather than showing abstract blocks', () => {
+    const { container } = render(<ThemePicker value="midnight" onChange={vi.fn()} />)
+    const preview = container.querySelector('[data-theme-preview="nord"]')
+
+    // Surface/background separation and the accent are the three things a
+    // theme choice actually turns on, so each has to appear somewhere in the
+    // miniature. Asserting on tokens, not on the band layout, keeps this from
+    // breaking every time the geometry is nudged.
+    const html = preview?.innerHTML ?? ''
+    expect(html).toContain('--color-surface')
+    expect(html).toContain('--color-accent')
+    expect(html).toContain('--color-border')
+  })
+
+  it('hides previews from assistive tech, which cannot use them', () => {
+    const { container } = render(<ThemePicker value="midnight" onChange={vi.fn()} />)
+
+    for (const preview of container.querySelectorAll('[data-theme-preview]')) {
+      expect(preview.closest('[aria-hidden="true"]')).not.toBeNull()
+    }
   })
 })

--- a/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
@@ -201,6 +201,42 @@ describe('TitleBar — platform layout', () => {
   })
 })
 
+describe('TitleBar — palette centring', () => {
+  // The palette overlay is 480px wide and centred on the window, so its gutter has to clear the
+  // *widest* cluster on both sides — an asymmetric reserve would decentre it, which defeats the
+  // point of the overlay. jsdom cannot measure this, so the contract is asserted on the classes.
+  it('reserves symmetric space on both sides of the centred palette', () => {
+    for (const platform of ['mac', 'windows'] as const) {
+      mocks.platform.current = platform
+      const { unmount } = render(<TitleBar />)
+      const slot = screen.getByTestId('titlebar-palette-slot')
+
+      expect(slot.className).toMatch(/\bpx-\[\d+px\]/)
+      expect(slot.className).not.toMatch(/\b(pl|pr)-\[/)
+      unmount()
+    }
+  })
+
+  // Notes leads alone; the two modal, rarely-used buttons trail. Three buttons on the leading edge
+  // left 14px between them and the macOS traffic lights, so they read as a fourth window control.
+  it('keeps only the notes button ahead of the palette, with settings and shortcuts behind it', () => {
+    render(<TitleBar />)
+    const slot = screen.getByTestId('titlebar-palette-slot')
+    const before = slot.DOCUMENT_POSITION_PRECEDING
+    const after = slot.DOCUMENT_POSITION_FOLLOWING
+
+    expect(
+      slot.compareDocumentPosition(screen.getByLabelText('Toggle notes drawer')) & before
+    ).toBeTruthy()
+    expect(
+      slot.compareDocumentPosition(screen.getByLabelText('Open settings')) & after
+    ).toBeTruthy()
+    expect(
+      slot.compareDocumentPosition(screen.getByLabelText('Open keyboard shortcuts')) & after
+    ).toBeTruthy()
+  })
+})
+
 describe('TitleBar — drag region', () => {
   it('uses a background drag layer that never contains interactive children', () => {
     const { container } = render(<TitleBar />)

--- a/apps/cockpit/src/components/shell/__tests__/WorkspaceTabStrip.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/WorkspaceTabStrip.test.tsx
@@ -296,9 +296,13 @@ describe('WorkspaceTabStrip — active tab pill indicator', () => {
     // Top edge, not bottom: the strip sits above the panel, so the active tab
     // should read as continuous with the content below it. A bottom pill drew
     // a bright line across precisely the seam that wants to disappear.
+    // Full tab width, not a centred pill: against the title bar's divider a
+    // 40px stub with empty tab either side read as an artifact of that divider
+    // rather than as a marker for the tab it belongs to.
     expect(pill).not.toBeNull()
     expect(pill!.className).toContain('top-0')
-    expect(pill!.className).toContain('rounded-b-full')
+    expect(pill!.className).toContain('inset-x-0')
+    expect(pill!.className).not.toContain('rounded-b-full')
   })
 
   it('does not render a pill on inactive tabs', () => {

--- a/apps/cockpit/src/components/shell/__tests__/WorkspaceTabStrip.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/WorkspaceTabStrip.test.tsx
@@ -771,3 +771,75 @@ describe('WorkspaceTabStrip — overflow menu', () => {
     })
   })
 })
+
+// ── Keeping the active tab in view ─────────────────────────────────
+//
+// The reveal effect used to key only on `[activeTabId, tabs]`, so it fired when
+// you *selected* a tab and never again. Everything else that can push the active
+// tab out of view — opening the notes drawer, collapsing or dragging the sidebar,
+// resizing the window — changes the strip's width without touching either
+// dependency, and left you looking at a strip with no visible active tab.
+//
+// jsdom has neither layout nor `ResizeObserver`, so both are stubbed here. That
+// makes this a test of the *wiring* (does a resize reach `scrollIntoView`, and
+// with which behaviour) rather than of the scrolling itself, which is the part
+// that was actually missing.
+describe('WorkspaceTabStrip — reveal on resize', () => {
+  function withResizeObserver(run: (trigger: () => void) => void) {
+    const callbacks: (() => void)[] = []
+    class StubResizeObserver {
+      constructor(cb: () => void) {
+        callbacks.push(cb)
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'ResizeObserver')
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      value: StubResizeObserver,
+      configurable: true,
+      writable: true,
+    })
+    const scrollIntoView = vi.fn()
+    window.Element.prototype.scrollIntoView = scrollIntoView
+    try {
+      run(() => callbacks.forEach((cb) => cb()))
+    } finally {
+      if (original) Object.defineProperty(globalThis, 'ResizeObserver', original)
+      else delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver
+      delete (window.Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    }
+  }
+
+  it('scrolls the active tab back into view when the strip is resized', () => {
+    withResizeObserver((resize) => {
+      seedTabs(['json-tools', 'diff-viewer', 'base64'])
+      render(<WorkspaceTabStrip />)
+
+      const scrollIntoView = window.Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>
+      scrollIntoView.mockClear()
+
+      act(() => resize())
+
+      expect(scrollIntoView).toHaveBeenCalled()
+      // `auto`, not `smooth`: a sidebar resize-drag fires this on every frame,
+      // and nine overlapping smooth scrolls fight each other.
+      expect(scrollIntoView).toHaveBeenLastCalledWith(expect.objectContaining({ behavior: 'auto' }))
+    })
+  })
+
+  it('does nothing when there is no active tab to reveal', () => {
+    withResizeObserver((resize) => {
+      useUiStore.setState({ tabs: [], activeTabId: null, activeTool: '', tabMru: [] })
+      render(<WorkspaceTabStrip />)
+
+      const scrollIntoView = window.Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>
+      scrollIntoView.mockClear()
+
+      act(() => resize())
+
+      expect(scrollIntoView).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/sidebar.test.tsx
@@ -57,10 +57,25 @@ const TOOLS: ToolDefinition[] = [
   },
 ]
 
+// The store is a module singleton and one test below swaps `setActiveTool` for a
+// spy. Without restoring it here, every later test that clicks a tool is asserting
+// against the previous test's mock, which silently does nothing.
+const realSetActiveTool = useUiStore.getState().setActiveTool
+
 beforeEach(() => {
   cleanup()
   useToolStateCache.setState({ cache: new Map() })
-  useUiStore.setState({ activeTool: '' })
+  // Tabs and recents are singleton state that clicking a tool writes to, and
+  // `SidebarRecent` renders a `data-sidebar-item` per recent — so a leaked
+  // recent breaks the "one node per tool id" invariant asserted further down.
+  useUiStore.setState({
+    activeTool: '',
+    setActiveTool: realSetActiveTool,
+    recentToolIds: [],
+    tabs: [],
+    tabMru: [],
+    activeTabId: null,
+  })
   useSettingsStore.setState({ ...DEFAULT_SETTINGS, initialized: true })
 })
 
@@ -246,6 +261,51 @@ describe('SidebarPinned — favorite tools', () => {
 
     expect(screen.getByRole('heading', { name: 'Pinned' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Base64' })).toBeInTheDocument()
+  })
+})
+
+// ── Pinned tools in the collapsed rail ─────────────────────────────
+
+describe('Sidebar — pinned tools in the collapsed rail', () => {
+  it('gives each pinned tool its own rail button that activates on one click', () => {
+    useSettingsStore.setState({ sidebarCollapsed: true, pinnedToolIds: ['base64'] })
+    // Tabs are module-singleton state and earlier tests leave some behind; a
+    // stale base64 tab would make `openTab` take its "already open" branch and
+    // this assertion pass for the wrong reason.
+    useUiStore.setState({ activeTool: '', tabs: [], tabMru: [], activeTabId: null })
+
+    render(<Sidebar />)
+
+    const pin = screen.getByRole('button', { name: 'Base64 (pinned)' })
+    expect(pin).toBeInTheDocument()
+
+    // One click, not two: the group flyout route costs an extra click, which is
+    // the thing pinning is supposed to buy you out of.
+    fireEvent.click(pin)
+    expect(useUiStore.getState().activeTool).toBe('base64')
+  })
+
+  it('skips pin ids whose tool no longer exists rather than rendering a hole', () => {
+    useSettingsStore.setState({ sidebarCollapsed: true, pinnedToolIds: ['ghost-tool', 'base64'] })
+
+    render(<Sidebar />)
+
+    expect(document.querySelectorAll('[data-sidebar-collapsed-tool]')).toHaveLength(1)
+    expect(document.querySelector('[data-sidebar-collapsed-tool="base64"]')).toBeInTheDocument()
+  })
+
+  it('includes pinned tools in the collapsed rail arrow-key run', () => {
+    useSettingsStore.setState({ sidebarCollapsed: true, pinnedToolIds: ['base64'] })
+
+    render(<Sidebar />)
+
+    const pin = screen.getByRole('button', { name: 'Base64 (pinned)' })
+    pin.focus()
+    fireEvent.keyDown(pin, { key: 'ArrowDown' })
+
+    // Down from the last pin must land on the first group, not skip the pins'
+    // existence entirely and jump somewhere unrelated.
+    expect(document.activeElement).toHaveAttribute('data-sidebar-collapsed-group')
   })
 })
 

--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -68,6 +68,20 @@ body,
   background: var(--color-text-muted);
 }
 
+/* Opt a scroller out of the bars above.
+ *
+ * `scrollbar-width: none` alone is not enough: it is the Firefox property, and the
+ * app ships in WKWebView (macOS) and WebView2 (Windows), which both need the
+ * `::-webkit-scrollbar` rule. Set on its own it left an 8px bar — inherited from the
+ * global rule above — painted across the bottom of the tab strip, which is only 36px
+ * tall to begin with. Use this class rather than `[scrollbar-width:none]`. */
+.no-scrollbar {
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 /* ─── Global focus ring ─────────────────────────────────────────────────────
    Covers every interactive element. Individual components must NOT add
    focus:outline-none unless they supply their own focus-visible style.       */

--- a/apps/cockpit/src/lib/tool-samples.ts
+++ b/apps/cockpit/src/lib/tool-samples.ts
@@ -88,10 +88,128 @@ limits:
   // it verifies, the built-in sample would have announced "Signature invalid" and looked broken.
   'jwt-decoder':
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZW1vLXVzZXIiLCJuYW1lIjoiQWRhIEV4YW1wbGUiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTk5OTk5OTk5OX0.QN2XAKs0z0ZCi7e8xNwnR2pfHYRKLcfKO-hYDP1OOA0',
+
+  // Exercises every branch the converter has: a non-GET method, two headers, a
+  // JSON body and a query string. A bare `curl https://example.com` would
+  // convert successfully and demonstrate none of it.
+  'curl-to-fetch': `curl 'https://api.example.com/v1/orders?status=open' \\
+  -X POST \\
+  -H 'Authorization: Bearer demo-token' \\
+  -H 'Content-Type: application/json' \\
+  -d '{"sku":"book-001","qty":2}'`,
+
+  // Half of these map cleanly to Tailwind and half deliberately do not
+  // (`grid-template-columns`, `backdrop-filter`), so the "unconvertible" list is
+  // populated too — a sample that converted perfectly would hide the half of the
+  // output that matters most.
+  //
+  // Note for editors: the design-system lint gate reads raw source text, so it
+  // cannot tell a CSS sample from a className, and it does not spare comments
+  // either. A `transition` shorthand naming a bare easing keyword, or a hex
+  // colour beside the word `class`, is reported here as a violation even though
+  // this string styles nothing — and the escape-hatch comment is no help,
+  // because inside a template literal it would become part of the sample. Pick
+  // properties that don't collide, and describe them without quoting them.
+  'css-to-tailwind': `.card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  margin-top: 8px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  backdrop-filter: blur(4px);
+}`,
 }
 
 /**
- * TypeScript Playground's starting document, also offered as "Load example"
+ * Regex Tester needs a pattern, flags and a subject rather than a single input
+ * string. The pattern is a readable one with two named-ish capture groups so the
+ * match list, the group count in the toolbar and the `$1`/`$2` replacement
+ * syntax all have something to show at once.
+ */
+export const REGEX_TESTER_SAMPLE = {
+  pattern: '(\\w+)@(\\w+\\.\\w+)',
+  flags: 'g',
+  testString: `Contact ada@example.com for billing questions.
+Escalations go to grace@example.org, and the on-call
+address is alan@example.net. Plain text like "user at
+host" is deliberately not an address and should not match.`,
+}
+
+/**
+ * Code Formatter's samples, keyed by the language ids in
+ * `src/tools/code-formatter/languages.ts`. Every one is deliberately
+ * mis-formatted — inconsistent indentation, run-together statements, stray
+ * whitespace — because a sample that is already formatted makes the tool look
+ * broken when pressing Format changes nothing.
+ *
+ * There is one per supported language rather than a single JavaScript sample:
+ * the language selector defaults to JavaScript but the button would then vanish
+ * for the other eleven, which reads as a bug rather than as a decision.
+ */
+export const CODE_FORMATTER_SAMPLES: Partial<Record<string, string>> = {
+  javascript: `const orders=[{sku:'book-001',qty:2},{sku:'pen-014',qty:5}]
+function total(items){return items.reduce((sum,i)=>{
+return sum+i.qty},0)}
+console.log( total(orders) )`,
+
+  typescript: `interface Order{sku:string;qty:number}
+const orders:Order[]=[{sku:'book-001',qty:2},{sku:'pen-014',qty:5}]
+function total(items:Order[]):number{return items.reduce((sum,i)=>{
+return sum+i.qty},0)}`,
+
+  json: `{"id":"ord_8f2a1c","customer":"Ada Lovelace",
+"items":[{"sku":"book-001","qty":2},{"sku":"pen-014","qty":5}],"shipped":false}`,
+
+  css: `.card{display:flex;padding:16px 24px;
+  border-radius:8px}
+.card    .title{font-size:14px;font-weight:600}`,
+
+  scss: `$accent:#3b82f6;
+.card{display:flex;padding:16px;
+&__title{color:$accent;font-weight:600}
+&:hover{box-shadow:0 1px 2px rgba(0,0,0,.2)}}`,
+
+  less: `@accent:#3b82f6;
+.card{display:flex;padding:16px;
+.title{color:@accent;font-weight:600}
+&:hover{box-shadow:0 1px 2px fade(#000,20%)}}`,
+
+  html: `<div class="card"><h3>Sales</h3>
+<p>Totals for the current quarter.</p>
+   <ul><li>Books</li><li>Stationery</li></ul></div>`,
+
+  markdown: `#  Release notes
+Formatting  is  inconsistent   here.
+*  first item
+*  second item
+
+|Tool|Status|
+|-|-|
+|Formatter|Shipped|`,
+
+  yaml: `service:    cockpit
+features: [json-tools,   yaml-tools, diff-viewer]
+limits:   {maxUploadMb: 25, timeoutSec: 30}`,
+
+  xml: `<?xml version="1.0"?><catalog><book id="bk101">
+<author>Ada Lovelace</author><title>Notes on the Analytical Engine</title>
+</book></catalog>`,
+
+  sql: `select o.id, c.name, sum(i.qty) as items from orders o
+join customers c on c.id=o.customer_id join order_items i
+on i.order_id=o.id where o.shipped=false group by o.id, c.name order by items desc`,
+
+  graphql: `query Orders($status:String!){orders(status:$status){
+id customer{name email} items{sku qty price} total}}`,
+}
+
+/**
+ * TypeScript Playground's starting document, also offered as "Load sample"
  * once the editor is empty. Deliberately exercises interfaces, generics via
  * `Array.map` and a DOM global so a broken standard library shows up at once.
  */
@@ -112,7 +230,7 @@ console.log(greeting)
 `
 
 /**
- * Refactoring Toolkit's "Load example". Deliberately contains something for
+ * Refactoring Toolkit's "Load sample". Deliberately contains something for
  * every category: `var` and a `function` expression to modernise, a loose `==`
  * to tighten, and a `console.log` for the destructive cleanup transforms.
  */

--- a/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
@@ -13,6 +13,7 @@ import { FORMATTER_WORKER_METHODS } from '@/workers/formatter.methods'
 import { dispatchToolAction } from '@/lib/tool-actions'
 import { saveFileDialog } from '@/lib/file-io'
 import { useUiStore } from '@/stores/ui.store'
+import { CODE_FORMATTER_SAMPLES } from '@/lib/tool-samples'
 
 vi.mock('@/lib/file-io', () => ({
   saveFileDialog: vi.fn(),
@@ -299,5 +300,35 @@ describe('formatter parser coverage', () => {
     for (const language of LANGUAGES) {
       expect(supported.has(language.id), `${language.id} is missing a parser`).toBe(true)
     }
+  })
+})
+
+describe('CodeFormatter — Load sample', () => {
+  it('names the selected language and loads a sample in it', () => {
+    renderTool(CodeFormatter)
+
+    // The label names the language because the sample depends on it — loading
+    // JavaScript into a buffer set to SQL would format it as SQL.
+    fireEvent.click(screen.getByRole('button', { name: 'Load JavaScript sample' }))
+
+    expect((screen.getByTestId('monaco-editor') as HTMLTextAreaElement).value).toContain(
+      'const orders='
+    )
+    expect(screen.queryByRole('button', { name: /Load .* sample/ })).not.toBeInTheDocument()
+  })
+
+  it('follows the language selector', () => {
+    renderTool(CodeFormatter)
+
+    fireEvent.change(screen.getByLabelText(/language/i), { target: { value: 'sql' } })
+
+    expect(screen.getByRole('button', { name: 'Load SQL sample' })).toBeInTheDocument()
+  })
+
+  it('has a sample for every supported language', () => {
+    // The button renders only when a sample exists, so a language added without
+    // one loses the affordance silently — which reads as a bug, not a decision.
+    const missing = LANGUAGES.filter((l) => !CODE_FORMATTER_SAMPLES[l.id]).map((l) => l.id)
+    expect(missing).toEqual([])
   })
 })

--- a/apps/cockpit/src/tools/__tests__/color-converter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/color-converter.test.tsx
@@ -48,3 +48,28 @@ describe('ColorConverter', () => {
     expect(screen.queryByText(/hsl\(120, 150%/i)).not.toBeInTheDocument()
   })
 })
+
+describe('ColorConverter — status and copy affordance', () => {
+  it('reports the parsed color in the document toolbar', () => {
+    renderTool(ColorConverter)
+
+    expect(screen.getByTestId('color-status')).toHaveTextContent('#39FF14')
+    expect(screen.getByTestId('color-status')).toHaveTextContent('formats')
+  })
+
+  it('says the input was not understood rather than silently showing nothing', () => {
+    renderTool(ColorConverter)
+    fireEvent.change(screen.getByPlaceholderText(/#39ff14/), { target: { value: 'not a color' } })
+
+    expect(screen.getByTestId('color-status')).toHaveTextContent('Unrecognised color')
+  })
+
+  it('makes each format row itself the copy target, not a column of Copy buttons', () => {
+    renderTool(ColorConverter)
+
+    // One button per format, labelled with the format — the seven identically
+    // labelled "Copy" buttons this replaced told you nothing about their target.
+    expect(screen.getByRole('button', { name: /Copy Hex value/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Copy RGB value/ })).toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/css-to-tailwind.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/css-to-tailwind.test.tsx
@@ -82,3 +82,27 @@ describe('CssToTailwind', () => {
     })
   })
 })
+
+describe('CssToTailwind — Load sample', () => {
+  it('fills the editor and produces both converted and unconvertible output', () => {
+    renderTool(CssToTailwind)
+
+    // The empty state is the only thing on screen until something is entered,
+    // and before this it offered no way out except knowing what to type.
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
+
+    expect((screen.getByTestId('monaco-editor') as HTMLTextAreaElement).value).toContain(
+      'display: flex'
+    )
+    expect(screen.getByText('Converted Classes')).toBeInTheDocument()
+    // The half that matters: a sample converting cleanly would never show this.
+    expect(screen.getByText('Unconvertible')).toBeInTheDocument()
+  })
+
+  it('replaces the empty state rather than sitting alongside it', () => {
+    renderTool(CssToTailwind)
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
+
+    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/curl-to-fetch.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/curl-to-fetch.test.tsx
@@ -118,3 +118,21 @@ describe('CurlToFetch', () => {
     expect(cached['activeRequestId']).toBeNull()
   })
 })
+
+describe('CurlToFetch — Load sample', () => {
+  it('converts the sample and clears the empty state', async () => {
+    renderTool(CurlToFetch)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
+
+    // A sample that parsed to a bare GET would demonstrate none of the
+    // converter — method, headers and body all have to survive the round trip.
+    await waitFor(() => {
+      const output = (screen.getAllByTestId('monaco-editor').at(-1) as HTMLTextAreaElement).value
+      expect(output).toContain("method: 'POST'")
+      expect(output).toContain('Authorization')
+      expect(output).toContain('body')
+    })
+    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/diff-viewer.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/diff-viewer.test.tsx
@@ -280,3 +280,35 @@ describe('diff helpers', () => {
     )
   })
 })
+
+// The comparison pane used to take half the window before there was anything to
+// compare, so the largest thing on screen was an empty state telling you to use
+// the editors it had just squashed.
+describe('DiffViewer — uncompared layout', () => {
+  it('reduces the comparison pane to a single prompt line in split view', () => {
+    renderTool(DiffViewer)
+
+    const grid = document.querySelector('.grid')
+    expect(grid?.className).toContain('grid-rows-[1fr_auto]')
+    expect(screen.getByText(/Paste the original on the left/)).toBeInTheDocument()
+    // The full-pane empty state belongs to the diff-only view, not this one.
+    expect(screen.queryByText('Nothing to compare')).not.toBeInTheDocument()
+  })
+
+  it('gives the comparison half the window once there is a result', async () => {
+    renderTool(DiffViewer)
+    fillBothSides()
+    pressCompareShortcut()
+
+    await waitFor(() => {
+      expect(document.querySelector('.grid')?.className).toContain('grid-rows-2')
+    })
+  })
+
+  it('keeps the full empty state in the diff-only view, where the pane is all there is', () => {
+    renderTool(DiffViewer)
+    fireEvent.click(screen.getByRole('radio', { name: 'Diff' }))
+
+    expect(screen.getByText('Nothing to compare')).toBeInTheDocument()
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -344,6 +344,21 @@ describe('JsonTools', () => {
     })
   })
 
+  // This bar wraps to two rows at 1024px. With view options first the wrap put Indent/Path/view
+  // mode on row one and buried every primary action beneath them, so the least important row has
+  // to be the one that sheds last. Save is labelled for the same reason Copy JSON is — an
+  // unlabelled floppy disk next to five labelled buttons reads as a different class of control.
+  it('leads the toolbar with document actions and trails with view options', () => {
+    renderTool(JsonTools)
+    const actions = screen.getByRole('group', { name: 'Document actions' })
+    const viewOptions = screen.getByRole('group', { name: 'View options' })
+
+    expect(
+      actions.compareDocumentPosition(viewOptions) & actions.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(within(actions).getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
   it('offers a sample only while the document is empty', () => {
     renderTool(JsonTools)
     fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))

--- a/apps/cockpit/src/tools/__tests__/jwt-decoder.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/jwt-decoder.test.tsx
@@ -50,11 +50,11 @@ describe('JwtDecoder', () => {
     expect(screen.getByText(/invalid jwt/i)).toBeInTheDocument()
   })
 
-  it('loads the fake sample token via Load Sample and decodes it through the same input path as typing', () => {
+  it('loads the fake sample token via Load sample and decodes it through the same input path as typing', () => {
     renderTool(JwtDecoder)
-    expect(screen.getByText('Load Sample')).toBeInTheDocument()
+    expect(screen.getByText('Load sample')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('Load Sample'))
+    fireEvent.click(screen.getByText('Load sample'))
 
     const input = screen.getByPlaceholderText(/paste a jwt/i) as HTMLTextAreaElement
     expect(input.value).toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9')

--- a/apps/cockpit/src/tools/__tests__/refactoring-toolkit.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/refactoring-toolkit.test.tsx
@@ -236,9 +236,9 @@ describe('RefactoringToolkit', () => {
 
   it('offers an example while the buffer is empty', () => {
     renderTool(RefactoringToolkit)
-    fireEvent.click(screen.getByRole('button', { name: 'Load example' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
 
     expect(editor().value).toContain("var API = require('./api')")
-    expect(screen.queryByRole('button', { name: 'Load example' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderTool } from '@/tools/__tests__/test-utils'
 import RegexTester, { describeMatches } from '@/tools/regex-tester/RegexTester'
+import { REGEX_TESTER_SAMPLE } from '@/lib/tool-samples'
 
 const setPattern = (value: string) =>
   fireEvent.change(screen.getByPlaceholderText(/enter regex pattern/i), { target: { value } })
@@ -266,5 +267,31 @@ describe('RegexTester (component)', () => {
 
     // Back to "show diff" title
     expect(screen.getByTitle(/show diff/i)).toBeInTheDocument()
+  })
+})
+
+describe('RegexTester — Load sample', () => {
+  it('fills pattern, flags and subject together and produces matches', async () => {
+    renderTool(RegexTester)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
+
+    expect(screen.getByPlaceholderText(/enter regex pattern/i)).toHaveValue(
+      REGEX_TESTER_SAMPLE.pattern
+    )
+    expect(screen.getByPlaceholderText(/enter text to test/i)).toHaveValue(
+      REGEX_TESTER_SAMPLE.testString
+    )
+    // Both halves at once is the point: a pattern with no subject, or a subject
+    // with no pattern, still shows the user nothing.
+    await expect(screen.findByTestId('match-count')).resolves.toHaveTextContent('3 matches')
+  })
+
+  it('disappears once either field has been touched, so it cannot overwrite work', () => {
+    renderTool(RegexTester)
+
+    setPattern('\\d+')
+
+    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/regex-tester.test.tsx
@@ -57,7 +57,21 @@ describe('RegexTester (component)', () => {
     fireEvent.change(screen.getByPlaceholderText(/enter text to test/i), {
       target: { value: 'abc 123 def 456' },
     })
-    expect(await screen.findByText('2')).toBeInTheDocument()
+    // The badge reads "2 matches", split across text nodes by the JSX — a
+    // bare getByText('2') would miss it.
+    expect(await screen.findByTestId('match-count')).toHaveTextContent('2 matches')
+  })
+
+  it('names the capture-group count next to the match count', async () => {
+    renderTool(RegexTester)
+    setPattern('(\\d)(\\d)')
+    setText('12 34')
+
+    // Captures across all matches — the same total the sr-only live region and
+    // the matches pane already report. It previously existed only there, so a
+    // sighted user had to count parentheses to get it.
+    expect(await screen.findByTestId('match-count')).toHaveTextContent('2 matches')
+    expect(screen.getByTestId('match-count')).toHaveTextContent('4 groups')
   })
 
   it('exposes regex flag toggle pressed state', () => {
@@ -175,7 +189,7 @@ describe('RegexTester (component)', () => {
       target: { value: 'a'.repeat(1205) },
     })
 
-    expect(await screen.findByText('1000+')).toBeInTheDocument()
+    expect(await screen.findByTestId('match-count')).toHaveTextContent('1000+ matches')
     expect(screen.getByText('Showing first 1000 matches')).toBeInTheDocument()
     expect(screen.getByText(/First 1000 matches/)).toBeInTheDocument()
   })
@@ -214,7 +228,9 @@ describe('RegexTester (component)', () => {
     setPattern('\\d+')
     setText('abc 123 def 456')
 
-    expect(await screen.findByText('2')).toBeInTheDocument()
+    // The badge reads "2 matches", split across text nodes by the JSX — a
+    // bare getByText('2') would miss it.
+    expect(await screen.findByTestId('match-count')).toHaveTextContent('2 matches')
 
     const live = document.querySelectorAll('[aria-live]')
     expect(live).toHaveLength(1)

--- a/apps/cockpit/src/tools/__tests__/ts-playground.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/ts-playground.test.tsx
@@ -62,9 +62,9 @@ describe('TsPlayground', () => {
     expect(screen.getByRole('button', { name: /Compile/ })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Save output to file' })).toBeDisabled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Load example' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
     expect(editors()[0]!.value).toContain('interface User')
-    expect(screen.queryByRole('button', { name: 'Load example' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
     await waitFor(() => expect(screen.getByRole('button', { name: /Compile/ })).toBeEnabled())
   })
 

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -36,6 +36,7 @@ import {
   supportsJsStyleOptions,
   supportsQuoteStyle,
 } from '@/tools/code-formatter/languages'
+import { CODE_FORMATTER_SAMPLES } from '@/lib/tool-samples'
 
 type CodeFormatterState = {
   input: string
@@ -426,6 +427,21 @@ export default function CodeFormatter() {
               {LANGUAGES.length} languages supported. Press <Kbd keys="mod+enter" /> to format, or
               open a file with <Kbd keys="mod+o" />.
             </p>
+            {/* Keyed to the selected language, not a single JavaScript snippet:
+                loading JS into a buffer set to SQL would format it as SQL and
+                make the formatter look broken. Every sample is deliberately
+                mis-formatted, because one that came in already tidy would make
+                pressing Format appear to do nothing. */}
+            {CODE_FORMATTER_SAMPLES[state.language] && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => updateState({ input: CODE_FORMATTER_SAMPLES[state.language] ?? '' })}
+                className="pointer-events-auto"
+              >
+                Load {languageLabel(state.language)} sample
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -236,7 +236,7 @@ export default function CodeFormatter() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar border={false} aria-label="Code formatting actions">
+          <DocumentToolbar aria-label="Code formatting actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}
               icon={
@@ -327,14 +327,16 @@ export default function CodeFormatter() {
               </Button>
               <CopyButton text={input} />
               <Button
-                variant="icon"
+                variant="secondary"
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasCode}
                 title={`Save to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save to file"
+                className="gap-1"
               >
                 <FloppyDiskIcon size={14} aria-hidden="true" />
+                Save
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useToolState } from '@/hooks/useToolState'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { CopyButton } from '@/components/shared/CopyButton'
+import { DocumentIdentity, DocumentToolbar } from '@/components/shared/Toolbar'
 import { Field } from '@/components/shared/Field'
 import { Panel } from '@/components/shared/Panel'
 import { useUiStore } from '@/stores/ui.store'
@@ -9,7 +11,14 @@ import { Input } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { StatusBadge } from '@/components/shared/StatusBadge'
-import { ArrowsLeftRightIcon, CheckCircleIcon, XCircleIcon } from '@phosphor-icons/react'
+import {
+  ArrowsLeftRightIcon,
+  CheckCircleIcon,
+  CheckIcon,
+  CopyIcon,
+  PaletteIcon,
+  XCircleIcon,
+} from '@phosphor-icons/react'
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -478,6 +487,62 @@ function findCssName(hex: string): string | null {
   return null
 }
 
+// ── Format Row ───────────────────────────────────────────────────────
+
+/**
+ * One `LABEL: value` row in the Formats section.
+ *
+ * The whole row is the copy target. It used to be a static row with a `CopyButton`
+ * pinned to its right, which meant seven identically-labelled "Copy" buttons in a
+ * column — the label carried no information and the value, the thing you were
+ * actually aiming at, wasn't clickable. The tick replaces the trailing icon in
+ * place so the row doesn't reflow on copy.
+ */
+function FormatRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = useCopyToClipboard()
+
+  async function handleCopy() {
+    if (!(await copy(value))) return
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    /* A clickable row, not a button: no Button variant expresses a bordered surface panel with
+     * justify-between content, and overriding one's padding and background via className would
+     * fight the primitive rather than use it. */
+    // eslint-disable-next-line no-restricted-syntax -- clickable row, see above
+    <button
+      type="button"
+      onClick={() => {
+        void handleCopy()
+      }}
+      aria-label={copied ? `${label} copied` : `Copy ${label} value ${value}`}
+      className="group flex w-full items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-left transition-colors duration-[var(--duration-fast)] hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)]"
+    >
+      <div>
+        <span className="text-xs text-[var(--color-text-muted)]">{label}: </span>
+        <span className="font-mono text-sm text-[var(--color-text)]">{value}</span>
+      </div>
+      {copied ? (
+        <CheckIcon
+          size={14}
+          weight="bold"
+          aria-hidden="true"
+          className="shrink-0 text-[var(--color-success)]"
+        />
+      ) : (
+        <CopyIcon
+          size={14}
+          aria-hidden="true"
+          className="shrink-0 text-[var(--color-text-muted)] opacity-0 transition-opacity duration-[var(--duration-fast)] group-hover:opacity-100 group-focus-visible:opacity-100"
+        />
+      )}
+    </button>
+  )
+}
+
 // ── Contrast Inputs (avoids double parseColor calls) ─────────────────
 
 function ContrastInputs({
@@ -629,7 +694,57 @@ export default function ColorConverter() {
   }, [state.contrastFg, state.contrastBg, updateState, setLastAction])
 
   return (
-    <ToolLayout maxWidth="max-w-4xl">
+    <ToolLayout
+      maxWidth="max-w-4xl"
+      toolbar={
+        // Same chrome grammar as the document tools: identity on the left, live
+        // status beside it. This tool had neither, so a parse failure showed up
+        // only as the rest of the page silently not being there.
+        <DocumentToolbar aria-label="Color status">
+          <DocumentIdentity
+            title={color ? (color.cssName ?? color.hex.toUpperCase()) : 'No color'}
+            icon={
+              color ? (
+                <span
+                  aria-hidden="true"
+                  className="h-4 w-4 shrink-0 rounded border border-[var(--color-border)]"
+                  style={{ backgroundColor: color.hex }}
+                />
+              ) : (
+                <PaletteIcon
+                  size={16}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-text-muted)]"
+                />
+              )
+            }
+            status={
+              color
+                ? `${color.hex.toUpperCase()} · ${formats.length} formats`
+                : state.input.trim()
+                  ? 'Unrecognised color'
+                  : 'Enter a color to convert'
+            }
+            statusTestId="color-status"
+            statusIcon={
+              color ? (
+                <CheckCircleIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-success)]"
+                />
+              ) : state.input.trim() ? (
+                <XCircleIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0 text-[var(--color-error)]"
+                />
+              ) : undefined
+            }
+          />
+        </DocumentToolbar>
+      }
+    >
       <div className="flex flex-col gap-4">
         {/* ── Input ──────────────────────────────────────── */}
         <Panel title="Color Input">
@@ -691,16 +806,7 @@ export default function ColorConverter() {
             {activeSection === 'formats' && (
               <section className="flex flex-col gap-2">
                 {formats.map((f) => (
-                  <div
-                    key={f.label}
-                    className="flex items-center justify-between rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2"
-                  >
-                    <div>
-                      <span className="text-xs text-[var(--color-text-muted)]">{f.label}: </span>
-                      <span className="font-mono text-sm text-[var(--color-text)]">{f.value}</span>
-                    </div>
-                    <CopyButton text={f.value} />
-                  </div>
+                  <FormatRow key={f.label} label={f.label} value={f.value} />
                 ))}
               </section>
             )}

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from 'react'
 import Editor from '@monaco-editor/react'
+import { WindIcon } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
+import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SplitPane } from '@/components/shared/SplitPane'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { TOOL_SAMPLES } from '@/lib/tool-samples'
 
 type CssToTailwindState = {
   input: string
@@ -403,7 +406,22 @@ export default function CssToTailwind() {
                 )}
               </div>
             ) : (
-              <EmptyState title="Enter CSS on the left to convert" />
+              <EmptyState
+                icon={WindIcon}
+                title="Enter CSS on the left to convert"
+                description="Declarations map to Tailwind utilities; anything without an equivalent is listed separately."
+                action={
+                  TOOL_SAMPLES['css-to-tailwind'] ? (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => updateState({ input: TOOL_SAMPLES['css-to-tailwind'] ?? '' })}
+                    >
+                      Load sample
+                    </Button>
+                  ) : undefined
+                }
+              />
             )}
           </div>
         </div>

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -466,7 +466,7 @@ export default function CssValidator() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <DocumentToolbar border={false} aria-label="Stylesheet actions">
+        <DocumentToolbar aria-label="Stylesheet actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled stylesheet'}
             titleTooltip={state.filePath ?? state.fileName ?? 'Untitled stylesheet'}

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -465,7 +465,14 @@ export default function CssValidator() {
 
   return (
     <ToolLayout fullBleed>
-      <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+      {/* The seam belongs to the rules panel, not the toolbar: it marks the bottom of a chrome
+          block that is genuinely two rows tall. With the panel closed this header is a single
+          toolbar row, and a border would be the divider the toolbar primitive dropped. */}
+      <header
+        className={`bg-[var(--color-surface)] ${
+          state.showRules ? 'border-b border-[var(--color-border)]' : ''
+        }`}
+      >
         <DocumentToolbar aria-label="Stylesheet actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled stylesheet'}

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -423,14 +423,16 @@ export default function CsvTools() {
               }
             />
             <Button
-              variant="ghost"
+              variant="secondary"
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}
               title={`Save the current view to a file (${formatShortcut('mod+s')})`}
               aria-label="Save output to file"
+              className="gap-1"
             >
-              <FloppyDiskIcon size={16} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -12,6 +12,9 @@ import { sendToTool } from '@/lib/tool-handoff'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
 import { TextArea } from '@/components/shared/TextArea'
+import { EmptyState } from '@/components/shared/EmptyState'
+import { TOOL_SAMPLES } from '@/lib/tool-samples'
+import { TerminalWindowIcon } from '@phosphor-icons/react'
 import { Alert } from '@/components/shared/Alert'
 import { PlayIcon } from '@phosphor-icons/react'
 
@@ -357,8 +360,24 @@ export default function CurlToFetch() {
               Could not parse cURL command
             </Alert>
           ) : (
-            <div className="p-4 text-sm text-[var(--color-text-muted)]">
-              Paste a cURL command on the left
+            <div className="flex flex-1 items-center justify-center p-4">
+              <EmptyState
+                icon={TerminalWindowIcon}
+                size="sm"
+                title="Paste a cURL command on the left"
+                description="Copy as cURL from any browser's network panel. The command is parsed here — nothing is sent."
+                action={
+                  TOOL_SAMPLES['curl-to-fetch'] ? (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => updateState({ input: TOOL_SAMPLES['curl-to-fetch'] ?? '' })}
+                    >
+                      Load sample
+                    </Button>
+                  ) : undefined
+                }
+              />
             </div>
           )}
         </div>

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -387,6 +387,19 @@ export default function DiffViewer() {
   const showEditors = state.view !== 'diff'
   const showDiff = state.view !== 'editors'
 
+  // Is there anything in the comparison pane worth giving half the window to?
+  //
+  // "Nothing to compare" is not. Splitting the pane 50/50 regardless meant the
+  // empty state — whose entire message is "paste into the editors" — was the
+  // largest thing on screen, crowding out the editors it was pointing at. The
+  // editors keep the space until there is a real result to show.
+  const hasComparison = identical || isComparing || !!diffHtml
+
+  const prompt = bothSidesFilled
+    ? `Press ${formatShortcut('mod+enter')} to compare the two sides.`
+    : 'Paste the original on the left and the modified version on the right.'
+  const canLoadSample = !state.left.trim() && !state.right.trim()
+
   const diffBody = identical ? (
     <EmptyState
       icon={CheckCircleIcon}
@@ -413,18 +426,29 @@ export default function DiffViewer() {
       style={D2H_THEME_VARS}
       dangerouslySetInnerHTML={sanitizedDiffProp}
     />
+  ) : showEditors ? (
+    // Split view, nothing compared yet: one line, not a full-pane empty state.
+    // The editors above already say what to do by being empty and focusable, and
+    // the toolbar carries Compare — this only has to name the next step and hand
+    // over the sample.
+    <div className="flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-muted)]">
+      <GitDiffIcon size={14} aria-hidden="true" />
+      <span>{prompt}</span>
+      {canLoadSample && (
+        <Button variant="ghost" size="xs" onClick={loadSample}>
+          Load sample
+        </Button>
+      )}
+    </div>
   ) : (
+    // Diff-only view: the pane is all there is, so the full empty state is right.
     <EmptyState
       icon={GitDiffIcon}
       size="sm"
       title={bothSidesFilled ? 'No comparison yet' : 'Nothing to compare'}
-      description={
-        bothSidesFilled
-          ? `Press ${formatShortcut('mod+enter')} to compare the two sides.`
-          : 'Paste the original on the left and the modified version on the right.'
-      }
+      description={prompt}
       action={
-        !state.left.trim() && !state.right.trim() ? (
+        canLoadSample ? (
           <Button variant="secondary" size="sm" onClick={loadSample}>
             Load sample
           </Button>
@@ -575,7 +599,11 @@ export default function DiffViewer() {
       {/* Editors and diff coexist: comparing never takes the editors away. */}
       <div
         className={`grid min-h-0 flex-1 overflow-hidden ${
-          showEditors && showDiff ? 'grid-rows-2' : 'grid-rows-1'
+          showEditors && showDiff
+            ? hasComparison
+              ? 'grid-rows-2'
+              : 'grid-rows-[1fr_auto]'
+            : 'grid-rows-1'
         }`}
       >
         {showEditors && (

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -612,7 +612,14 @@ export default function HtmlValidator() {
 
   return (
     <ToolLayout fullBleed>
-      <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+      {/* The seam belongs to the rules panel, not the toolbar: it marks the bottom of a chrome
+          block that is genuinely two rows tall. With the panel closed this header is a single
+          toolbar row, and a border would be the divider the toolbar primitive dropped. */}
+      <header
+        className={`bg-[var(--color-surface)] ${
+          state.showRules ? 'border-b border-[var(--color-border)]' : ''
+        }`}
+      >
         <DocumentToolbar aria-label="HTML document actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled document'}

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -613,7 +613,7 @@ export default function HtmlValidator() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <DocumentToolbar border={false} aria-label="HTML document actions">
+        <DocumentToolbar aria-label="HTML document actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled document'}
             titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -720,14 +720,16 @@ function EditorPane({
             </Button>
             <CopyButton text={value} label={copyLabel} className="min-w-0" />
             <Button
-              variant="ghost"
+              variant="secondary"
               size="xs"
               onClick={onSave}
               disabled={!value.trim()}
               aria-label={`Save ${title.toLowerCase()} to file`}
               title={`Save to a file (${formatShortcut('mod+s')})`}
+              className="gap-1"
             >
               <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
             </Button>
           </>
         }

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -551,7 +551,7 @@ export default function JsonTools() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar border={false} aria-label="JSON document actions">
+          <DocumentToolbar aria-label="JSON document actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}
               icon={
@@ -591,6 +591,53 @@ export default function JsonTools() {
               </Button>
             )}
 
+            {/* Actions lead, view options trail. This bar wraps to two rows at 1024px — one of
+                the two viewports the UI audit checks — and with view options first the wrap put
+                Indent/Path/Source-Tree-Table on row one and buried every primary action on row
+                two, underneath them. Ordering by importance means the wrap sheds the least
+                important row last. */}
+            <ToolbarGroup label="Document actions" separated>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => void handleFormat()}
+                disabled={!hasInput || isFormatting}
+                loading={isFormatting}
+                title={`Format the document (${formatShortcut('mod+enter')})`}
+              >
+                Format
+                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+              </Button>
+              <Button variant="secondary" size="sm" onClick={handleMinify} disabled={!isValid}>
+                Minify
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleSortKeys}
+                disabled={!isValid}
+                className="gap-1"
+              >
+                <SortAscendingIcon size={14} aria-hidden="true" />
+                Sort keys
+              </Button>
+              <CopyButton text={input} label="Copy JSON" />
+              {/* Labelled, like every other button in this group. As a bare icon it was the only
+                  unlabelled control on the row and the dimmest thing on it, which read as
+                  disabled rather than as an action. */}
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleSave}
+                disabled={!hasInput}
+                title={`Save to a file (${formatShortcut('mod+s')})`}
+                className="gap-1"
+              >
+                <FloppyDiskIcon size={14} aria-hidden="true" />
+                Save
+              </Button>
+            </ToolbarGroup>
+
             <ToolbarGroup label="View options" separated>
               <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
                 <span className="max-[900px]:hidden">Indent</span>
@@ -620,44 +667,6 @@ export default function JsonTools() {
                 onChange={(next) => updateState({ view: next })}
                 options={VIEW_OPTIONS}
               />
-            </ToolbarGroup>
-
-            <ToolbarGroup label="Document actions" separated>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={() => void handleFormat()}
-                disabled={!hasInput || isFormatting}
-                loading={isFormatting}
-                title={`Format the document (${formatShortcut('mod+enter')})`}
-              >
-                Format
-                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
-              </Button>
-              <Button variant="secondary" size="sm" onClick={handleMinify} disabled={!isValid}>
-                Minify
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSortKeys}
-                disabled={!isValid}
-                className="gap-1"
-              >
-                <SortAscendingIcon size={14} aria-hidden="true" />
-                Sort keys
-              </Button>
-              <CopyButton text={input} label="Copy JSON" />
-              <Button
-                variant="icon"
-                size="sm"
-                onClick={handleSave}
-                disabled={!hasInput}
-                title={`Save to a file (${formatShortcut('mod+s')})`}
-                aria-label="Save JSON to file"
-              >
-                <FloppyDiskIcon size={16} aria-hidden="true" />
-              </Button>
             </ToolbarGroup>
           </DocumentToolbar>
 

--- a/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -431,7 +431,7 @@ export default function JwtDecoder() {
                   size="sm"
                   onClick={() => updateState({ input: TOOL_SAMPLES['jwt-decoder'] ?? '' })}
                 >
-                  Load Sample
+                  Load sample
                 </Button>
               ) : undefined
             }

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -1043,7 +1043,7 @@ export default function MarkdownEditor() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <DocumentToolbar border={false} aria-label="Markdown document actions">
+        <DocumentToolbar aria-label="Markdown document actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled document'}
             titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -1042,7 +1042,9 @@ export default function MarkdownEditor() {
 
   return (
     <ToolLayout fullBleed>
-      <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+      {/* No seam: nothing stacks under the toolbar inside this header, so a border here would be
+          the single-row divider the toolbar primitive dropped, just re-expressed on the wrapper. */}
+      <header className="bg-[var(--color-surface)]">
         <DocumentToolbar aria-label="Markdown document actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled document'}

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -575,7 +575,7 @@ export default function MermaidEditor() {
   return (
     <ToolLayout fullBleed>
       <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-        <DocumentToolbar border={false} aria-label="Diagram actions">
+        <DocumentToolbar aria-label="Diagram actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled diagram'}
             titleTooltip={state.filePath ?? state.fileName ?? 'Untitled diagram'}

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -574,7 +574,9 @@ export default function MermaidEditor() {
 
   return (
     <ToolLayout fullBleed>
-      <header className="border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+      {/* No seam: nothing stacks under the toolbar inside this header, so a border here would be
+          the single-row divider the toolbar primitive dropped, just re-expressed on the wrapper. */}
+      <header className="bg-[var(--color-surface)]">
         <DocumentToolbar aria-label="Diagram actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled diagram'}

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -633,7 +633,7 @@ export default function RefactoringToolkit() {
                 }
                 className="pointer-events-auto"
               >
-                Load example
+                Load sample
               </Button>
             </div>
           )}

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -458,14 +458,16 @@ export default function RefactoringToolkit() {
             </Button>
             <CopyButton text={copyText} label={showDiff ? 'Copy transformed code' : 'Copy code'} />
             <Button
-              variant="icon"
+              variant="secondary"
               size="sm"
               onClick={handleSave}
               disabled={!hasCode}
               title={`Save the code to a file (${formatShortcut('mod+s')})`}
               aria-label="Save code to file"
+              className="gap-1"
             >
-              <FloppyDiskIcon size={16} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -16,6 +16,7 @@ import { TextArea } from '@/components/shared/TextArea'
 import { REGEX_TIMEOUT_MS, useRegexEvaluation } from '@/hooks/useRegexEvaluation'
 import { MAX_REGEX_MATCHES } from '@/workers/regex.api'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
+import { REGEX_TESTER_SAMPLE } from '@/lib/tool-samples'
 
 type RegexTesterState = {
   pattern: string
@@ -137,6 +138,7 @@ export default function RegexTester() {
     replacePattern: '',
   })
   const copy = useCopyToClipboard()
+  const isUntouched = !state.pattern.trim() && !state.testString.trim()
   const [showRef, setShowRef] = useState(false)
   const [mode, setMode] = useState<RegexMode>('match')
   const [showDiff, setShowDiff] = useState(false)
@@ -301,6 +303,26 @@ export default function RegexTester() {
             >
               {showRef ? 'Hide' : 'Ref'}
             </Button>
+            {/* Only while both fields are untouched. A regex tool needs a pattern
+                *and* a subject before it shows anything, so a cold start means
+                inventing both — and the tax falls hardest on the user who came
+                here because they are unsure of the syntax. Gone on the first
+                keystroke, so it can never overwrite work in progress. */}
+            {isUntouched && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  updateState({
+                    pattern: REGEX_TESTER_SAMPLE.pattern,
+                    flags: REGEX_TESTER_SAMPLE.flags,
+                    testString: REGEX_TESTER_SAMPLE.testString,
+                  })
+                }
+              >
+                Load sample
+              </Button>
+            )}
             {matchError && (
               <Alert variant="error" className="px-2 py-0.5">
                 {matchError}

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -292,7 +292,13 @@ export default function RegexTester() {
                 </Button>
               ))}
             </div>
-            <Button variant="ghost" size="sm" onClick={() => setShowRef(!showRef)}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowRef(!showRef)}
+              title={showRef ? 'Hide the regex reference' : 'Show the regex syntax reference'}
+              aria-expanded={showRef}
+            >
               {showRef ? 'Hide' : 'Ref'}
             </Button>
             {matchError && (
@@ -300,10 +306,22 @@ export default function RegexTester() {
                 {matchError}
               </Alert>
             )}
+            {/* The bare number was ambiguous — 3 what? — and the capture-group
+                count existed only in the sr-only live region, so sighted users
+                had to count parentheses. Same `N matches · N groups` shape the
+                document tools use for their status line. */}
             {!matchError && matchCount > 0 && (
-              <StatusBadge variant={truncated ? 'warning' : 'info'}>
-                {truncated ? `${matchCount}+` : matchCount}
-              </StatusBadge>
+              <div className="flex shrink-0 items-center gap-2" data-testid="match-count">
+                <StatusBadge variant={truncated ? 'warning' : 'info'}>
+                  {truncated ? `${matchCount}+` : matchCount}{' '}
+                  {matchCount === 1 && !truncated ? 'match' : 'matches'}
+                </StatusBadge>
+                {groupCount > 0 && (
+                  <span className="text-xs text-[var(--color-text-muted)]">
+                    {groupCount} group{groupCount === 1 ? '' : 's'}
+                  </span>
+                )}
+              </div>
             )}
             {!matchError && truncated && (
               <span className="text-xs text-[var(--color-warning)]">

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -422,7 +422,7 @@ export default function TsPlayground() {
                   onClick={loadExample}
                   className="pointer-events-auto"
                 >
-                  Load example
+                  Load sample
                 </Button>
               </div>
             )}

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -247,7 +247,7 @@ export default function TsPlayground() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar border={false} aria-label="TypeScript playground actions">
+          <DocumentToolbar aria-label="TypeScript playground actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled.ts'}
               icon={
@@ -314,14 +314,16 @@ export default function TsPlayground() {
               </Button>
               <CopyButton text={output} label="Copy output" />
               <Button
-                variant="icon"
+                variant="secondary"
                 size="sm"
                 onClick={handleSave}
                 disabled={!output}
                 title={`Save the JavaScript output to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save output to file"
+                className="gap-1"
               >
-                <FloppyDiskIcon size={16} aria-hidden="true" />
+                <FloppyDiskIcon size={14} aria-hidden="true" />
+                Save
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -369,14 +369,16 @@ export default function XmlTools() {
             </Button>
             <CopyButton text={input} label="Copy XML" />
             <Button
-              variant="icon"
+              variant="secondary"
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}
               title={`Save to a file (${formatShortcut('mod+s')})`}
               aria-label="Save XML to file"
+              className="gap-1"
             >
-              <FloppyDiskIcon size={16} aria-hidden="true" />
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -322,7 +322,9 @@ export default function YamlTools() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="border-b border-[var(--color-border)]">
+        // No seam: nothing stacks under the toolbar inside this wrapper, so a border here would
+        // be the single-row divider the toolbar primitive dropped, moved onto the wrapper.
+        <div>
           <DocumentToolbar aria-label="YAML document actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -323,7 +323,7 @@ export default function YamlTools() {
       fullBleed
       toolbar={
         <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar border={false} aria-label="YAML document actions">
+          <DocumentToolbar aria-label="YAML document actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}
               icon={
@@ -405,14 +405,16 @@ export default function YamlTools() {
               )}
               <CopyButton text={input} label="Copy YAML" />
               <Button
-                variant="icon"
+                variant="secondary"
                 size="sm"
                 onClick={handleSave}
                 disabled={!hasInput}
                 title={`Save to a file (${formatShortcut('mod+s')})`}
                 aria-label="Save YAML to file"
+                className="gap-1"
               >
-                <FloppyDiskIcon size={16} aria-hidden="true" />
+                <FloppyDiskIcon size={14} aria-hidden="true" />
+                Save
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>


### PR DESCRIPTION
Started as a walk of the running app in the browser harness, then each finding was mapped app-wide before being fixed, so the same shape got the same treatment everywhere it appeared rather than only where I happened to spot it.

`apps/cockpit/documentation/TODO.md` is rewritten with the full audit — method, per-item outcome, what was deliberately left, and what was rejected.

## Shell

- **Tab strip scrollbar** — `scrollbar-width: none` is Firefox-only, so WKWebView drew a scrollbar over the strip. Added a `.no-scrollbar` utility with the `::-webkit-scrollbar` half.
- **Tab strip reveal on resize** — the active tab was only scrolled into view when it changed. Opening the notes drawer narrows the strip from 716px to 420px and used to push the active tab out of sight. A `ResizeObserver` now re-reveals it with `behavior: 'auto'`.
- **Command palette** — `mod+1..9` switches workspace tabs and always has, but the binding was invisible outside the shortcuts modal. Tool rows now carry the digit of the tab they're open in.
- **Collapsed sidebar** — pinned tools reaching them meant opening a group flyout. They now get their own rail buttons above the group glyphs, with the existing portal tooltip and included in the arrow-key run.
- **Shortcuts modal** — a pinned filter matching both action names and rendered key combos (`mod+k` finds "Command palette"), categories that match nothing drop out, and an empty state instead of a blank panel.
- **Dialog scrolling** — the settings panel and shortcuts modal scrolled the whole dialog, taking the tab bar and filter with them. The body scrolls now.
- **Status bar** — dropped the active tool name. The tab strip names it one strip above and each tool now carries live status in its own toolbar; this was the least informative of the three copies.

## Tools

- **Color Converter** — had no toolbar at all, so an unparseable input showed up only as the rest of the page silently not being there. It now has the same document-toolbar grammar as the other tools: swatch, resolved color, live parse status. The seven stacked Copy buttons became clickable format rows.
- **Regex Tester** — match count is a `StatusBadge` with a capture-group count beside it, and the `Ref` toggle got a title and `aria-expanded`.
- **Diff Viewer** — split view showed a full `EmptyState` wedged between the two editors. The editors get the full pane and a one-line prompt sits below them; diff-only view keeps the `EmptyState`.

Three of my own findings turned out to be wrong or overstated once mapped against the source — the regex toolbar, the flag pills' labelling, and the collapsed rail's tooltips — and are recorded as corrections rather than "fixed".

## Load sample coverage and theme previews

- **`Load sample` sweep** — the affordance existed in some tools and not others with no rule behind
  which. Applied the rule uniformly and recorded it in the TODO; see §3.1 there for the tools that
  correctly have none.
- **Theme swatches** — the settings theme picker showed abstract colour chips. Each swatch is now a
  miniature of the app rendered in that theme, so you pick by what you'll get.

## Title bar and toolbar chrome pass

A second runtime audit, this time of the chrome itself, measured with DevTools at 800px (the
configured `minWidth`), 1024px and 1512px rather than eyeballed. Recorded as §8 C1–C11 in the TODO.

The defect: the command palette is centred by a full-width overlay, and at 480px wide its left edge
crosses the title bar's icon cluster below a window width of ~820px. The overlay is
`pointer-events-none`, so those buttons stayed **clickable while invisible** — worse than plain
occlusion. `minWidth` is 800, so this was reachable at the smallest window the app allows. The
overlay stays, since window-centring is the point, but now reserves a symmetric gutter sized to the
widest cluster per platform; the palette shrinks rather than overlaps. Equal-flex side columns were
tried first and rejected: `flex-basis: 0` sizes the *content* box, so the macOS traffic-light
padding is added on top and slides every column left (measured: palette centre 794 against a window
centre of 756).

Also in this pass:

- **Title bar clusters** — Settings and Shortcuts moved to the trailing edge. Three icons 14px from
  the traffic lights read as a fourth window control. Notes stays: it's the one with state worth
  glancing at.
- **Toolbar height** — `min-h-10` was a floor almost nothing reached, so toolbars came out 42, 43,
  46 and 47px depending purely on which controls a tool happened to contain, and the line under the
  tab strip jumped on every tab switch. Now `min-h-11` + `py-1.5`, which puts the natural height
  under the floor so the floor decides. Every non-wrapping toolbar is 44px — the title bar's `h-11`.
- **Toolbar divider** — eight of thirteen `DocumentToolbar` call sites had independently passed
  `border={false}`. The decision moved into the primitive; the five toolbars that *lost* a divider
  were re-checked in the harness and the surface→canvas transition separates them on its own.
- **`SegmentedControl`** — solid `--color-accent` made a view mode as loud as a primary button, so
  JSON Tools showed "Format" and "Source" competing. Now an accent tint.
- **Active-tab indicator** — a 40px centred pill sitting on the title bar's divider read as an
  artifact of that divider. Now full tab width; `top-0` kept, per the existing rationale in the file.
- **JSON Tools toolbar** — groups reordered by importance, so the wrap at 1024px sheds the least
  important row last instead of burying every primary action under the view options.
- **Save buttons** — labelled in seven tools where an icon-only floppy disk sat among five labelled
  buttons. Left alone in the three that pair an icon-only Save with an icon-only Open.

## Verification

Run from `apps/cockpit/`:

- `npx tsc --noEmit` — clean
- `bun run lint` — passes, including `lint:ds` ("design-system: no violations")
- `bunx vitest run` — **124 files, 1619 tests, all passing** (up from 115/1344 at the base commit)

New tests lock the contracts rather than the pixels, since jsdom can't measure layout: the palette
gutter is symmetric on both platforms and Notes is the only control ahead of it; `DocumentToolbar`
has no divider by default and `border` still opts back in; the selected segment carries the dim
accent and not the solid one; JSON Tools' action group precedes its view options and Save is
labelled.

Every change was also re-walked in the harness at 1024×700 and confirmed on screen.

Two pre-existing test-isolation weaknesses in `sidebar.test.tsx` surfaced during this and are fixed: `setActiveTool` was permanently replaced with a `vi.fn()` that leaked into later files, and tab/recent state was never reset between tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

