### PR TITLE
fix(cockpit): restore window control clicks

### DIFF
--- a/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
+++ b/apps/cockpit/documentation/NATIVE_UI_HARNESS.md
@@ -280,6 +280,13 @@ foreground is a two-line check that no app logic can influence.
 
 Recorded against Tauri 2.10.3 / macOS 15, on branch `feat/ui-polish-phase-2`.
 
+- **A leading-cluster padding box swallowed all three traffic-light clicks.** The visible notes
+  button needed a 76px traffic-light allowance, but implementing that allowance as `padding-left`
+  made the cluster's transparent box cover close, minimize, and maximize at the same z-index. The
+  later cluster won hit-testing even though the traffic lights remained visible. Using an equivalent
+  `margin-left` keeps the layout unchanged without placing an element over the controls. The event
+  probe exposed this as clicks targeting the leading cluster `DIV` instead of a traffic-light
+  `BUTTON`.
 - **`decorations: false` disables native edge resizing on macOS.** It does not merely clear the
   `NSWindowStyleMask.titled` bit while leaving edge tracking intact. Dragging every edge and corner
   at ±3px around the frame moved nothing; the window could not be resized at all. Hence

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -97,7 +97,7 @@ export function TitleBar() {
           trailing edge — both are modal, rarely-used and reachable from the palette, and keeping
           three buttons here left only 14px between them and the macOS traffic lights, so the
           cluster read as a fourth window control. */}
-      <div className={`${SIDE_CLUSTER_CLASS} ${isMac ? 'pl-[76px]' : ''}`}>
+      <div className={`${SIDE_CLUSTER_CLASS} ${isMac ? 'ml-[76px]' : ''}`}>
         <button
           type="button"
           onClick={toggleNotes}

--- a/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/TitleBar.test.tsx
@@ -193,6 +193,15 @@ describe('TitleBar — platform layout', () => {
     expect(screen.queryByTestId('titlebar-right-controls')).not.toBeInTheDocument()
   })
 
+  it('reserves macOS traffic-light space without covering their hit targets', () => {
+    mocks.platform.current = 'mac'
+    render(<TitleBar />)
+
+    const leadingCluster = screen.getByLabelText('Toggle notes drawer').parentElement
+    expect(leadingCluster).toHaveClass('ml-[76px]')
+    expect(leadingCluster).not.toHaveClass('pl-[76px]')
+  })
+
   it('renders window controls on the right, and none on the left, on non-macOS', () => {
     mocks.platform.current = 'windows'
     render(<TitleBar />)


### PR DESCRIPTION
## Summary

- restore Close, Minimize, and Maximize clicks on macOS by moving the title-bar spacing outside the hit-testable leading cluster
- keep the visual traffic-light allowance unchanged while preventing the notes cluster from covering the controls
- confirm the Windows control path is unaffected and retains its existing drag-layer protection
- document the native harness finding and add a regression assertion for the layout contract

## Test plan

- [x] Native macOS harness: minimize changes AXMinimized to true
- [x] Native macOS harness: maximize and restore change OS window bounds
- [x] Native macOS harness: close reaches the Rust handler and exits the app
- [x] Targeted title-bar, window-control, hook, and native bridge tests: 35 passed
- [x] Full Vitest suite: 126 files, 1666 tests passed
- [x] TypeScript check
- [x] ESLint and design-system lint
- [x] cargo check
- [x] cargo fmt --check