### PR TITLE
refactor(cockpit): consistent chrome typography, and tool settings in a popover

### DIFF
--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -84,6 +84,14 @@ commands for real without giving up the browser.
   editable". Drive the content through the API instead — `window.monaco.editor.getModels()` and
   `.getEditors()` are both reachable from `page.evaluate`, and `setValue` fires the same change
   event the tool listens to. Pick the editor by visibility, not by index.
+- **An editor's index is not its role.** `getEditors()` returns them in creation order, which is
+  neither left-to-right nor the order the labels suggest. JSON Schema Validator puts the _data_ on
+  the left and the _schema_ on the right; an agent that assumed the opposite wrote each into the
+  other and reported a validator that "fails to detect type violations" — a schema of
+  `{"age":"not_a_number"}` has no recognised keywords, so it accepts everything, and the tool was
+  right. Read the pane heading (`JSON DATA` / `JSON SCHEMA`) or sort by
+  `getDomNode().getBoundingClientRect().x` and confirm the existing content matches what you expect
+  before you overwrite it.
 - **Results are debounced.** Lint, compile and format land ~1–2s after the model changes. Reading
   the output straight after `setValue` reports the previous run, which reads exactly like "the
   setting had no effect".

--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -87,6 +87,20 @@ commands for real without giving up the browser.
 - **Results are debounced.** Lint, compile and format land ~1–2s after the model changes. Reading
   the output straight after `setValue` reports the previous run, which reads exactly like "the
   setting had no effect".
+- **The first minutes on a cold dep cache are not the app.** Tools import their heavy dependencies
+  lazily, so the first visit to one sends Vite off to pre-bundle — and when it finishes it reloads
+  the page under you. Anything in flight across that reload dies loudly and misleadingly: a worker
+  module 504s (`[useWorker] Worker error: Event`), a half-loaded CommonJS dep throws
+  `X is not a function`, and the tool renders its error state. An agent reported exactly that as a
+  critical CSV Tools bug; it was Vite. The tell is in the dev server log, not the page:
+
+  ```
+  [vite] ✨ new dependencies optimized: prettier/standalone, …
+  [vite] ✨ optimized dependencies changed. reloading
+  ```
+
+  Warm the cache before you measure anything — visit the tools you plan to test once, let the
+  reload happen, then start. If a failure will not reproduce after that, it was never real.
 
 ## Driving the app as an agent
 
@@ -105,6 +119,14 @@ reporting something you inferred rather than saw.
   dead keyboard path in `Popover` behind a passing assertion.
 - **Prefer one `page.evaluate` that returns a fact over a screenshot you interpret.** "Right edges
   align to within 1.5px" is checkable; "looks aligned" is not.
+- **Read the console before calling anything a crash.** The page's error state tells you a promise
+  rejected, not why. An agent that reports "Something broke" without the console line behind it has
+  found a symptom that may not even belong to the app (see the cold-cache gotcha above).
+- **Quote, don't paraphrase.** A report is actionable when it carries the verbatim error string and
+  the exact code that produced it — selector, input, waits. "The parser failed" is a rumour.
+- **"It opens correctly" is not a finding, and its absence is not a clean bill of health.** A tool
+  mounting proves the router works. Exercising it means changing a setting and asserting the output
+  changed: toggle ignore-whitespace and diff the diff.
 - Artifacts land in the gitignored `.playwright-mcp/`, so nothing you capture reaches a commit.
 
 ## Recipe: who is rewriting my DOM?

--- a/apps/cockpit/documentation/BROWSER_HARNESS.md
+++ b/apps/cockpit/documentation/BROWSER_HARNESS.md
@@ -74,6 +74,38 @@ commands for real without giving up the browser.
   bug is in your coordinates, not in the app.
 - **Toolbar buttons collide by name.** `getByRole('button', { name: 'Templates' })` matched three
   elements; pass `{ exact: true }`.
+- **Tools you have visited stay mounted.** Switching tools does not unmount the previous one; it
+  collapses to zero height. So `document.querySelector('.monaco-editor')` can return a hidden
+  editor from two tools ago and report `height: 0`, and a locator can fail strict mode against a
+  toolbar the user cannot see. Filter to what is on screen:
+  `[...document.querySelectorAll(sel)].filter((e) => e.getBoundingClientRect().height > 0)`.
+- **Monaco has no editable `<textarea>` to type into.** This build uses an edit context; the only
+  `textarea` in the page is a read-only IME shim, so `fill()` times out with "element is not
+  editable". Drive the content through the API instead — `window.monaco.editor.getModels()` and
+  `.getEditors()` are both reachable from `page.evaluate`, and `setValue` fires the same change
+  event the tool listens to. Pick the editor by visibility, not by index.
+- **Results are debounced.** Lint, compile and format land ~1–2s after the model changes. Reading
+  the output straight after `setValue` reports the previous run, which reads exactly like "the
+  setting had no effect".
+
+## Driving the app as an agent
+
+The harness rewards evidence and punishes assumption, so the failure mode to guard against is
+reporting something you inferred rather than saw.
+
+- **Reproduce before reporting.** Do the interaction twice. An HMR reload can drop the app back to
+  the launcher, and a selector that "does not match any elements" then means the page moved on, not
+  that the control is missing.
+- **Ask whether the user can reach it.** The window is created with `minWidth: 800` /
+  `minHeight: 500` ([`src-tauri/tauri.conf.json`](../src-tauri/tauri.conf.json)); a defect that only
+  appears at 250px tall is real for the browser and remote-ui paths but unreachable in the desktop
+  app, and the report should say which.
+- **A green Vitest run is not evidence about layout, focus or fonts.** jsdom implements none of
+  them. It will happily report a `visibility: hidden` element as focused — that exact gap hid a
+  dead keyboard path in `Popover` behind a passing assertion.
+- **Prefer one `page.evaluate` that returns a fact over a screenshot you interpret.** "Right edges
+  align to within 1.5px" is checkable; "looks aligned" is not.
+- Artifacts land in the gitignored `.playwright-mcp/`, so nothing you capture reaches a commit.
 
 ## Recipe: who is rewriting my DOM?
 

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -122,6 +122,38 @@ Use `font-ui`, `font-mono`, `font-pixel` (Tailwind `@theme` families — not
 **The split is semantic, not decorative:** chrome is `font-ui`, content the user typed or the tool
 produced is `font-mono`. A _label naming_ a monospace region is chrome and takes `font-ui`.
 
+#### `--font-ui` is the inherited default; monospace is opted into
+
+`html, body, #root` set `font-family: var(--font-ui)`, so **chrome needs no font class at all** —
+a `<span>` with no font utility is already correct. Only content opts out, and it does so in one
+of four ways, in order of preference:
+
+1. **The right tag.** `pre`, `code`, `kbd` and `samp` are monospace by a base rule in `index.css`.
+   Tool output rendered in `<code>` or `<pre>` needs nothing else.
+2. **A primitive's `monospace` prop.** `Input` and `TextArea` both take one; it is off by default,
+   because a field is chrome until proven otherwise. Turn it on for URLs, header values, JSONPath,
+   identifiers, tokens, colour literals — anything read character by character.
+3. **`font-mono` on the container** of a content region (a tree view, a results pane), so every
+   row inherits it rather than repeating the class.
+4. **`font-mono` on the element**, last resort.
+
+This was inverted until the typography pass. With mono inherited, every label, badge, status line
+and empty state had to _remember_ `font-ui` or silently render monospace — three of forty-six tool
+files did, so a tool title in system-ui routinely sat beside its own status text in Source Code
+Pro, in the same toolbar row. Do not flip it back: the default must be the case that needs the
+fewest exceptions, and chrome outnumbers content by an order of magnitude.
+
+Two consequences worth knowing:
+
+- `--font-mono` is **theme-dependent** — 11 of the 22 themes pick `'Source Code Pro'`, the rest a
+  generic `ui-monospace` stack. Both the `font-mono` utility and the tag rule read the same
+  variable, so they always agree within a theme. Never hard-code a family.
+- The `neon-brutalist` theme sets `--font-ui: var(--font-mono)` on purpose, for an all-mono
+  aesthetic.
+  That keeps working precisely _because_ chrome reads `--font-ui` rather than naming a family, and
+  it is the reason chrome must never be given `font-mono` "to look right" — that would make the
+  theme unable to opt out.
+
 ### Size scale
 
 Five sizes. Nothing else. `text-[13px]` and friends are a lint error.

--- a/apps/cockpit/documentation/DESIGN_SYSTEM.md
+++ b/apps/cockpit/documentation/DESIGN_SYSTEM.md
@@ -352,6 +352,46 @@ Import from `@/components/shared/<Name>`.
 | `SectionLabel` | The small uppercase label naming a region                        |
 | `Dialog`       | Modal; owns focus trap, escape, and backdrop                     |
 
+### Floating surfaces
+
+| Component         | Use                                                                   |
+| ----------------- | --------------------------------------------------------------------- |
+| `Dialog`          | Modal. Owns focus trap, escape, backdrop. Centred, not anchored.      |
+| `Popover`         | Anchored dismissible surface — menus, flyouts, anything above chrome  |
+| `SettingsPopover` | The toolbar options surface: gear-style trigger plus rows of settings |
+
+**Never hand-roll `absolute right-0 top-full` plus a `mousedown` effect.** Five surfaces were
+written that way before `Popover` existed and between them managed: no Escape handling at all, a
+raw `z-20` that put a menu underneath every other popover, clamping in one direction only, three
+duplicated dismiss effects in one file, and not one that returned focus to its trigger.
+
+`Popover` takes its trigger as a render prop, because `aria-expanded`, `aria-controls` and the
+anchoring ref all have to land on the same element and every hand-rolled version forgot at least
+one of the three. It anchors by the trigger's trailing edge, so it needs no measurement pass and
+never paints at the wrong coordinates; vertically it takes the room left below as `max-height` and
+scrolls rather than flipping above, since a toolbar popover that flipped would cover the thing it
+configures.
+
+#### Tool options go in a `SettingsPopover`, not a second toolbar row
+
+A collapsible options row costs more than its space: it resizes the editor underneath, so toggling
+an option relayouts the document at the moment the user is reading it, and it makes toolbar height
+a function of which tool is open. Code Formatter, TS Playground, HTML Validator and CSS Validator
+all use the popover.
+
+What stays in the toolbar:
+
+- **Anything acted on repeatedly while working.** Diff Viewer's ignore-whitespace and ignore-case
+  get cycled several times per comparison, and CSV Tools' delimiter is the first thing tried when
+  a paste won't parse. These are working controls wearing an option's clothes; a gear costs two
+  clicks per attempt. Diff Viewer keeps its second row for exactly this reason.
+- **Actions.** A popover full of settings is live-applied — no OK, no Cancel, and nothing that
+  performs an operation. A settings surface with a confirm button is a dialog in disguise.
+- **Read-outs.** A line count or a byte size is a fact about the document, not a setting.
+
+Pass `badge` wherever "back to defaults" is meaningful state. Hiding settings means the toolbar
+stops showing that any were changed; the badge is what buys that back.
+
 Use semantic variants (`info`/`success`/`warning`/`error`) rather than styling status text at the
 call site. Do not add check marks, warning glyphs, emoji, or custom SVG — the component or a
 Phosphor icon supplies the cue.

--- a/apps/cockpit/src/app/providers.tsx
+++ b/apps/cockpit/src/app/providers.tsx
@@ -233,7 +233,7 @@ export function Providers({ children }: { children: ReactNode }) {
     return (
       <div className="flex h-full items-center justify-center gap-2 text-[var(--color-accent)]">
         <Spinner size="sm" label="Starting cockpit" />
-        <span className="font-mono text-sm">Loading...</span>
+        <span className="text-sm">Loading...</span>
       </div>
     )
   }

--- a/apps/cockpit/src/components/shared/Checkbox.tsx
+++ b/apps/cockpit/src/components/shared/Checkbox.tsx
@@ -1,0 +1,67 @@
+import { forwardRef, useEffect, useRef, type InputHTMLAttributes } from 'react'
+import { CheckIcon, MinusIcon } from '@phosphor-icons/react'
+
+type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> & {
+  /** Renders the mixed state. Also sets `input.indeterminate`, which has no HTML attribute. */
+  indeterminate?: boolean
+}
+
+/**
+ * The multi-select control. `Toggle` is a `role="switch"` — it means "this setting is on",
+ * takes effect immediately, and is 32px wide; a checkbox means "this item is part of a set"
+ * and has to sit in a dense list row. Six call sites had reached for a raw
+ * `<input type="checkbox" className="accent-[var(--color-accent)]">` instead, and no two
+ * agreed on the vertical nudge that follows (`mt-0.5`, `mt-1`, nothing), because
+ * `accent-color` styles the OS checkbox and leaves its box metrics unknowable.
+ *
+ * So the native input stays for semantics, keyboard and form behaviour, but is made
+ * transparent and stretched over the box we draw, which is sized in the same tokens as
+ * every other control. `peer` + `peer-checked`/`peer-focus-visible` do the state styling
+ * with no JS.
+ */
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ indeterminate = false, className = '', disabled, ...props }, forwardedRef) => {
+    const localRef = useRef<HTMLInputElement>(null)
+
+    useEffect(() => {
+      if (localRef.current) localRef.current.indeterminate = indeterminate
+    }, [indeterminate])
+
+    return (
+      <span
+        className={`relative inline-flex h-4 w-4 shrink-0 items-center justify-center ${className}`}
+      >
+        <input
+          ref={(node) => {
+            localRef.current = node
+            if (typeof forwardedRef === 'function') forwardedRef(node)
+            else if (forwardedRef) forwardedRef.current = node
+          }}
+          type="checkbox"
+          disabled={disabled}
+          aria-checked={indeterminate ? 'mixed' : undefined}
+          className="peer absolute inset-0 m-0 cursor-pointer appearance-none rounded-[var(--radius-sm)] disabled:cursor-not-allowed"
+          {...props}
+        />
+        <span
+          aria-hidden="true"
+          /* The glyph's visibility rides on `color`, not `opacity`, because `peer-*`
+             variants only match siblings of the peer — this span is one, the icon
+             inside it is not. Transparent text hides the icon; `peer-checked` and
+             `peer-indeterminate` paint it. */
+          className={`pointer-events-none flex h-full w-full items-center justify-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)] text-transparent transition-colors duration-[var(--duration-fast)] peer-checked:border-[var(--color-accent)] peer-checked:bg-[var(--color-accent)] peer-checked:text-[var(--color-bg)] peer-indeterminate:border-[var(--color-accent)] peer-indeterminate:bg-[var(--color-accent)] peer-indeterminate:text-[var(--color-bg)] peer-focus-visible:shadow-[var(--focus-ring)] ${
+            disabled ? 'opacity-50' : ''
+          }`}
+        >
+          {indeterminate ? (
+            <MinusIcon size={12} weight="bold" />
+          ) : (
+            <CheckIcon size={12} weight="bold" />
+          )}
+        </span>
+      </span>
+    )
+  }
+)
+
+Checkbox.displayName = 'Checkbox'

--- a/apps/cockpit/src/components/shared/Dialog.tsx
+++ b/apps/cockpit/src/components/shared/Dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, type KeyboardEvent, type ReactNode, type RefObject } from 'react'
 import { XIcon } from '@phosphor-icons/react'
+import { cycleFocus, getFocusableElements } from '@/lib/focus'
 
 /**
  * The dialog width scale.
@@ -40,21 +41,6 @@ type DialogProps = {
   closeLabel?: string
   initialFocusRef?: RefObject<HTMLElement | null>
   onOpenAutoFocus?: (target: HTMLElement) => void
-}
-
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',')
-
-function getFocusableElements(root: HTMLElement): HTMLElement[] {
-  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
-    return el.tabIndex >= 0 && el.getAttribute('aria-hidden') !== 'true'
-  })
 }
 
 export function Dialog({
@@ -103,26 +89,8 @@ export function Dialog({
     const panel = panelRef.current
     if (!panel) return
 
-    const focusable = getFocusableElements(panel)
-    if (focusable.length === 0) {
+    if (cycleFocus(panel, { shiftKey: e.shiftKey }) === 'wrapped') {
       e.preventDefault()
-      panel.focus()
-      return
-    }
-
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    const active = document.activeElement
-
-    if (e.shiftKey && (!active || active === first || !panel.contains(active))) {
-      e.preventDefault()
-      last?.focus()
-      return
-    }
-
-    if (!e.shiftKey && active === last) {
-      e.preventDefault()
-      first?.focus()
     }
   }
 

--- a/apps/cockpit/src/components/shared/ErrorBoundary.tsx
+++ b/apps/cockpit/src/components/shared/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         <div className="flex h-full flex-col items-center justify-center gap-3 p-8">
-          <div className="font-mono text-lg text-[var(--color-error)]">Something broke</div>
+          <div className="text-lg text-[var(--color-error)]">Something broke</div>
           <pre className="max-w-lg overflow-auto rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-xs text-[var(--color-text-muted)]">
             {this.state.error?.message}
           </pre>

--- a/apps/cockpit/src/components/shared/Input.tsx
+++ b/apps/cockpit/src/components/shared/Input.tsx
@@ -9,6 +9,14 @@ type InputSize = 'sm' | 'md'
 
 type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
   size?: InputSize
+  /**
+   * Monospace the value. Off by default, matching `TextArea`: an input is chrome
+   * until proven otherwise. Turn it on where the field holds something the user
+   * reads character by character — a URL, a header value, a JSONPath, an
+   * identifier, a token, a colour literal — and where a proportional font would
+   * make `l`/`1` and `O`/`0` ambiguous.
+   */
+  monospace?: boolean
 }
 
 const SIZE_CLASSES: Record<InputSize, string> = {
@@ -20,11 +28,11 @@ const BASE_CLASSES =
   'rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] focus-visible:shadow-[var(--focus-ring)] transition-colors duration-[var(--duration-fast)] disabled:opacity-50'
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ size = 'sm', className = '', ...props }, ref) => {
+  ({ size = 'sm', monospace = false, className = '', ...props }, ref) => {
     return (
       <input
         ref={ref}
-        className={`${BASE_CLASSES} ${SIZE_CLASSES[size]} ${className}`}
+        className={`${BASE_CLASSES} ${SIZE_CLASSES[size]} ${monospace ? 'font-mono' : ''} ${className}`}
         {...props}
       />
     )

--- a/apps/cockpit/src/components/shared/Popover.tsx
+++ b/apps/cockpit/src/components/shared/Popover.tsx
@@ -75,11 +75,21 @@ export function Popover({
   const surfaceId = useId()
   const isInstanceActive = useIsInstanceActive()
   const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const surfaceRef = useRef<HTMLDivElement>(null)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
   const [position, setPosition] = useState<CSSProperties | null>(null)
 
   const setTriggerRef = useCallback((node: HTMLButtonElement | null) => {
     triggerRef.current = node
+  }, [])
+
+  // Focus on mount rather than in an effect keyed on `open`. The surface is not in the DOM until
+  // a position exists, so an effect that fires when `open` flips would be aiming at nothing —
+  // and an unpositioned surface rendered `visibility: hidden` to hide the flash cannot take
+  // focus at all, which is a silent no-op rather than an error. Mounting already positioned
+  // removes both problems, and a ref callback focuses exactly once per open for free.
+  const setSurfaceRef = useCallback((node: HTMLDivElement | null) => {
+    surfaceRef.current = node
+    node?.focus()
   }, [])
 
   useLayoutEffect(() => {
@@ -150,9 +160,6 @@ export function Popover({
   useEffect(() => {
     if (!open) return
 
-    const surface = surfaceRef.current
-    surface?.focus()
-
     return () => {
       // Only reclaim focus if the surface still had it. Once the surface unmounts the browser
       // parks focus on <body>, so that is what "the user did not click anything else" looks
@@ -185,15 +192,16 @@ export function Popover({
         ...(open ? { 'aria-controls': surfaceId } : {}),
       })}
       {open &&
+        position &&
         createPortal(
           <div
-            ref={surfaceRef}
+            ref={setSurfaceRef}
             id={surfaceId}
             role="dialog"
             aria-label={label}
             tabIndex={-1}
             onKeyDown={handleKeyDown}
-            style={position ?? { top: 0, left: 0, visibility: 'hidden' }}
+            style={position}
             className={`animate-fade-in fixed z-[var(--z-popover)] flex max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg outline-none ${className}`}
           >
             {children}

--- a/apps/cockpit/src/components/shared/Popover.tsx
+++ b/apps/cockpit/src/components/shared/Popover.tsx
@@ -1,0 +1,205 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { useIsInstanceActive } from '@/app/tool-instance'
+import { cycleFocus } from '@/lib/focus'
+
+/** Gap between the trigger and the surface, and the minimum inset from a viewport edge. */
+const GAP = 6
+const EDGE = 8
+/** Floor for the computed max-height, so a cramped window scrolls rather than collapses. */
+const MIN_HEIGHT = 120
+
+export type PopoverAlign = 'start' | 'end'
+
+export type PopoverTriggerProps = {
+  ref: (node: HTMLButtonElement | null) => void
+  onClick: () => void
+  'aria-expanded': boolean
+  'aria-haspopup': 'dialog'
+  'aria-controls'?: string
+}
+
+type PopoverProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Accessible name of the surface. Announced when focus lands in it. */
+  label: string
+  /**
+   * The trigger, given the props that make it one. It is a render prop rather than a node
+   * because `aria-expanded`, `aria-controls` and the ref that anchors the surface all have to
+   * land on the same element, and every hand-rolled menu in this app has forgotten at least one
+   * of the three.
+   */
+  trigger: (props: PopoverTriggerProps) => ReactNode
+  children: ReactNode
+  /** Which edge of the trigger the surface lines up with. `end` (right) suits toolbar tails. */
+  align?: PopoverAlign
+  className?: string
+}
+
+/**
+ * A dismissible surface anchored to its trigger.
+ *
+ * The app had five of these written by hand — two in the tab strip, three in Markdown Editor —
+ * and no two agreed on the contract. Between them they managed: no Escape handling at all, a raw
+ * `z-20` that put a menu underneath every other popover, coordinate clamping in one direction
+ * only, and three duplicated `mousedown` effects in a single file. None returned focus to the
+ * trigger.
+ *
+ * Positioning is measurement-free on purpose. Anchoring by the *trailing* edge
+ * (`right: viewportWidth - triggerRight`) means the surface can grow leftwards without ever
+ * being measured, so there is no first paint at the wrong coordinates and nothing to correct on
+ * a second pass. Vertically it takes what room is left below the trigger as `max-height` and
+ * scrolls, which is why there is no flip-above logic: a toolbar popover opens near the top of
+ * the window, where flipping would trade a scrollbar for a surface over the thing it configures.
+ */
+export function Popover({
+  open,
+  onOpenChange,
+  label,
+  trigger,
+  children,
+  align = 'end',
+  className = '',
+}: PopoverProps) {
+  const surfaceId = useId()
+  const isInstanceActive = useIsInstanceActive()
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<CSSProperties | null>(null)
+
+  const setTriggerRef = useCallback((node: HTMLButtonElement | null) => {
+    triggerRef.current = node
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null)
+      return
+    }
+
+    function reposition() {
+      const anchor = triggerRef.current
+      if (!anchor) return
+
+      const rect = anchor.getBoundingClientRect()
+      const top = rect.bottom + GAP
+      const next: CSSProperties = {
+        top,
+        maxHeight: Math.max(MIN_HEIGHT, window.innerHeight - top - EDGE),
+      }
+
+      if (align === 'end') {
+        next.right = Math.max(EDGE, window.innerWidth - rect.right)
+      } else {
+        next.left = Math.max(EDGE, rect.left)
+      }
+
+      setPosition(next)
+    }
+
+    reposition()
+    window.addEventListener('resize', reposition)
+    // Capture phase: the workspace scrolls its own containers, and a scroll event on one of
+    // those does not bubble to window.
+    window.addEventListener('scroll', reposition, true)
+    return () => {
+      window.removeEventListener('resize', reposition)
+      window.removeEventListener('scroll', reposition, true)
+    }
+  }, [open, align])
+
+  useEffect(() => {
+    if (!open) return
+
+    function handlePointerDown(e: MouseEvent) {
+      if (!isInstanceActive) return
+      const target = e.target as Node
+      if (surfaceRef.current?.contains(target)) return
+      // The trigger is excluded so a click on it toggles once, rather than closing here and
+      // reopening in the click handler a moment later.
+      if (triggerRef.current?.contains(target)) return
+      onOpenChange(false)
+    }
+
+    function handleEscape(e: globalThis.KeyboardEvent) {
+      if (!isInstanceActive) return
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      onOpenChange(false)
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleEscape, true)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape, true)
+    }
+  }, [open, isInstanceActive, onOpenChange])
+
+  useEffect(() => {
+    if (!open) return
+
+    const surface = surfaceRef.current
+    surface?.focus()
+
+    return () => {
+      // Only reclaim focus if the surface still had it. Once the surface unmounts the browser
+      // parks focus on <body>, so that is what "the user did not click anything else" looks
+      // like; if they did click something, focus is already on it and stealing it back is
+      // hostile.
+      if (document.activeElement === document.body) {
+        triggerRef.current?.focus()
+      }
+    }
+  }, [open])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab') return
+    const surface = surfaceRef.current
+    if (!surface) return
+    if (cycleFocus(surface, { shiftKey: e.shiftKey }) === 'wrapped') {
+      e.preventDefault()
+    }
+  }
+
+  return (
+    <>
+      {trigger({
+        ref: setTriggerRef,
+        onClick: () => onOpenChange(!open),
+        'aria-expanded': open,
+        'aria-haspopup': 'dialog',
+        // Only advertise the relationship while the surface exists in the DOM: an
+        // `aria-controls` pointing at an unrendered id sends the user's cursor nowhere.
+        ...(open ? { 'aria-controls': surfaceId } : {}),
+      })}
+      {open &&
+        createPortal(
+          <div
+            ref={surfaceRef}
+            id={surfaceId}
+            role="dialog"
+            aria-label={label}
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
+            style={position ?? { top: 0, left: 0, visibility: 'hidden' }}
+            className={`animate-fade-in fixed z-[var(--z-popover)] flex max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-raised)] shadow-lg outline-none ${className}`}
+          >
+            {children}
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}

--- a/apps/cockpit/src/components/shared/Popover.tsx
+++ b/apps/cockpit/src/components/shared/Popover.tsx
@@ -103,11 +103,19 @@ export function Popover({
       if (!anchor) return
 
       const rect = anchor.getBoundingClientRect()
-      const top = rect.bottom + GAP
-      const next: CSSProperties = {
-        top,
-        maxHeight: Math.max(MIN_HEIGHT, window.innerHeight - top - EDGE),
+      let top = rect.bottom + GAP
+      let maxHeight = window.innerHeight - top - EDGE
+
+      if (maxHeight < MIN_HEIGHT) {
+        // Too little room below to be usable. Lift the surface until its floor is back on
+        // screen rather than letting the bottom overhang: a `fixed` surface cannot be scrolled
+        // to, so anything past the viewport edge — the footer, and a reset action with it — is
+        // not merely clipped but unreachable. Overlapping the trigger is the lesser harm.
+        maxHeight = Math.min(MIN_HEIGHT, window.innerHeight - EDGE * 2)
+        top = Math.max(EDGE, window.innerHeight - EDGE - maxHeight)
       }
+
+      const next: CSSProperties = { top, maxHeight }
 
       if (align === 'end') {
         next.right = Math.max(EDGE, window.innerWidth - rect.right)
@@ -115,7 +123,18 @@ export function Popover({
         next.left = Math.max(EDGE, rect.left)
       }
 
-      setPosition(next)
+      // Scroll fires on capture for every scrollable container in the app, including this
+      // surface's own list, so an unconditional set would re-render the popover on each tick
+      // of a scroll that never moved it.
+      setPosition((prev) =>
+        prev &&
+        prev.top === next.top &&
+        prev.maxHeight === next.maxHeight &&
+        prev.right === next.right &&
+        prev.left === next.left
+          ? prev
+          : next
+      )
     }
 
     reposition()

--- a/apps/cockpit/src/components/shared/SettingsPopover.tsx
+++ b/apps/cockpit/src/components/shared/SettingsPopover.tsx
@@ -1,0 +1,196 @@
+import { useId, type ReactNode } from 'react'
+import { SlidersHorizontalIcon } from '@phosphor-icons/react'
+import { Button } from './Button'
+import { Popover, type PopoverAlign } from './Popover'
+import { SectionLabel } from './SectionLabel'
+
+/**
+ * Width steps, all clamped against the viewport the way `Dialog`'s are — a popover anchored to
+ * the right edge of a toolbar has the same chance of running off a narrow window as a centred
+ * modal has of overflowing one.
+ *
+ * There is no wide step. A settings surface is a single column of label-and-control rows; the
+ * multi-column grids these replaced existed only because a strip stretched across the whole
+ * window and had to fill it, not because anyone wanted to read options in four columns.
+ */
+const WIDTH_CLASSES = {
+  sm: 'w-[min(16rem,calc(100vw-1rem))]',
+  md: 'w-[min(20rem,calc(100vw-1rem))]',
+  lg: 'w-[min(24rem,calc(100vw-1rem))]',
+} as const
+
+type SettingsPopoverProps = {
+  /** Trigger label and, unless `title` says otherwise, the surface's accessible name. */
+  label: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: ReactNode
+  /** Trigger icon. Defaults to the sliders glyph every options button already used. */
+  icon?: ReactNode
+  /**
+   * Count of settings that differ from their defaults, shown as a badge on the trigger.
+   *
+   * This is the price of hiding settings: with the controls off-screen the toolbar no longer
+   * shows that anything was changed. Pass it wherever "back to defaults" is a meaningful state.
+   */
+  badge?: number
+  /** Surface heading. Defaults to `label`. */
+  title?: string
+  /** Muted line under the heading — what these settings affect, or a live summary. */
+  description?: ReactNode
+  /** Pinned below the scroll area. A reset action belongs here. */
+  footer?: ReactNode
+  width?: keyof typeof WIDTH_CLASSES
+  align?: PopoverAlign
+}
+
+/**
+ * The toolbar settings surface: a gear-style trigger and a popover of option rows.
+ *
+ * It replaces the collapsible second row that five tools had grown. That row cost more than
+ * space — it resized the editor underneath, so toggling an option relayouted the document at
+ * exactly the moment the user was looking at it, and it made toolbar height a function of which
+ * tool happened to be open. A popover floats over the content and changes nothing beneath it.
+ *
+ * What stays out of it: anything the user acts on repeatedly while working. Options that get
+ * cycled — a delimiter that decides whether a paste parses at all, a diff's ignore-whitespace —
+ * belong in the toolbar where they can be reached in one click.
+ */
+export function SettingsPopover({
+  label,
+  open,
+  onOpenChange,
+  children,
+  icon,
+  badge,
+  title,
+  description,
+  footer,
+  width = 'md',
+  align = 'end',
+}: SettingsPopoverProps) {
+  const heading = title ?? label
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={onOpenChange}
+      label={heading}
+      align={align}
+      className={WIDTH_CLASSES[width]}
+      trigger={(triggerProps) => (
+        <Button
+          {...triggerProps}
+          // The variant flip is the only cue that the surface is open once it is drawn over
+          // content rather than pushing it down.
+          variant={open ? 'secondary' : 'ghost'}
+          size="sm"
+          className="gap-1"
+        >
+          {icon ?? <SlidersHorizontalIcon size={14} aria-hidden="true" />}
+          {label}
+          {badge !== undefined && badge > 0 && (
+            <span className="rounded-full bg-[var(--color-accent)] px-1.5 text-2xs text-[var(--color-bg)]">
+              {badge}
+            </span>
+          )}
+        </Button>
+      )}
+    >
+      <div className="border-b border-[var(--color-border)] px-3 py-2">
+        <SectionLabel as="h2">{heading}</SectionLabel>
+      </div>
+      {description && (
+        <p className="border-b border-[var(--color-border)] px-3 py-2 text-2xs text-[var(--color-text-muted)]">
+          {description}
+        </p>
+      )}
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3">{children}</div>
+      {footer && (
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--color-border)] px-3 py-2">
+          {footer}
+        </div>
+      )}
+    </Popover>
+  )
+}
+
+type SettingsSectionProps = {
+  title?: string
+  children: ReactNode
+  /** Tighter spacing for a list of checkboxes, where each row is one line. */
+  dense?: boolean
+  className?: string
+}
+
+/** A titled group of rows inside a `SettingsPopover`. */
+export function SettingsSection({
+  title,
+  children,
+  dense = false,
+  className = '',
+}: SettingsSectionProps) {
+  return (
+    <section className={className}>
+      {title && (
+        <SectionLabel as="h3" className="mb-2">
+          {title}
+        </SectionLabel>
+      )}
+      <div className={`flex flex-col ${dense ? 'gap-1' : 'gap-2'}`}>{children}</div>
+    </section>
+  )
+}
+
+type SettingsRowIds = { controlId: string; labelId: string }
+
+type SettingsRowProps = {
+  label: string
+  /**
+   * The control. As a function when it needs the generated ids — a `Toggle` renders a
+   * `role="switch"` button, which is not a labelable element, so a wrapping `<label>` would
+   * leave it with no accessible name at all. Selects and inputs can take the node form and be
+   * associated by `htmlFor`.
+   */
+  children: ReactNode | ((ids: SettingsRowIds) => ReactNode)
+  hint?: ReactNode
+  disabled?: boolean
+}
+
+/**
+ * One setting: name on the left, control on the right.
+ *
+ * Uniform alignment is the point. The rows this replaces put a select's label before the
+ * control and a toggle's label after it, so a column of seven options had its labels down the
+ * left and its labels down the right at the same time.
+ */
+export function SettingsRow({ label, children, hint, disabled = false }: SettingsRowProps) {
+  const controlId = useId()
+  const labelId = useId()
+  const isRenderProp = typeof children === 'function'
+  const content = isRenderProp ? children({ controlId, labelId }) : children
+
+  // Node form: the row *is* a `<label>`, so the single control inside is associated
+  // structurally and there is no id to keep in sync — the same trade `Field` makes.
+  const Wrapper = isRenderProp ? 'div' : 'label'
+
+  return (
+    <Wrapper className={`block ${disabled ? 'opacity-50' : ''}`}>
+      <div className="flex items-center justify-between gap-3">
+        {isRenderProp ? (
+          <label
+            id={labelId}
+            htmlFor={controlId}
+            className="text-xs text-[var(--color-text)] select-none"
+          >
+            {label}
+          </label>
+        ) : (
+          <span className="text-xs text-[var(--color-text)] select-none">{label}</span>
+        )}
+        <div className="shrink-0">{content}</div>
+      </div>
+      {hint && <p className="mt-1 text-2xs text-[var(--color-text-muted)]">{hint}</p>}
+    </Wrapper>
+  )
+}

--- a/apps/cockpit/src/components/shared/SettingsPopover.tsx
+++ b/apps/cockpit/src/components/shared/SettingsPopover.tsx
@@ -142,15 +142,16 @@ export function SettingsSection({
   )
 }
 
-type SettingsRowIds = { controlId: string; labelId: string }
+type SettingsRowIds = { labelId: string }
 
 type SettingsRowProps = {
   label: string
   /**
-   * The control. As a function when it needs the generated ids — a `Toggle` renders a
-   * `role="switch"` button, which is not a labelable element, so a wrapping `<label>` would
-   * leave it with no accessible name at all. Selects and inputs can take the node form and be
-   * associated by `htmlFor`.
+   * The control. As a function when the control cannot be labelled the ordinary way — a `Toggle`
+   * renders a `role="switch"` button, which is not a labelable element, so neither a wrapping
+   * `<label>` nor an `htmlFor` gives it a name. That form hands back `labelId` to point
+   * `aria-labelledby` at instead. Selects and inputs take the node form and are associated
+   * structurally.
    */
   children: ReactNode | ((ids: SettingsRowIds) => ReactNode)
   hint?: ReactNode
@@ -165,10 +166,9 @@ type SettingsRowProps = {
  * left and its labels down the right at the same time.
  */
 export function SettingsRow({ label, children, hint, disabled = false }: SettingsRowProps) {
-  const controlId = useId()
   const labelId = useId()
   const isRenderProp = typeof children === 'function'
-  const content = isRenderProp ? children({ controlId, labelId }) : children
+  const content = isRenderProp ? children({ labelId }) : children
 
   // Node form: the row *is* a `<label>`, so the single control inside is associated
   // structurally and there is no id to keep in sync — the same trade `Field` makes.
@@ -178,13 +178,11 @@ export function SettingsRow({ label, children, hint, disabled = false }: Setting
     <Wrapper className={`block ${disabled ? 'opacity-50' : ''}`}>
       <div className="flex items-center justify-between gap-3">
         {isRenderProp ? (
-          <label
-            id={labelId}
-            htmlFor={controlId}
-            className="text-xs text-[var(--color-text)] select-none"
-          >
+          // No `htmlFor`: this branch exists for controls that are not labelable, so a `for`
+          // attribute could only ever dangle. `aria-labelledby` does the naming instead.
+          <span id={labelId} className="text-xs text-[var(--color-text)] select-none">
             {label}
-          </label>
+          </span>
         ) : (
           <span className="text-xs text-[var(--color-text)] select-none">{label}</span>
         )}

--- a/apps/cockpit/src/components/shared/Toggle.tsx
+++ b/apps/cockpit/src/components/shared/Toggle.tsx
@@ -5,9 +5,23 @@ type ToggleProps = {
   onChange: (checked: boolean) => void
   label?: string
   disabled?: boolean
+  /**
+   * Names the switch from text rendered elsewhere — a `SettingsRow` label, say. A switch is a
+   * `<button role="switch">`, which is not a labelable element, so an enclosing `<label>` gives
+   * it no name; without one of these it is announced as an unnamed button.
+   */
+  'aria-labelledby'?: string
+  'aria-label'?: string
 }
 
-export function Toggle({ checked, onChange, label, disabled = false }: ToggleProps) {
+export function Toggle({
+  checked,
+  onChange,
+  label,
+  disabled = false,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-label': ariaLabel,
+}: ToggleProps) {
   const id = useId()
 
   return (
@@ -16,6 +30,8 @@ export function Toggle({ checked, onChange, label, disabled = false }: TogglePro
         id={id}
         role="switch"
         aria-checked={checked}
+        aria-labelledby={ariaLabelledBy}
+        aria-label={ariaLabel}
         disabled={disabled}
         onClick={() => onChange(!checked)}
         className={`relative h-[18px] w-8 shrink-0 rounded-full transition-colors duration-[var(--duration-panel)] focus-visible:outline-none focus-visible:shadow-[var(--focus-ring)] ${

--- a/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
@@ -52,6 +52,20 @@ describe('Popover', () => {
     expect(trigger).toHaveFocus()
   })
 
+  it('never mounts the surface before it has been positioned', () => {
+    // Regression: the surface used to render for one commit with `visibility: hidden` while it
+    // waited for a position. A hidden element cannot be focused, so the focus call was a silent
+    // no-op and the whole keyboard path — Tab into the surface, Escape back to the trigger —
+    // was dead in the browser. jsdom does not implement that restriction and had happily
+    // reported the surface as focused, so the assertion below is on the *cause* instead.
+    render(<PopoverHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+
+    const surface = screen.getByRole('dialog')
+    expect(surface.style.visibility).toBe('')
+    expect(surface.style.top).not.toBe('')
+  })
+
   it('renders into the document body so it cannot be clipped by the toolbar', () => {
     render(<PopoverHarness />)
     fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))

--- a/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Popover } from '@/components/shared/Popover'
+
+afterEach(cleanup)
+
+function PopoverHarness({ align }: { align?: 'start' | 'end' } = {}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button type="button">Outside</button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        label="Example popover"
+        {...(align ? { align } : {})}
+        trigger={(props) => (
+          <button type="button" {...props}>
+            Open popover
+          </button>
+        )}
+      >
+        <button type="button">First action</button>
+        <button type="button">Second action</button>
+      </Popover>
+    </>
+  )
+}
+
+describe('Popover', () => {
+  it('wires the trigger to the surface and returns focus when it closes', () => {
+    render(<PopoverHarness />)
+
+    const trigger = screen.getByRole('button', { name: 'Open popover' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
+    // No dangling reference while the surface is unrendered.
+    expect(trigger).not.toHaveAttribute('aria-controls')
+
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    const surface = screen.getByRole('dialog', { name: 'Example popover' })
+    expect(trigger).toHaveAttribute('aria-controls', surface.id)
+    expect(surface).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('renders into the document body so it cannot be clipped by the toolbar', () => {
+    render(<PopoverHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+
+    const surface = screen.getByRole('dialog')
+    expect(surface.parentElement).toBe(document.body)
+    expect(surface.className).toContain('z-[var(--z-popover)]')
+  })
+
+  it('closes on a click outside but lets the trigger toggle itself', () => {
+    render(<PopoverHarness />)
+    const trigger = screen.getByRole('button', { name: 'Open popover' })
+
+    fireEvent.click(trigger)
+    fireEvent.mouseDown(screen.getByRole('dialog'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    // A mousedown on the trigger must not close the surface out from under the click
+    // that follows, or the trigger would reopen what it just closed and never toggle off.
+    fireEvent.click(trigger)
+    fireEvent.mouseDown(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(trigger)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('keeps Tab inside the surface', () => {
+    render(<PopoverHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+
+    const surface = screen.getByRole('dialog')
+    const first = screen.getByRole('button', { name: 'First action' })
+    const last = screen.getByRole('button', { name: 'Second action' })
+
+    last.focus()
+    fireEvent.keyDown(surface, { key: 'Tab' })
+    expect(first).toHaveFocus()
+
+    fireEvent.keyDown(surface, { key: 'Tab', shiftKey: true })
+    expect(last).toHaveFocus()
+  })
+
+  it('anchors to the trailing edge of the trigger, and to the leading edge on request', () => {
+    // jsdom gives every rect zeros, so the assertion is which axis was written, not the
+    // value — that is the part that decides whether the surface grows away from the
+    // viewport edge or into it.
+    render(<PopoverHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+    expect(screen.getByRole('dialog').style.right).not.toBe('')
+    expect(screen.getByRole('dialog').style.left).toBe('')
+
+    cleanup()
+
+    render(<PopoverHarness align="start" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+    expect(screen.getByRole('dialog').style.left).not.toBe('')
+    expect(screen.getByRole('dialog').style.right).toBe('')
+  })
+})

--- a/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/Popover.test.tsx
@@ -66,6 +66,25 @@ describe('Popover', () => {
     expect(surface.style.top).not.toBe('')
   })
 
+  it('keeps the surface on screen when there is no room below the trigger', () => {
+    // A `fixed` surface cannot be scrolled to, so anything past the bottom edge is unreachable
+    // rather than merely clipped — in the validators that is the footer, and the reset action
+    // with it. jsdom reports a zero-height trigger, so the case is forced with a short window.
+    const originalHeight = window.innerHeight
+    Object.defineProperty(window, 'innerHeight', { value: 100, configurable: true })
+
+    try {
+      render(<PopoverHarness />)
+      fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))
+
+      const { top, maxHeight } = screen.getByRole('dialog').style
+      expect(parseFloat(top) + parseFloat(maxHeight)).toBeLessThanOrEqual(100)
+      expect(parseFloat(top)).toBeGreaterThanOrEqual(0)
+    } finally {
+      Object.defineProperty(window, 'innerHeight', { value: originalHeight, configurable: true })
+    }
+  })
+
   it('renders into the document body so it cannot be clipped by the toolbar', () => {
     render(<PopoverHarness />)
     fireEvent.click(screen.getByRole('button', { name: 'Open popover' }))

--- a/apps/cockpit/src/components/shared/__tests__/SettingsPopover.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/SettingsPopover.test.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SettingsPopover, SettingsRow, SettingsSection } from '@/components/shared/SettingsPopover'
+import { Select } from '@/components/shared/Input'
+import { Toggle } from '@/components/shared/Toggle'
+
+afterEach(cleanup)
+
+function SettingsHarness({ badge }: { badge?: number } = {}) {
+  const [open, setOpen] = useState(false)
+  const [indent, setIndent] = useState('2')
+  const [tabs, setTabs] = useState(false)
+
+  return (
+    <SettingsPopover
+      label="Style"
+      open={open}
+      onOpenChange={setOpen}
+      {...(badge === undefined ? {} : { badge })}
+      description="Applies to the current document."
+      footer={<button type="button">Reset to defaults</button>}
+    >
+      <SettingsSection title="Formatting">
+        <SettingsRow label="Indent">
+          <Select value={indent} onChange={(e) => setIndent(e.target.value)}>
+            <option value="2">2 spaces</option>
+            <option value="4">4 spaces</option>
+          </Select>
+        </SettingsRow>
+        <SettingsRow label="Use tabs">
+          {({ labelId }) => <Toggle aria-labelledby={labelId} checked={tabs} onChange={setTabs} />}
+        </SettingsRow>
+      </SettingsSection>
+    </SettingsPopover>
+  )
+}
+
+describe('SettingsPopover', () => {
+  it('names every control from its row label', () => {
+    render(<SettingsHarness />)
+    fireEvent.click(screen.getByRole('button', { name: /Style/ }))
+
+    // The node form associates structurally; the render-prop form has to name a
+    // `role="switch"` button, which no enclosing <label> can do.
+    expect(screen.getByLabelText('Indent')).toHaveValue('2')
+    expect(screen.getByRole('switch', { name: 'Use tabs' })).toBeInTheDocument()
+  })
+
+  it('keeps its controls live — a setting applies without closing the surface', () => {
+    render(<SettingsHarness />)
+    fireEvent.click(screen.getByRole('button', { name: /Style/ }))
+
+    fireEvent.change(screen.getByLabelText('Indent'), { target: { value: '4' } })
+    expect(screen.getByLabelText('Indent')).toHaveValue('4')
+
+    const toggle = screen.getByRole('switch', { name: 'Use tabs' })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+    expect(screen.getByRole('dialog', { name: 'Style' })).toBeInTheDocument()
+  })
+
+  it('shows the description, section heading and footer', () => {
+    render(<SettingsHarness />)
+    fireEvent.click(screen.getByRole('button', { name: /Style/ }))
+
+    expect(screen.getByText('Applies to the current document.')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Formatting' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reset to defaults' })).toBeInTheDocument()
+  })
+
+  it('badges the trigger when settings depart from their defaults', () => {
+    // The cost of hiding settings is that the toolbar stops showing they were changed.
+    // The badge is what buys that back, so it is a contract, not decoration.
+    render(<SettingsHarness badge={3} />)
+    expect(screen.getByRole('button', { name: /Style/ })).toHaveTextContent('3')
+
+    cleanup()
+
+    render(<SettingsHarness badge={0} />)
+    expect(screen.getByRole('button', { name: /Style/ })).not.toHaveTextContent('0')
+  })
+})

--- a/apps/cockpit/src/components/shell/SettingsPanel.tsx
+++ b/apps/cockpit/src/components/shell/SettingsPanel.tsx
@@ -730,7 +730,7 @@ function DataTab() {
 function StatCard({ label, count }: { label: string; count: number }) {
   return (
     <div className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-center">
-      <div className="font-mono text-sm font-bold text-[var(--color-text)]">{count}</div>
+      <div className="text-sm font-bold tabular-nums text-[var(--color-text)]">{count}</div>
       <div className="text-xs text-[var(--color-text-muted)]">{label}</div>
     </div>
   )

--- a/apps/cockpit/src/components/shell/SidebarGroup.tsx
+++ b/apps/cockpit/src/components/shell/SidebarGroup.tsx
@@ -111,10 +111,7 @@ export function SidebarGroup({
         {/* SectionLabel rather than a bespoke type treatment, so group headers
             and the Pinned/Recent headers above them are one style instead of
             two competing ones in the same column. */}
-        <SectionLabel
-          as="span"
-          hint={<span className="font-mono tabular-nums">{tools.length}</span>}
-        >
+        <SectionLabel as="span" hint={<span className="tabular-nums">{tools.length}</span>}>
           <CaretRightIcon
             size={12}
             className={`shrink-0 transition-transform duration-[var(--duration-panel)] ease-[var(--ease-in-out)] ${collapsed ? '' : 'rotate-90'}`}

--- a/apps/cockpit/src/components/shell/Workspace.tsx
+++ b/apps/cockpit/src/components/shell/Workspace.tsx
@@ -113,7 +113,7 @@ export function Workspace() {
     <div className="relative flex h-full flex-col overflow-hidden bg-[var(--color-bg)]">
       {isDragging && (
         <div className="absolute inset-0 z-[var(--z-scrim)] flex items-center justify-center bg-[var(--color-bg)]/80 backdrop-blur-sm">
-          <div className="rounded border-2 border-dashed border-[var(--color-accent)] px-8 py-4 font-mono text-sm text-[var(--color-accent)]">
+          <div className="rounded border-2 border-dashed border-[var(--color-accent)] px-8 py-4 text-sm text-[var(--color-accent)]">
             Drop file here
           </div>
         </div>

--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -35,6 +35,21 @@
   box-sizing: border-box;
 }
 
+/* ─── Typography default ─────────────────────────────────────────────────────
+   The app's inherited font is `--font-ui`, and monospace is opted into.
+   It used to be the other way round, which quietly lost the argument: the
+   design system says chrome is `font-ui` and only tool content is `font-mono`,
+   but with mono inherited, every label, button, badge, status line and empty
+   state had to *remember* to say `font-ui` or silently render monospace. Three
+   of forty-six tool files remembered. The result was a tool title in system-ui
+   sitting beside its own status text in Source Code Pro, in the same row.
+
+   Chrome outnumbers content by an order of magnitude in element count, but
+   content is concentrated in a handful of places — Monaco (which sets its own
+   font), `pre`/`code`/`kbd`/`samp` (covered by the rule below), and the
+   primitives that take a `monospace` prop. So the correct default is the one
+   that needs the fewest exceptions, and the exceptions are all somewhere a
+   reviewer will actually look.                                                */
 html,
 body,
 #root {
@@ -44,6 +59,15 @@ body,
   overflow: hidden;
   background-color: var(--color-bg);
   color: var(--color-text);
+  font-family: var(--font-ui);
+}
+
+/* Content elements are monospace by tag, so a tool rendering output in the
+   obvious element gets the right font without a class. */
+pre,
+code,
+kbd,
+samp {
   font-family: var(--font-mono);
 }
 

--- a/apps/cockpit/src/lib/focus.ts
+++ b/apps/cockpit/src/lib/focus.ts
@@ -1,0 +1,53 @@
+/**
+ * Focusable-element discovery, shared by every surface that has to keep Tab inside itself.
+ *
+ * `Dialog` owned this privately until `Popover` needed the same answer. Two copies of a
+ * selector list is how the two surfaces end up disagreeing about whether a `[tabindex="-1"]`
+ * element is reachable, which is the kind of difference nobody notices until a keyboard user
+ * falls out of one of them.
+ */
+export const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
+    return el.tabIndex >= 0 && el.getAttribute('aria-hidden') !== 'true'
+  })
+}
+
+/**
+ * Tab / Shift-Tab cycling within `container`. Returns true when the event was handled, so the
+ * caller can decide whether to `preventDefault` on its own terms.
+ */
+export function cycleFocus(
+  container: HTMLElement,
+  { shiftKey }: { shiftKey: boolean }
+): 'wrapped' | 'passed' {
+  const focusable = getFocusableElements(container)
+  if (focusable.length === 0) {
+    container.focus()
+    return 'wrapped'
+  }
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+
+  if (shiftKey && (!active || active === first || !container.contains(active))) {
+    last?.focus()
+    return 'wrapped'
+  }
+
+  if (!shiftKey && active === last) {
+    first?.focus()
+    return 'wrapped'
+  }
+
+  return 'passed'
+}

--- a/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
@@ -60,17 +60,22 @@ describe('CodeFormatter', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Not formatted yet')
   })
 
-  it('keeps style options behind a disclosure so the toolbar stays narrow', () => {
+  it('keeps style options in a popover so opening them never resizes the editor', () => {
     renderTool(CodeFormatter)
     const toggle = screen.getByRole('button', { name: /Style/ })
 
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.queryByLabelText('Indent width')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Indent')).not.toBeInTheDocument()
 
     fireEvent.click(toggle)
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByLabelText('Indent width')).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Style' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Indent')).toBeInTheDocument()
     expect(screen.getByRole('switch', { name: 'Single quotes' })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
   })
 
   // `trailingComma` was in persisted state with no control anywhere in the UI —

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -17,6 +17,7 @@ import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolba
 import { SplitPane } from '@/components/shared/SplitPane'
 import { Alert } from '@/components/shared/Alert'
 import { StatusBadge } from '@/components/shared/StatusBadge'
+import { Checkbox } from '@/components/shared/Checkbox'
 import { useUiStore } from '@/stores/ui.store'
 import { sendToTool } from '@/lib/tool-handoff'
 import { useToolAction } from '@/hooks/useToolAction'
@@ -1588,9 +1589,7 @@ export default function ApiClient() {
               {requestTab === 'params' && (
                 <div className="min-h-0 flex-1 overflow-auto p-3">
                   <div className="mb-2 flex items-center justify-between gap-2">
-                    <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
-                      Query Parameters
-                    </h3>
+                    <h3 className="text-xs text-[var(--color-text-muted)]">Query Parameters</h3>
                     <Button
                       type="button"
                       variant="secondary"
@@ -1648,7 +1647,7 @@ export default function ApiClient() {
               {requestTab === 'headers' && (
                 <div className="min-h-0 flex-1 overflow-auto p-3">
                   <div className="mb-2 flex items-center justify-between gap-2">
-                    <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
+                    <h3 className="text-xs text-[var(--color-text-muted)]">
                       Headers
                       {activeHeaderCount > 0 && (
                         <span className="ml-1 text-[var(--color-text)]">({activeHeaderCount})</span>
@@ -1669,12 +1668,10 @@ export default function ApiClient() {
                     <div className="flex flex-col gap-1">
                       {headers.map((h, i) => (
                         <div key={i} className="flex items-center gap-1">
-                          <input
-                            type="checkbox"
+                          <Checkbox
                             checked={h.enabled}
                             onChange={(e) => updateHeader(i, { enabled: e.target.checked })}
                             aria-label={`Send header ${h.key || i + 1}`}
-                            className="accent-[var(--color-accent)]"
                           />
                           <Input
                             value={h.key}
@@ -1749,7 +1746,7 @@ export default function ApiClient() {
                   {showFormEditor ? (
                     <div className="min-h-0 flex-1 overflow-auto p-3">
                       <div className="mb-2 flex items-center justify-between gap-2">
-                        <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
+                        <h3 className="text-xs text-[var(--color-text-muted)]">
                           {bodyMode === FORMDATA_MODE ? 'Multipart fields' : 'Form fields'}
                         </h3>
                         <Button
@@ -1947,7 +1944,12 @@ export default function ApiClient() {
                       ) : (
                         <div className="h-full overflow-auto p-3">
                           {Object.entries(response.headers).map(([key, value]) => (
-                            <div key={key} className="mb-1 flex items-start gap-1 text-xs">
+                            // Response headers are what the server sent, not chrome — the
+                            // whole row is mono so the name, colon and value share metrics.
+                            <div
+                              key={key}
+                              className="mb-1 flex items-start gap-1 font-mono text-xs"
+                            >
                               <span className="shrink-0 font-bold text-[var(--color-accent)]">
                                 {key}
                               </span>

--- a/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/EnvironmentModal.tsx
@@ -235,7 +235,7 @@ export function EnvironmentModal({ onClose }: Props) {
 
               <div className="min-h-0 flex-1 overflow-y-auto p-3">
                 <div className="mb-2 flex items-center justify-between gap-2">
-                  <h3 className="font-mono text-xs text-[var(--color-text-muted)]">
+                  <h3 className="text-xs text-[var(--color-text-muted)]">
                     Variables — use as <code>{'{{name}}'}</code>
                   </h3>
                   <Button

--- a/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
+++ b/apps/cockpit/src/tools/api-client/components/ImportSpecModal.tsx
@@ -106,7 +106,7 @@ export function ImportSpecModal({ onImport, onClose }: Props) {
       <div className="flex flex-col gap-4 p-4">
         <div className="flex items-center justify-between gap-3">
           <div>
-            <div className="font-mono text-xs text-[var(--color-text-muted)]">Source</div>
+            <div className="text-xs text-[var(--color-text-muted)]">Source</div>
             <div className="text-sm text-[var(--color-text)]">
               {filename ??
                 'Paste a Postman, OpenAPI, AsyncAPI, protobuf, GraphQL, or cockpit JSON spec'}
@@ -141,7 +141,7 @@ export function ImportSpecModal({ onImport, onClose }: Props) {
         {preview && (
           <div className="rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
             <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
-              <span className="font-mono text-[var(--color-text-muted)]">Detected:</span>
+              <span className="text-[var(--color-text-muted)]">Detected:</span>
               <span className="font-bold text-[var(--color-accent)]">
                 {FORMAT_LABELS[preview.format]}
               </span>

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor, { DiffEditor, type OnMount } from '@monaco-editor/react'
 import {
   ArrowCounterClockwiseIcon,
@@ -7,7 +7,6 @@ import {
   FloppyDiskIcon,
   MagicWandIcon,
   PencilSimpleIcon,
-  SlidersHorizontalIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
@@ -23,6 +22,7 @@ import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { SettingsPopover, SettingsRow, SettingsSection } from '@/components/shared/SettingsPopover'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
 import { FORMATTER_WORKER_METHODS } from '@/workers/formatter.methods'
@@ -48,8 +48,6 @@ type CodeFormatterState = {
   singleQuote: boolean
   trailingComma: 'all' | 'es5' | 'none'
   semi: boolean
-  /** Style options are collapsed by default — persisted so the choice sticks. */
-  optionsOpen: boolean
   /** Opt-in because formatting incomplete code while typing can be surprising. */
   autoFormat: boolean
   /**
@@ -92,7 +90,6 @@ export default function CodeFormatter() {
     singleQuote: true,
     trailingComma: 'es5',
     semi: false,
-    optionsOpen: false,
     autoFormat: false,
     lastFormat: null,
   })
@@ -107,7 +104,9 @@ export default function CodeFormatter() {
   const [previewOpen, setPreviewOpen] = useState(false)
   const [pendingFormat, setPendingFormat] = useState<{ before: string; after: string } | null>(null)
   const formattingRef = useRef(false)
-  const optionsId = useId()
+  // Session state, deliberately not persisted: a floating surface that reopened itself on
+  // launch would cover the document before the user had asked for anything.
+  const [optionsOpen, setOptionsOpen] = useState(false)
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null)
 
   // `state` as a whole changes on every keystroke; the format call only cares
@@ -310,221 +309,224 @@ export default function CodeFormatter() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar aria-label="Code formatting actions">
-            <DocumentIdentity
-              title={state.fileName ?? 'Untitled'}
-              icon={
-                <CodeBlockIcon
-                  size={16}
+        <DocumentToolbar border aria-label="Code formatting actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled'}
+            icon={
+              <CodeBlockIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            status={isFormatting ? 'Formatting…' : describeStatus(status)}
+            statusIcon={
+              status === 'formatted' ? (
+                <CheckCircleIcon
+                  size={12}
                   aria-hidden="true"
-                  className="shrink-0 text-[var(--color-text-muted)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              }
-              status={isFormatting ? 'Formatting…' : describeStatus(status)}
-              statusIcon={
-                status === 'formatted' ? (
-                  <CheckCircleIcon
-                    size={12}
-                    aria-hidden="true"
-                    className="shrink-0 text-[var(--color-success)]"
-                  />
-                ) : status === 'modified' ? (
-                  <PencilSimpleIcon size={12} aria-hidden="true" className="shrink-0" />
-                ) : undefined
-              }
-            />
+              ) : status === 'modified' ? (
+                <PencilSimpleIcon size={12} aria-hidden="true" className="shrink-0" />
+              ) : undefined
+            }
+          />
 
-            {/* Two groups so a narrow window breaks between "what to format" and
-                "act on it" rather than orphaning a single icon on its own row. */}
-            <ToolbarGroup label="Formatting options" separated>
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                <span className="max-[900px]:hidden">Language</span>
-                <Select
-                  aria-label="Language"
-                  value={state.language}
-                  onChange={(e) => updateState({ language: e.target.value })}
-                >
-                  {LANGUAGES.map((lang) => (
-                    <option key={lang.id} value={lang.id}>
-                      {lang.label}
-                    </option>
-                  ))}
-                </Select>
-              </label>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => void handleAutoDetect()}
-                disabled={!hasCode}
-                title="Guess the language from the code"
-                className="gap-1"
-              >
-                <MagicWandIcon size={14} aria-hidden="true" />
-                Auto-detect
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => updateState({ optionsOpen: !state.optionsOpen })}
-                aria-expanded={state.optionsOpen}
-                // Only advertise the relationship while the panel exists in the DOM.
-                {...(state.optionsOpen ? { 'aria-controls': optionsId } : {})}
-                className="gap-1"
-              >
-                <SlidersHorizontalIcon size={14} aria-hidden="true" />
-                Style
-              </Button>
-            </ToolbarGroup>
-
-            <ToolbarGroup label="Document actions" separated>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={() => void handleFormat()}
-                disabled={!canFormat}
-                loading={isFormatting}
-                title={`Format the code (${formatShortcut('mod+enter')})`}
-              >
-                Format
-                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleRevert}
-                disabled={!canRevert}
-                title="Restore the code as it was before formatting"
-                className="gap-1"
-              >
-                <ArrowCounterClockwiseIcon size={14} aria-hidden="true" />
-                Revert
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setPreviewOpen((open) => !open)}
-                disabled={!pendingFormat && (!lastFormat || lastFormat.before === lastFormat.after)}
-                aria-pressed={previewOpen}
-                title="Compare the source before and after formatting"
-              >
-                Diff
-              </Button>
-              {pendingFormat && (
-                <>
-                  <Button variant="primary" size="sm" onClick={handleAcceptPreview}>
-                    Apply format
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setPendingFormat(null)
-                      setPreviewOpen(false)
-                    }}
-                  >
-                    Discard preview
-                  </Button>
-                </>
-              )}
-              <CopyButton text={input} />
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSave}
-                disabled={!hasCode}
-                title={`Save to a file (${formatShortcut('mod+s')})`}
-                aria-label="Save to file"
-                className="gap-1"
-              >
-                <FloppyDiskIcon size={14} aria-hidden="true" />
-                Save
-              </Button>
-            </ToolbarGroup>
-          </DocumentToolbar>
-
-          {state.optionsOpen && (
-            <div
-              id={optionsId}
-              className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2"
-            >
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                Indent
-                <Select
-                  aria-label="Indent width"
-                  value={state.tabWidth}
-                  onChange={(e) => updateState({ tabWidth: Number(e.target.value) })}
-                >
-                  <option value={2}>2 spaces</option>
-                  <option value={4}>4 spaces</option>
-                  <option value={8}>8 spaces</option>
-                </Select>
-              </label>
-              <Toggle
-                label="Use tabs"
-                checked={state.useTabs}
-                onChange={(checked) => updateState({ useTabs: checked })}
-              />
-              <Toggle
-                label="Auto-format"
-                checked={state.autoFormat}
-                onChange={(checked) => updateState({ autoFormat: checked })}
-              />
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                Width
-                <Select
-                  aria-label="Print width"
-                  value={state.printWidth}
-                  onChange={(e) => updateState({ printWidth: Number(e.target.value) })}
-                >
-                  <option value={80}>80</option>
-                  <option value={100}>100</option>
-                  <option value={120}>120</option>
-                </Select>
-              </label>
-              <Toggle
-                label="Single quotes"
-                checked={state.singleQuote}
-                disabled={!quoteStyle}
-                onChange={(checked) => updateState({ singleQuote: checked })}
-              />
-              <Toggle
-                label="Semicolons"
-                checked={state.semi}
-                disabled={!jsOptions}
-                onChange={(checked) => updateState({ semi: checked })}
-              />
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                Trailing commas
-                <Select
-                  aria-label="Trailing commas"
-                  value={state.trailingComma}
-                  disabled={!jsOptions}
-                  onChange={(e) =>
-                    updateState({
-                      trailingComma: e.target.value as CodeFormatterState['trailingComma'],
-                    })
-                  }
-                >
-                  <option value="none">None</option>
-                  <option value="es5">ES5</option>
-                  <option value="all">All</option>
-                </Select>
-              </label>
-              {(!jsOptions || !quoteStyle) && (
-                <span className="text-2xs text-[var(--color-text-muted)]">
-                  Greyed-out options have no effect on {languageLabel(state.language)}.
-                </span>
-              )}
-              {stats && (
-                <span className="ml-auto text-2xs text-[var(--color-text-muted)]">
-                  {stats.lines} line{stats.lines === 1 ? '' : 's'} · {stats.characters} character
-                  {stats.characters === 1 ? '' : 's'}
-                </span>
-              )}
-            </div>
+          {stats && (
+            <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
+              {stats.lines} line{stats.lines === 1 ? '' : 's'} · {stats.characters} character
+              {stats.characters === 1 ? '' : 's'}
+            </span>
           )}
-        </div>
+
+          {/* Two groups so a narrow window breaks between "what to format" and
+                "act on it" rather than orphaning a single icon on its own row. */}
+          <ToolbarGroup label="Formatting options" separated>
+            <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
+              <span className="max-[900px]:hidden">Language</span>
+              <Select
+                aria-label="Language"
+                value={state.language}
+                onChange={(e) => updateState({ language: e.target.value })}
+              >
+                {LANGUAGES.map((lang) => (
+                  <option key={lang.id} value={lang.id}>
+                    {lang.label}
+                  </option>
+                ))}
+              </Select>
+            </label>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleAutoDetect()}
+              disabled={!hasCode}
+              title="Guess the language from the code"
+              className="gap-1"
+            >
+              <MagicWandIcon size={14} aria-hidden="true" />
+              Auto-detect
+            </Button>
+            <SettingsPopover
+              label="Style"
+              open={optionsOpen}
+              onOpenChange={setOptionsOpen}
+              description={
+                jsOptions && quoteStyle
+                  ? undefined
+                  : `Greyed-out options have no effect on ${languageLabel(state.language)}.`
+              }
+            >
+              <SettingsSection>
+                <SettingsRow label="Indent">
+                  <Select
+                    value={state.tabWidth}
+                    onChange={(e) => updateState({ tabWidth: Number(e.target.value) })}
+                  >
+                    <option value={2}>2 spaces</option>
+                    <option value={4}>4 spaces</option>
+                    <option value={8}>8 spaces</option>
+                  </Select>
+                </SettingsRow>
+                <SettingsRow label="Use tabs">
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.useTabs}
+                      onChange={(checked) => updateState({ useTabs: checked })}
+                    />
+                  )}
+                </SettingsRow>
+                <SettingsRow label="Print width">
+                  <Select
+                    value={state.printWidth}
+                    onChange={(e) => updateState({ printWidth: Number(e.target.value) })}
+                  >
+                    <option value={80}>80</option>
+                    <option value={100}>100</option>
+                    <option value={120}>120</option>
+                  </Select>
+                </SettingsRow>
+                <SettingsRow label="Single quotes" disabled={!quoteStyle}>
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.singleQuote}
+                      disabled={!quoteStyle}
+                      onChange={(checked) => updateState({ singleQuote: checked })}
+                    />
+                  )}
+                </SettingsRow>
+                <SettingsRow label="Semicolons" disabled={!jsOptions}>
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.semi}
+                      disabled={!jsOptions}
+                      onChange={(checked) => updateState({ semi: checked })}
+                    />
+                  )}
+                </SettingsRow>
+                <SettingsRow label="Trailing commas" disabled={!jsOptions}>
+                  <Select
+                    value={state.trailingComma}
+                    disabled={!jsOptions}
+                    onChange={(e) =>
+                      updateState({
+                        trailingComma: e.target.value as CodeFormatterState['trailingComma'],
+                      })
+                    }
+                  >
+                    <option value="none">None</option>
+                    <option value="es5">ES5</option>
+                    <option value="all">All</option>
+                  </Select>
+                </SettingsRow>
+              </SettingsSection>
+
+              <SettingsSection title="Behaviour">
+                <SettingsRow
+                  label="Auto-format"
+                  hint="Reformat as you type, without pressing Format."
+                >
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.autoFormat}
+                      onChange={(checked) => updateState({ autoFormat: checked })}
+                    />
+                  )}
+                </SettingsRow>
+              </SettingsSection>
+            </SettingsPopover>
+          </ToolbarGroup>
+
+          <ToolbarGroup label="Document actions" separated>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleFormat()}
+              disabled={!canFormat}
+              loading={isFormatting}
+              title={`Format the code (${formatShortcut('mod+enter')})`}
+            >
+              Format
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleRevert}
+              disabled={!canRevert}
+              title="Restore the code as it was before formatting"
+              className="gap-1"
+            >
+              <ArrowCounterClockwiseIcon size={14} aria-hidden="true" />
+              Revert
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setPreviewOpen((open) => !open)}
+              disabled={!pendingFormat && (!lastFormat || lastFormat.before === lastFormat.after)}
+              aria-pressed={previewOpen}
+              title="Compare the source before and after formatting"
+            >
+              Diff
+            </Button>
+            {pendingFormat && (
+              <>
+                <Button variant="primary" size="sm" onClick={handleAcceptPreview}>
+                  Apply format
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setPendingFormat(null)
+                    setPreviewOpen(false)
+                  }}
+                >
+                  Discard preview
+                </Button>
+              </>
+            )}
+            <CopyButton text={input} />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleSave}
+              disabled={!hasCode}
+              title={`Save to a file (${formatShortcut('mod+s')})`}
+              aria-label="Save to file"
+              className="gap-1"
+            >
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
+            </Button>
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
       {formatProblem && (

--- a/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
+++ b/apps/cockpit/src/tools/color-converter/ColorConverter.tsx
@@ -628,6 +628,7 @@ function ContrastInputs({
         <div className="flex items-center gap-2">
           <Input
             id="contrast-fg"
+            monospace
             value={contrastFg}
             onChange={(e) => onFgChange(e.target.value)}
             size="md"
@@ -655,6 +656,7 @@ function ContrastInputs({
         <div className="flex items-center gap-2">
           <Input
             id="contrast-bg"
+            monospace
             value={contrastBg}
             onChange={(e) => onBgChange(e.target.value)}
             size="md"
@@ -829,6 +831,7 @@ export default function ColorConverter() {
               value={state.input}
               onChange={(e) => handleInputChange(e.target.value)}
               placeholder="#39ff14, rgb(255,0,0), hsl(120,100%,50%), oklch(87% 0.35 145), red"
+              monospace
               size="md"
               className="flex-1"
             />

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -541,9 +541,7 @@ export default function CssToTailwind() {
               <div className="flex flex-col gap-4">
                 {result.classes.length > 0 && (
                   <section>
-                    <h3 className="mb-2 font-mono text-xs text-[var(--color-success)]">
-                      Converted Classes
-                    </h3>
+                    <h3 className="mb-2 text-xs text-[var(--color-success)]">Converted Classes</h3>
                     <div className="flex flex-wrap gap-2">
                       {result.classes.map((cls, i) => (
                         <code
@@ -564,9 +562,7 @@ export default function CssToTailwind() {
                 )}
                 {result.selectors.length > 0 && (
                   <section>
-                    <h3 className="mb-2 font-mono text-xs text-[var(--color-text-muted)]">
-                      Per selector
-                    </h3>
+                    <h3 className="mb-2 text-xs text-[var(--color-text-muted)]">Per selector</h3>
                     <div className="space-y-2">
                       {result.selectors.map((entry) => (
                         <div
@@ -586,13 +582,11 @@ export default function CssToTailwind() {
                 )}
                 {result.unconvertible.length > 0 && (
                   <section>
-                    <h3 className="mb-2 font-mono text-xs text-[var(--color-warning)]">
-                      Unconvertible
-                    </h3>
+                    <h3 className="mb-2 text-xs text-[var(--color-warning)]">Unconvertible</h3>
                     {result.unconvertible.map((prop, i) => (
-                      <div key={i} className="text-xs text-[var(--color-text-muted)]">
+                      <code key={i} className="block text-xs text-[var(--color-text-muted)]">
                         {prop}
-                      </div>
+                      </code>
                     ))}
                   </section>
                 )}

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -9,7 +9,6 @@ import {
   FloppyDiskIcon,
   FolderOpenIcon,
   InfoIcon,
-  SlidersHorizontalIcon,
   WarningCircleIcon,
   WarningIcon,
 } from '@phosphor-icons/react'
@@ -23,7 +22,7 @@ import { useValidatorDocument, type PendingValidatorDocument } from '@/hooks/use
 import { ProblemsList } from '@/components/shared/ProblemsList'
 import { Alert } from '@/components/shared/Alert'
 import { Kbd } from '@/components/shared/Kbd'
-import { SectionLabel } from '@/components/shared/SectionLabel'
+import { SettingsPopover, SettingsSection } from '@/components/shared/SettingsPopover'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Dialog } from '@/components/shared/Dialog'
@@ -71,7 +70,6 @@ type CssValidatorState = {
    */
   savedContent: string | null
   templateId: string
-  showRules: boolean
   panel: Panel
   panelOpen: boolean
   /** Departures from the rule defaults, so new defaults still reach the user. */
@@ -104,7 +102,9 @@ export default function CssValidator() {
   const setLastAction = useUiStore((s) => s.setLastAction)
   const copy = useCopyToClipboard()
   const { record } = useToolHistory({ toolId: 'css-validator' })
-  const rulesPanelId = useId()
+  // Session state: the rules surface floats over the editor, so restoring it open would
+  // hide the document the moment the tool loads.
+  const [rulesOpen, setRulesOpen] = useState(false)
 
   const [state, updateState] = useToolState<CssValidatorState>('css-validator', {
     input: '',
@@ -112,7 +112,6 @@ export default function CssValidator() {
     filePath: null,
     savedContent: null,
     templateId: TEMPLATES[0]?.id ?? 'flexbox',
-    showRules: false,
     panel: 'problems',
     panelOpen: true,
     disabledRules: [],
@@ -525,202 +524,172 @@ export default function CssValidator() {
 
   return (
     <ToolLayout fullBleed>
-      {/* The seam belongs to the rules panel, not the toolbar: it marks the bottom of a chrome
-          block that is genuinely two rows tall. With the panel closed this header is a single
-          toolbar row, and a border would be the divider the toolbar primitive dropped. */}
-      <header
-        className={`bg-[var(--color-surface)] ${
-          state.showRules ? 'border-b border-[var(--color-border)]' : ''
-        }`}
-      >
-        <DocumentToolbar aria-label="Stylesheet actions">
-          <DocumentIdentity
-            title={state.fileName ?? 'Untitled stylesheet'}
-            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled stylesheet'}
-            titleTestId="file-name"
-            icon={
-              <FileCssIcon
-                size={16}
+      <DocumentToolbar aria-label="Stylesheet actions">
+        <DocumentIdentity
+          title={state.fileName ?? 'Untitled stylesheet'}
+          titleTooltip={state.filePath ?? state.fileName ?? 'Untitled stylesheet'}
+          titleTestId="file-name"
+          icon={
+            <FileCssIcon
+              size={16}
+              aria-hidden="true"
+              className="shrink-0 text-[var(--color-text-muted)]"
+            />
+          }
+          stateLabel={isDirty ? 'Modified' : 'Saved'}
+          stateChanged={isDirty}
+          status={status}
+          statusTestId="validation-status"
+          statusIcon={
+            hasInput && hasAnalyzed && issues.length === 0 ? (
+              <CheckCircleIcon
+                size={12}
                 aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
+                className="shrink-0 text-[var(--color-success)]"
               />
-            }
-            stateLabel={isDirty ? 'Modified' : 'Saved'}
-            stateChanged={isDirty}
-            status={status}
-            statusTestId="validation-status"
-            statusIcon={
-              hasInput && hasAnalyzed && issues.length === 0 ? (
-                <CheckCircleIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-success)]"
-                />
-              ) : errorCount > 0 ? (
-                <WarningCircleIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-error)]"
-                />
-              ) : errorCount === 0 && warningCount > 0 ? (
-                <WarningIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-warning)]"
-                />
-              ) : undefined
-            }
-          />
+            ) : errorCount > 0 ? (
+              <WarningCircleIcon
+                size={12}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-error)]"
+              />
+            ) : errorCount === 0 && warningCount > 0 ? (
+              <WarningIcon
+                size={12}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-warning)]"
+              />
+            ) : undefined
+          }
+        />
 
-          <ToolbarGroup label="Document actions" separated>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={handleNew}
-              title="New stylesheet"
-              aria-label="New stylesheet"
-            >
-              <FilePlusIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleOpen()}
-              title={`Open a .css file (${formatShortcut('mod+o')})`}
-              aria-label="Open CSS file"
-            >
-              <FolderOpenIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleSave()}
-              title={`Save the stylesheet (${formatShortcut('mod+s')})`}
-              aria-label="Save stylesheet"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-            </Button>
-          </ToolbarGroup>
-
-          <ToolbarGroup label="Template actions" separated>
-            <Select
-              aria-label="Stylesheet syntax"
-              value={state.syntax}
-              onChange={(event) =>
-                updateState({ syntax: event.target.value as CssValidatorState['syntax'] })
-              }
-            >
-              <option value="css">CSS</option>
-              <option value="scss">SCSS</option>
-              <option value="less">Less</option>
-            </Select>
-            <Select
-              aria-label="Starter template"
-              value={state.templateId}
-              onChange={(e) => updateState({ templateId: e.target.value })}
-            >
-              {TEMPLATES.map((template) => (
-                <option key={template.id} value={template.id}>
-                  {template.label}
-                </option>
-              ))}
-            </Select>
-            <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
-              Load
-            </Button>
-          </ToolbarGroup>
-
-          <ToolbarGroup label="Stylesheet output" separated>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => void handleFormat()}
-              disabled={!hasInput || isFormatting || !formatter}
-              loading={isFormatting}
-              title={`Reformat the stylesheet (${formatShortcut('mod+enter')})`}
-            >
-              Format
-              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
-            </Button>
-            <CopyButton text={input} label="Copy CSS" />
-          </ToolbarGroup>
-
+        <ToolbarGroup label="Document actions" separated>
           <Button
-            variant={state.showRules ? 'secondary' : 'ghost'}
+            variant="icon"
             size="sm"
-            onClick={() => updateState({ showRules: !state.showRules })}
-            aria-expanded={state.showRules}
-            {...(state.showRules ? { 'aria-controls': rulesPanelId } : {})}
-            className="gap-1"
+            onClick={handleNew}
+            title="New stylesheet"
+            aria-label="New stylesheet"
           >
-            <SlidersHorizontalIcon size={14} aria-hidden="true" />
-            Rules
-            {overrideCount > 0 && (
-              <span className="rounded-full bg-[var(--color-accent)] px-1.5 text-2xs text-[var(--color-bg)]">
-                {overrideCount}
-              </span>
-            )}
+            <FilePlusIcon size={14} aria-hidden="true" />
           </Button>
-        </DocumentToolbar>
-
-        {state.showRules && (
-          <section
-            id={rulesPanelId}
-            aria-label="Lint rules"
-            className="max-h-56 overflow-auto border-t border-[var(--color-border)] px-4 py-3"
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={() => void handleOpen()}
+            title={`Open a .css file (${formatShortcut('mod+o')})`}
+            aria-label="Open CSS file"
           >
-            <div className="mb-2 flex items-center gap-3">
-              <p className="text-2xs text-[var(--color-text-muted)]">
-                {overrideCount === 0
-                  ? 'Using the default rules.'
-                  : `${overrideCount} rule${overrideCount === 1 ? '' : 's'} changed from the defaults.`}
-              </p>
-              <Button
-                variant="ghost"
-                size="xs"
-                onClick={handleResetRules}
-                disabled={overrideCount === 0}
-              >
-                Reset to defaults
-              </Button>
-            </div>
-            <div className="grid gap-x-8 gap-y-3 min-[700px]:grid-cols-2 min-[1100px]:grid-cols-3">
-              {RULE_CATEGORIES.map((category) => (
-                <div key={category.id}>
-                  <SectionLabel as="h2" className="mb-1">
-                    {category.label}
-                  </SectionLabel>
-                  {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
-                    const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
-                    return (
-                      <label
-                        key={rule.id}
-                        // The hint explains *why* — the rule ids alone told the
-                        // user nothing they could act on.
-                        title={`${rule.id} — ${rule.hint}`}
-                        className="flex cursor-pointer items-start gap-1.5 py-0.5 text-xs"
-                      >
-                        <Checkbox
-                          checked={enabled}
-                          onChange={(e) => handleToggleRule(rule, e.target.checked)}
-                          className="mt-0.5"
-                        />
-                        <span
-                          className={
-                            enabled ? 'text-[var(--color-text)]' : 'text-[var(--color-text-muted)]'
-                          }
-                        >
-                          {rule.label}
-                        </span>
-                      </label>
-                    )
-                  })}
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-      </header>
+            <FolderOpenIcon size={14} aria-hidden="true" />
+          </Button>
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={() => void handleSave()}
+            title={`Save the stylesheet (${formatShortcut('mod+s')})`}
+            aria-label="Save stylesheet"
+          >
+            <FloppyDiskIcon size={14} aria-hidden="true" />
+          </Button>
+        </ToolbarGroup>
+
+        <ToolbarGroup label="Template actions" separated>
+          <Select
+            aria-label="Stylesheet syntax"
+            value={state.syntax}
+            onChange={(event) =>
+              updateState({ syntax: event.target.value as CssValidatorState['syntax'] })
+            }
+          >
+            <option value="css">CSS</option>
+            <option value="scss">SCSS</option>
+            <option value="less">Less</option>
+          </Select>
+          <Select
+            aria-label="Starter template"
+            value={state.templateId}
+            onChange={(e) => updateState({ templateId: e.target.value })}
+          >
+            {TEMPLATES.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.label}
+              </option>
+            ))}
+          </Select>
+          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+            Load
+          </Button>
+        </ToolbarGroup>
+
+        <ToolbarGroup label="Stylesheet output" separated>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void handleFormat()}
+            disabled={!hasInput || isFormatting || !formatter}
+            loading={isFormatting}
+            title={`Reformat the stylesheet (${formatShortcut('mod+enter')})`}
+          >
+            Format
+            <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+          </Button>
+          <CopyButton text={input} label="Copy CSS" />
+        </ToolbarGroup>
+
+        <SettingsPopover
+          label="Rules"
+          title="Lint rules"
+          open={rulesOpen}
+          onOpenChange={setRulesOpen}
+          badge={overrideCount}
+          width="lg"
+          description={
+            overrideCount === 0
+              ? 'Using the default rules.'
+              : `${overrideCount} rule${overrideCount === 1 ? '' : 's'} changed from the defaults.`
+          }
+          footer={
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleResetRules}
+              disabled={overrideCount === 0}
+            >
+              Reset to defaults
+            </Button>
+          }
+        >
+          {RULE_CATEGORIES.map((category) => (
+            <SettingsSection key={category.id} title={category.label} dense>
+              {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
+                const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
+                return (
+                  <label
+                    key={rule.id}
+                    // The hint explains *why* — the rule ids alone told the
+                    // user nothing they could act on.
+                    title={`${rule.id} — ${rule.hint}`}
+                    className="flex cursor-pointer items-start gap-1.5 text-xs"
+                  >
+                    <Checkbox
+                      checked={enabled}
+                      onChange={(e) => handleToggleRule(rule, e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span
+                      className={
+                        enabled ? 'text-[var(--color-text)]' : 'text-[var(--color-text-muted)]'
+                      }
+                    >
+                      {rule.label}
+                    </span>
+                  </label>
+                )
+              })}
+            </SettingsSection>
+          ))}
+        </SettingsPopover>
+      </DocumentToolbar>
 
       {formatError && (
         <Alert

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -32,6 +32,7 @@ import { Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { Checkbox } from '@/components/shared/Checkbox'
 import { useUiStore } from '@/stores/ui.store'
 import { openFileDialog, saveFileDialog, filenameFromPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
@@ -699,11 +700,10 @@ export default function CssValidator() {
                         title={`${rule.id} — ${rule.hint}`}
                         className="flex cursor-pointer items-start gap-1.5 py-0.5 text-xs"
                       >
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={enabled}
                           onChange={(e) => handleToggleRule(rule, e.target.checked)}
-                          className="mt-0.5 accent-[var(--color-accent)]"
+                          className="mt-0.5"
                         />
                         <span
                           className={

--- a/apps/cockpit/src/tools/docs-browser/DocsBrowser.tsx
+++ b/apps/cockpit/src/tools/docs-browser/DocsBrowser.tsx
@@ -122,7 +122,7 @@ export default function DocsBrowser({ defaultLoadError = false, frameSrc }: Docs
                 ))}
               </Select>
             )}
-            <span className="font-mono text-xs text-[var(--color-text-muted)]">{label}</span>
+            <span className="text-xs text-[var(--color-text-muted)]">{label}</span>
             <Button variant="secondary" size="sm" onClick={handleRetry}>
               Reload
             </Button>

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -11,7 +11,6 @@ import {
   FrameCornersIcon,
   InfoIcon,
   ListBulletsIcon,
-  SlidersHorizontalIcon,
   WarningCircleIcon,
   WarningIcon,
 } from '@phosphor-icons/react'
@@ -24,7 +23,7 @@ import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { Alert } from '@/components/shared/Alert'
 import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
-import { SectionLabel } from '@/components/shared/SectionLabel'
+import { SettingsPopover, SettingsSection } from '@/components/shared/SettingsPopover'
 import { SplitPane } from '@/components/shared/SplitPane'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -78,7 +77,6 @@ type HtmlValidatorState = {
   savedContent: string | null
   viewMode: ViewMode
   templateId: string
-  showRules: boolean
   panel: Panel
   panelOpen: boolean
   /** Departures from the rule defaults, so new defaults still reach the user. */
@@ -103,7 +101,9 @@ export default function HtmlValidator() {
   const setLastAction = useUiStore((s) => s.setLastAction)
   const copy = useCopyToClipboard()
   const { record } = useToolHistory({ toolId: 'html-validator' })
-  const rulesPanelId = useId()
+  // Session state: the rules surface floats over the editor, so restoring it open would
+  // hide the document the moment the tool loads.
+  const [rulesOpen, setRulesOpen] = useState(false)
 
   const [state, updateState] = useToolState<HtmlValidatorState>('html-validator', {
     input: '',
@@ -112,7 +112,6 @@ export default function HtmlValidator() {
     savedContent: null,
     viewMode: 'split',
     templateId: TEMPLATES[0]?.id ?? 'minimal',
-    showRules: false,
     panel: 'problems',
     panelOpen: true,
     disabledRules: [],
@@ -601,203 +600,173 @@ export default function HtmlValidator() {
 
   return (
     <ToolLayout fullBleed>
-      {/* The seam belongs to the rules panel, not the toolbar: it marks the bottom of a chrome
-          block that is genuinely two rows tall. With the panel closed this header is a single
-          toolbar row, and a border would be the divider the toolbar primitive dropped. */}
-      <header
-        className={`bg-[var(--color-surface)] ${
-          state.showRules ? 'border-b border-[var(--color-border)]' : ''
-        }`}
-      >
-        <DocumentToolbar aria-label="HTML document actions">
-          <DocumentIdentity
-            title={state.fileName ?? 'Untitled document'}
-            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}
-            titleTestId="file-name"
-            icon={
-              <FileHtmlIcon
-                size={16}
-                aria-hidden="true"
-                className="shrink-0 text-[var(--color-text-muted)]"
-              />
-            }
-            stateLabel={isDirty ? 'Modified' : 'Saved'}
-            stateChanged={isDirty}
-            status={status}
-            statusTestId="validation-status"
-            statusIcon={
-              hasInput && hasValidated && issues.length === 0 ? (
-                <CheckCircleIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-success)]"
-                />
-              ) : errorCount > 0 ? (
-                <WarningCircleIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-error)]"
-                />
-              ) : errorCount === 0 && warningCount > 0 ? (
-                <WarningIcon
-                  size={12}
-                  aria-hidden="true"
-                  className="shrink-0 text-[var(--color-warning)]"
-                />
-              ) : undefined
-            }
-          />
-
-          <ToolbarGroup label="View controls" separated>
-            <SegmentedControl
-              aria-label="View mode"
-              options={VIEW_OPTIONS}
-              value={viewMode}
-              onChange={(next) => updateState({ viewMode: next })}
+      <DocumentToolbar aria-label="HTML document actions">
+        <DocumentIdentity
+          title={state.fileName ?? 'Untitled document'}
+          titleTooltip={state.filePath ?? state.fileName ?? 'Untitled document'}
+          titleTestId="file-name"
+          icon={
+            <FileHtmlIcon
+              size={16}
+              aria-hidden="true"
+              className="shrink-0 text-[var(--color-text-muted)]"
             />
-          </ToolbarGroup>
+          }
+          stateLabel={isDirty ? 'Modified' : 'Saved'}
+          stateChanged={isDirty}
+          status={status}
+          statusTestId="validation-status"
+          statusIcon={
+            hasInput && hasValidated && issues.length === 0 ? (
+              <CheckCircleIcon
+                size={12}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-success)]"
+              />
+            ) : errorCount > 0 ? (
+              <WarningCircleIcon
+                size={12}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-error)]"
+              />
+            ) : errorCount === 0 && warningCount > 0 ? (
+              <WarningIcon
+                size={12}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-warning)]"
+              />
+            ) : undefined
+          }
+        />
 
-          <ToolbarGroup label="Document actions" separated>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={handleNew}
-              title="New HTML document"
-              aria-label="New HTML document"
-            >
-              <FilePlusIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleOpen()}
-              title={`Open an .html file (${formatShortcut('mod+o')})`}
-              aria-label="Open HTML file"
-            >
-              <FolderOpenIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleSave()}
-              title={`Save the document (${formatShortcut('mod+s')})`}
-              aria-label="Save HTML document"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-            </Button>
-          </ToolbarGroup>
+        <ToolbarGroup label="View controls" separated>
+          <SegmentedControl
+            aria-label="View mode"
+            options={VIEW_OPTIONS}
+            value={viewMode}
+            onChange={(next) => updateState({ viewMode: next })}
+          />
+        </ToolbarGroup>
 
-          <ToolbarGroup label="Template actions" separated>
-            <Select
-              aria-label="Starter template"
-              value={state.templateId}
-              onChange={(e) => updateState({ templateId: e.target.value })}
-            >
-              {TEMPLATES.map((template) => (
-                <option key={template.id} value={template.id}>
-                  {template.label}
-                </option>
-              ))}
-            </Select>
-            <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
-              Load
-            </Button>
-          </ToolbarGroup>
+        <ToolbarGroup label="Document actions" separated>
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={handleNew}
+            title="New HTML document"
+            aria-label="New HTML document"
+          >
+            <FilePlusIcon size={14} aria-hidden="true" />
+          </Button>
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={() => void handleOpen()}
+            title={`Open an .html file (${formatShortcut('mod+o')})`}
+            aria-label="Open HTML file"
+          >
+            <FolderOpenIcon size={14} aria-hidden="true" />
+          </Button>
+          <Button
+            variant="icon"
+            size="sm"
+            onClick={() => void handleSave()}
+            title={`Save the document (${formatShortcut('mod+s')})`}
+            aria-label="Save HTML document"
+          >
+            <FloppyDiskIcon size={14} aria-hidden="true" />
+          </Button>
+        </ToolbarGroup>
 
-          <ToolbarGroup label="Markup output" separated>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => void handleFormat()}
-              disabled={!hasInput || isFormatting}
-              loading={isFormatting}
-              title={`Reformat the markup (${formatShortcut('mod+enter')})`}
-            >
-              Format
-              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
-            </Button>
-            <CopyButton text={input} label="Copy HTML" />
-          </ToolbarGroup>
+        <ToolbarGroup label="Template actions" separated>
+          <Select
+            aria-label="Starter template"
+            value={state.templateId}
+            onChange={(e) => updateState({ templateId: e.target.value })}
+          >
+            {TEMPLATES.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.label}
+              </option>
+            ))}
+          </Select>
+          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+            Load
+          </Button>
+        </ToolbarGroup>
 
-          {/* `aria-controls` is conditional because the panel only exists while open, and an
+        <ToolbarGroup label="Markup output" separated>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void handleFormat()}
+            disabled={!hasInput || isFormatting}
+            loading={isFormatting}
+            title={`Reformat the markup (${formatShortcut('mod+enter')})`}
+          >
+            Format
+            <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+          </Button>
+          <CopyButton text={input} label="Copy HTML" />
+        </ToolbarGroup>
+
+        {/* `aria-controls` is conditional because the panel only exists while open, and an
               `aria-controls` pointing at an unrendered id is worse than none — it sends the user's
               cursor nowhere. Matches css-validator, which already had it this way. */}
-          <Button
-            variant={state.showRules ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => updateState({ showRules: !state.showRules })}
-            aria-expanded={state.showRules}
-            {...(state.showRules ? { 'aria-controls': rulesPanelId } : {})}
-            className="gap-1"
-          >
-            <SlidersHorizontalIcon size={14} aria-hidden="true" />
-            Rules
-            {overrideCount > 0 && (
-              <span className="rounded-full bg-[var(--color-accent)] px-1.5 text-2xs text-[var(--color-bg)]">
-                {overrideCount}
-              </span>
-            )}
-          </Button>
-        </DocumentToolbar>
-
-        {state.showRules && (
-          <section
-            id={rulesPanelId}
-            aria-label="Validation rules"
-            className="max-h-56 overflow-auto border-t border-[var(--color-border)] px-4 py-3"
-          >
-            <div className="mb-2 flex items-center gap-3">
-              <p className="text-2xs text-[var(--color-text-muted)]">
-                {overrideCount === 0
-                  ? 'Using the default rules.'
-                  : `${overrideCount} rule${overrideCount === 1 ? '' : 's'} changed from the defaults.`}
-              </p>
-              <Button
-                variant="ghost"
-                size="xs"
-                onClick={handleResetRules}
-                disabled={overrideCount === 0}
-              >
-                Reset to defaults
-              </Button>
-            </div>
-            <div className="grid gap-x-8 gap-y-3 min-[700px]:grid-cols-2 min-[1100px]:grid-cols-4">
-              {RULE_CATEGORIES.map((category) => (
-                <div key={category.id}>
-                  <SectionLabel as="h2" className="mb-1">
-                    {category.label}
-                  </SectionLabel>
-                  {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
-                    const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
-                    return (
-                      <label
-                        key={rule.id}
-                        // The hint explains *why* — the rule ids alone told the
-                        // user nothing they could act on.
-                        title={`${rule.id} — ${rule.hint}`}
-                        className="flex cursor-pointer items-start gap-1.5 py-0.5 text-xs"
-                      >
-                        <Checkbox
-                          checked={enabled}
-                          onChange={(e) => handleToggleRule(rule, e.target.checked)}
-                          className="mt-0.5"
-                        />
-                        <span
-                          className={
-                            enabled ? 'text-[var(--color-text)]' : 'text-[var(--color-text-muted)]'
-                          }
-                        >
-                          {rule.label}
-                        </span>
-                      </label>
-                    )
-                  })}
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-      </header>
+        <SettingsPopover
+          label="Rules"
+          title="Validation rules"
+          open={rulesOpen}
+          onOpenChange={setRulesOpen}
+          badge={overrideCount}
+          width="lg"
+          description={
+            overrideCount === 0
+              ? 'Using the default rules.'
+              : `${overrideCount} rule${overrideCount === 1 ? '' : 's'} changed from the defaults.`
+          }
+          footer={
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleResetRules}
+              disabled={overrideCount === 0}
+            >
+              Reset to defaults
+            </Button>
+          }
+        >
+          {RULE_CATEGORIES.map((category) => (
+            <SettingsSection key={category.id} title={category.label} dense>
+              {ALL_RULES.filter((rule) => rule.category === category.id).map((rule) => {
+                const enabled = isRuleEnabled(rule, disabledRules, enabledRules)
+                return (
+                  <label
+                    key={rule.id}
+                    // The hint explains *why* — the rule ids alone told the
+                    // user nothing they could act on.
+                    title={`${rule.id} — ${rule.hint}`}
+                    className="flex cursor-pointer items-start gap-1.5 text-xs"
+                  >
+                    <Checkbox
+                      checked={enabled}
+                      onChange={(e) => handleToggleRule(rule, e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span
+                      className={
+                        enabled ? 'text-[var(--color-text)]' : 'text-[var(--color-text-muted)]'
+                      }
+                    >
+                      {rule.label}
+                    </span>
+                  </label>
+                )
+              })}
+            </SettingsSection>
+          ))}
+        </SettingsPopover>
+      </DocumentToolbar>
 
       {formatError && (
         <Alert

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -57,6 +57,7 @@ import {
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { useValidatorDocument, type PendingValidatorDocument } from '@/hooks/useValidatorDocument'
 import { ProblemsList } from '@/components/shared/ProblemsList'
+import { Checkbox } from '@/components/shared/Checkbox'
 import { formatShortcut } from '@/lib/shortcut-label'
 import type { HtmlWorker } from '@/workers/html.worker'
 import HtmlWorkerFactory from '@/workers/html.worker?worker'
@@ -776,11 +777,10 @@ export default function HtmlValidator() {
                         title={`${rule.id} — ${rule.hint}`}
                         className="flex cursor-pointer items-start gap-1.5 py-0.5 text-xs"
                       >
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={enabled}
                           onChange={(e) => handleToggleRule(rule, e.target.checked)}
-                          className="mt-0.5 accent-[var(--color-accent)]"
+                          className="mt-0.5"
                         />
                         <span
                           className={

--- a/apps/cockpit/src/tools/image-tool/ImageTool.tsx
+++ b/apps/cockpit/src/tools/image-tool/ImageTool.tsx
@@ -1276,7 +1276,7 @@ function ExportPanel({
         <div>
           <div className="mb-2 flex items-center justify-between">
             <SectionLabel as="div">Quality</SectionLabel>
-            <span className="font-mono text-xs text-[var(--color-text)]">{quality}%</span>
+            <span className="text-xs tabular-nums text-[var(--color-text)]">{quality}%</span>
           </div>
           <input
             type="range"

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -683,6 +683,7 @@ export default function JsonSchemaValidator() {
                 <Input
                   type="url"
                   aria-label="Schema URL"
+                  monospace
                   placeholder="Schema URL"
                   value={state.schemaUrl}
                   onChange={(e) => updateState({ schemaUrl: e.target.value })}

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -751,7 +751,8 @@ export default function JsonTools() {
                   value={query}
                   onChange={(e) => updateState({ query: e.target.value })}
                   placeholder="$.items[0].sku"
-                  className="min-w-0 flex-1 font-mono"
+                  monospace
+                  className="min-w-0 flex-1"
                 />
               </label>
               {queryResult?.found && <CopyButton text={toText(queryResult.value)} />}

--- a/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
+++ b/apps/cockpit/src/tools/jwt-decoder/JwtDecoder.tsx
@@ -297,7 +297,7 @@ export default function JwtDecoder() {
       {/* Token input */}
       <div className="border-b border-[var(--color-border)] p-4">
         <div className="mb-2 flex items-center gap-3">
-          <span className="font-mono text-xs text-[var(--color-text-muted)]">JWT Token</span>
+          <span className="text-xs text-[var(--color-text-muted)]">JWT Token</span>
           {claimWindow && (
             <StatusBadge variant={claimWindowVariant(claimWindow.state)}>
               {WINDOW_LABELS[claimWindow.state]} · {claimWindow.relative}
@@ -458,7 +458,7 @@ export default function JwtDecoder() {
               {/* Header */}
               <section>
                 <div className="mb-1 flex items-center justify-between">
-                  <h3 className="font-mono text-xs text-[var(--color-info)]">Header</h3>
+                  <h3 className="text-xs text-[var(--color-info)]">Header</h3>
                   <CopyButton text={JSON.stringify(decoded.header, null, 2)} />
                 </div>
                 <pre className="rounded border border-[var(--color-info)]/30 bg-[var(--color-surface)] p-3 font-mono text-xs text-[var(--color-text)]">
@@ -469,7 +469,7 @@ export default function JwtDecoder() {
               {/* Signature */}
               <section>
                 <div className="mb-1 flex items-center justify-between">
-                  <h3 className="font-mono text-xs text-[var(--color-error)]">Signature</h3>
+                  <h3 className="text-xs text-[var(--color-error)]">Signature</h3>
                   <CopyButton text={decoded.signature} />
                 </div>
                 <pre className="break-all rounded border border-[var(--color-error)]/30 bg-[var(--color-surface)] p-3 font-mono text-xs text-[var(--color-text)]">
@@ -481,7 +481,7 @@ export default function JwtDecoder() {
             {/* Payload with claim annotations */}
             <section>
               <div className="mb-1 flex items-center justify-between">
-                <h3 className="font-mono text-xs text-[var(--color-success)]">Payload Claims</h3>
+                <h3 className="text-xs text-[var(--color-success)]">Payload Claims</h3>
                 <CopyButton text={JSON.stringify(decoded.payload, null, 2)} />
               </div>
               <div className="rounded border border-[var(--color-success)]/30 bg-[var(--color-surface)] p-3">

--- a/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/ImageModal.tsx
@@ -81,6 +81,7 @@ export function ImageModal({ onInsert, onClose }: Props) {
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               placeholder="https://example.com/image.png"
+              monospace
               size="md"
               className="flex-1"
             />

--- a/apps/cockpit/src/tools/markdown-editor/modals/LinkModal.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/modals/LinkModal.tsx
@@ -62,6 +62,7 @@ export function LinkModal({ initialText = '', onInsert, onClose }: Props) {
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
+            monospace
             size="md"
           />
         </Field>

--- a/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
+++ b/apps/cockpit/src/tools/prompt-templates/PromptTemplates.tsx
@@ -66,6 +66,7 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { sendToTool } from '@/lib/tool-handoff'
 import { SearchInput } from '@/components/shared/SearchInput'
 import { MasterDetailLayout } from '@/components/shared/MasterDetailLayout'
+import { Checkbox } from '@/components/shared/Checkbox'
 
 type CategoryFilter = PromptTemplateCategory | 'all'
 
@@ -144,7 +145,7 @@ function VariableForm({ template, values, onChange }: VariableFormProps) {
     <div className="space-y-3">
       {template.variables.map((variable) => (
         <label key={variable.name} className="block">
-          <span className="mb-1 flex items-center gap-1 font-mono text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
+          <span className="mb-1 flex items-center gap-1 text-2xs uppercase tracking-widest text-[var(--color-text-muted)]">
             {variable.label}
             {variable.required && <span className="text-[var(--color-error)]">*</span>}
           </span>
@@ -168,6 +169,7 @@ function VariableForm({ template, values, onChange }: VariableFormProps) {
               placeholder={variable.placeholder}
               rows={variable.name === 'code' || variable.name === 'logs' ? 10 : 5}
               aria-label={variable.label}
+              monospace
               className="min-h-24 resize-none"
             />
           ) : (
@@ -175,6 +177,7 @@ function VariableForm({ template, values, onChange }: VariableFormProps) {
               value={values[variable.name] ?? ''}
               onChange={(event) => onChange(variable.name, event.target.value)}
               placeholder={variable.placeholder}
+              monospace
               className="w-full"
               aria-label={variable.label}
             />
@@ -199,7 +202,7 @@ function PreviewPane({ renderedPrompt, tokens, missingVariables }: PreviewPanePr
       <PaneHeader
         title="Preview"
         actions={
-          <span className={`font-mono rounded border px-2 py-0.5 text-2xs ${tokenClass(tone)}`}>
+          <span className={`rounded border px-2 py-0.5 text-2xs tabular-nums ${tokenClass(tone)}`}>
             ~{tokens} tokens (chars/4 estimate)
           </span>
         }
@@ -346,7 +349,9 @@ function QuickFillModal({
             <VariableForm template={template} values={values} onChange={onChange} />
           </div>
           <div className="flex h-12 shrink-0 items-center justify-between border-t border-[var(--color-border)] px-4">
-            <span className={`rounded border px-2 py-0.5 font-mono text-2xs ${tokenClass(tone)}`}>
+            <span
+              className={`rounded border px-2 py-0.5 text-2xs tabular-nums ${tokenClass(tone)}`}
+            >
               ~{tokens} tokens (chars/4 estimate)
             </span>
             <div className="flex gap-2">
@@ -702,8 +707,7 @@ function TemplateEditorModal({ mode, sourceTemplate, onClose, onSave }: Template
                       ))}
                     </Select>
                     <label className="flex items-center justify-center gap-1 text-2xs text-[var(--color-text-muted)]">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={variable.required ?? false}
                         onChange={(event) =>
                           setDraft((current) => ({

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -22,6 +22,7 @@ import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { Checkbox } from '@/components/shared/Checkbox'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { REFACTORING_SAMPLE } from '@/lib/tool-samples'
@@ -100,18 +101,12 @@ function IndeterminateCheckbox({
   onChange: () => void
   'aria-label': string
 }) {
-  const ref = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    if (ref.current) ref.current.indeterminate = indeterminate
-  }, [indeterminate])
   return (
-    <input
-      ref={ref}
-      type="checkbox"
+    <Checkbox
+      indeterminate={indeterminate}
       checked={checked}
       onChange={onChange}
       aria-label={ariaLabel}
-      className="accent-[var(--color-accent)]"
     />
   )
 }
@@ -554,6 +549,7 @@ export default function RefactoringToolkit() {
                 <div className="grid grid-cols-2 gap-2">
                   <Input
                     aria-label="Identifier to rename"
+                    monospace
                     placeholder="oldName"
                     value={state.customFind}
                     onChange={(event) =>
@@ -562,6 +558,7 @@ export default function RefactoringToolkit() {
                   />
                   <Input
                     aria-label="Replacement identifier"
+                    monospace
                     placeholder="newName"
                     value={state.customReplace}
                     onChange={(event) =>
@@ -613,11 +610,10 @@ export default function RefactoringToolkit() {
                           key={transform.id}
                           className="mb-1 flex cursor-pointer items-start gap-2 rounded p-1.5 text-xs hover:bg-[var(--color-surface-hover)]"
                         >
-                          <input
-                            type="checkbox"
+                          <Checkbox
                             checked={selectedTransforms.includes(transform.id)}
                             onChange={() => toggleTransform(transform.id)}
-                            className="mt-0.5 accent-[var(--color-accent)]"
+                            className="mt-0.5"
                           />
                           <span className="min-w-0 flex-1">
                             <span className="flex items-center gap-1.5">

--- a/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
+++ b/apps/cockpit/src/tools/regex-tester/RegexTester.tsx
@@ -560,7 +560,7 @@ export default function RegexTester() {
           {/* Match details */}
           {matchCount > 0 && (
             <div className="max-h-48 shrink-0 overflow-auto border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-              <div className="mb-2 flex items-center gap-2 font-mono text-xs text-[var(--color-text-muted)]">
+              <div className="mb-2 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                 <span>
                   {truncated ? `First ${matchCount}` : matchCount} match
                   {matchCount !== 1 ? 'es' : ''}
@@ -621,7 +621,7 @@ export default function RegexTester() {
         {/* Reference sidebar */}
         {showRef && (
           <div className="w-56 shrink-0 overflow-auto border-l border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-            <div className="mb-2 font-mono text-xs text-[var(--color-text-muted)]">
+            <div className="mb-2 text-xs text-[var(--color-text-muted)]">
               Reference · click to insert
             </div>
             {REFERENCE_CATEGORIES.map((cat) => (

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -4,7 +4,6 @@ import {
   CheckCircleIcon,
   FileTsIcon,
   FloppyDiskIcon,
-  SlidersHorizontalIcon,
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -21,6 +20,7 @@ import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { SettingsPopover, SettingsRow, SettingsSection } from '@/components/shared/SettingsPopover'
 import { useUiStore } from '@/stores/ui.store'
 import { saveFileDialog } from '@/lib/file-io'
 import { TS_PLAYGROUND_SAMPLE } from '@/lib/tool-samples'
@@ -40,7 +40,6 @@ type TsPlaygroundState = {
   strict: boolean
   jsx: boolean
   /** Compiler options live behind a disclosure; the choice is persisted. */
-  optionsOpen: boolean
   problemsOpen: boolean
 }
 
@@ -94,7 +93,6 @@ export default function TsPlayground() {
     module: 'ESNext',
     strict: true,
     jsx: false,
-    optionsOpen: false,
     problemsOpen: true,
   })
 
@@ -107,7 +105,8 @@ export default function TsPlayground() {
   const [typesChecked, setTypesChecked] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isTranspiling, setIsTranspiling] = useState(false)
-  const optionsId = useId()
+  // Session state: a popover that restored itself open would cover the editor at launch.
+  const [optionsOpen, setOptionsOpen] = useState(false)
   const problemsId = useId()
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null)
   const monacoRef = useRef<Parameters<OnMount>[1] | null>(null)
@@ -290,148 +289,134 @@ export default function TsPlayground() {
     <ToolLayout
       fullBleed
       toolbar={
-        <div className="border-b border-[var(--color-border)]">
-          <DocumentToolbar aria-label="TypeScript playground actions">
-            <DocumentIdentity
-              title={state.fileName ?? 'Untitled.ts'}
-              icon={
-                <FileTsIcon
-                  size={16}
+        <DocumentToolbar border aria-label="TypeScript playground actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled.ts'}
+            icon={
+              <FileTsIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            // Only the settled result is announced. "Compiling…" goes in
+            // aria-hidden so a keystroke-triggered run does not speak twice,
+            // while the live region itself stays mounted — a region added and
+            // removed around each run announces nothing at all.
+            status={
+              isTranspiling && hasCode ? <span aria-hidden="true">{summary}</span> : settledSummary
+            }
+            statusIcon={
+              !isTranspiling && hasCode && !error && sorted.length === 0 ? (
+                <CheckCircleIcon
+                  size={12}
                   aria-hidden="true"
-                  className="shrink-0 text-[var(--color-text-muted)]"
+                  className="shrink-0 text-[var(--color-success)]"
                 />
-              }
-              // Only the settled result is announced. "Compiling…" goes in
-              // aria-hidden so a keystroke-triggered run does not speak twice,
-              // while the live region itself stays mounted — a region added and
-              // removed around each run announces nothing at all.
-              status={
-                isTranspiling && hasCode ? (
-                  <span aria-hidden="true">{summary}</span>
-                ) : (
-                  settledSummary
-                )
-              }
-              statusIcon={
-                !isTranspiling && hasCode && !error && sorted.length === 0 ? (
-                  <CheckCircleIcon
-                    size={12}
-                    aria-hidden="true"
-                    className="shrink-0 text-[var(--color-success)]"
-                  />
-                ) : !isTranspiling && sorted.length > 0 ? (
-                  <WarningCircleIcon
-                    size={12}
-                    aria-hidden="true"
-                    className="shrink-0"
-                    style={{
-                      color: errorCount > 0 ? 'var(--color-error)' : 'var(--color-warning)',
-                    }}
-                  />
-                ) : undefined
-              }
-            />
+              ) : !isTranspiling && sorted.length > 0 ? (
+                <WarningCircleIcon
+                  size={12}
+                  aria-hidden="true"
+                  className="shrink-0"
+                  style={{
+                    color: errorCount > 0 ? 'var(--color-error)' : 'var(--color-warning)',
+                  }}
+                />
+              ) : undefined
+            }
+          />
 
-            <ToolbarGroup label="Playground actions" separated>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => updateState({ optionsOpen: !state.optionsOpen })}
-                aria-expanded={state.optionsOpen}
-                {...(state.optionsOpen ? { 'aria-controls': optionsId } : {})}
-                className="gap-1"
-              >
-                <SlidersHorizontalIcon size={14} aria-hidden="true" />
-                Options
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleCompile}
-                disabled={!hasCode}
-                // Deliberately not `loading`: a background auto-compile would
-                // then disable the very button that requests an announced one.
-                title={`Compile now (${formatShortcut('mod+enter')})`}
-              >
-                Compile
-                <Kbd keys="mod+enter" variant="inline" className="ml-1" />
-              </Button>
-              <CopyButton text={output} label="Copy output" />
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={!output}
-                onClick={() =>
-                  sendToTool('code-formatter', { input: output, language: 'javascript' })
-                }
-                title="Open the compiled JavaScript in Code Formatter"
-              >
-                Format output
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSave}
-                disabled={!output}
-                title={`Save the JavaScript output to a file (${formatShortcut('mod+s')})`}
-                aria-label="Save output to file"
-                className="gap-1"
-              >
-                <FloppyDiskIcon size={14} aria-hidden="true" />
-                Save
-              </Button>
-            </ToolbarGroup>
-          </DocumentToolbar>
-
-          {state.optionsOpen && (
-            <div
-              id={optionsId}
-              className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2"
+          <ToolbarGroup label="Playground actions" separated>
+            <SettingsPopover
+              label="Options"
+              title="Compiler options"
+              open={optionsOpen}
+              onOpenChange={setOptionsOpen}
+              description="Compiles automatically as you type."
             >
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                Target
-                <Select
-                  aria-label="Target"
-                  value={state.target}
-                  onChange={(e) => updateState({ target: e.target.value })}
-                >
-                  {TARGETS.map((t) => (
-                    <option key={t} value={t}>
-                      {t}
-                    </option>
-                  ))}
-                </Select>
-              </label>
-              <label className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)]">
-                Module
-                <Select
-                  aria-label="Module"
-                  value={state.module}
-                  onChange={(e) => updateState({ module: e.target.value })}
-                >
-                  {MODULES.map((m) => (
-                    <option key={m} value={m}>
-                      {m}
-                    </option>
-                  ))}
-                </Select>
-              </label>
-              <Toggle
-                label="Strict"
-                checked={state.strict}
-                onChange={(checked) => updateState({ strict: checked })}
-              />
-              <Toggle
-                label="JSX / TSX"
-                checked={state.jsx}
-                onChange={(checked) => updateState({ jsx: checked })}
-              />
-              <span className="ml-auto text-2xs text-[var(--color-text-muted)]">
-                Compiles automatically as you type.
-              </span>
-            </div>
-          )}
-        </div>
+              <SettingsSection>
+                <SettingsRow label="Target">
+                  <Select
+                    value={state.target}
+                    onChange={(e) => updateState({ target: e.target.value })}
+                  >
+                    {TARGETS.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </Select>
+                </SettingsRow>
+                <SettingsRow label="Module">
+                  <Select
+                    value={state.module}
+                    onChange={(e) => updateState({ module: e.target.value })}
+                  >
+                    {MODULES.map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                  </Select>
+                </SettingsRow>
+                <SettingsRow label="Strict">
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.strict}
+                      onChange={(checked) => updateState({ strict: checked })}
+                    />
+                  )}
+                </SettingsRow>
+                <SettingsRow label="JSX / TSX">
+                  {({ labelId }) => (
+                    <Toggle
+                      aria-labelledby={labelId}
+                      checked={state.jsx}
+                      onChange={(checked) => updateState({ jsx: checked })}
+                    />
+                  )}
+                </SettingsRow>
+              </SettingsSection>
+            </SettingsPopover>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCompile}
+              disabled={!hasCode}
+              // Deliberately not `loading`: a background auto-compile would
+              // then disable the very button that requests an announced one.
+              title={`Compile now (${formatShortcut('mod+enter')})`}
+            >
+              Compile
+              <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+            </Button>
+            <CopyButton text={output} label="Copy output" />
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!output}
+              onClick={() =>
+                sendToTool('code-formatter', { input: output, language: 'javascript' })
+              }
+              title="Open the compiled JavaScript in Code Formatter"
+            >
+              Format output
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleSave}
+              disabled={!output}
+              title={`Save the JavaScript output to a file (${formatShortcut('mod+s')})`}
+              aria-label="Save output to file"
+              className="gap-1"
+            >
+              <FloppyDiskIcon size={14} aria-hidden="true" />
+              Save
+            </Button>
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
       {error && (

--- a/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
+++ b/apps/cockpit/src/tools/url-codec/UrlCodec.tsx
@@ -276,7 +276,7 @@ export default function UrlCodec() {
       {/* URL parts panel */}
       {urlParts && (
         <div className="shrink-0 border-t border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-          <div className="mb-2 font-mono text-xs text-[var(--color-text-muted)]">URL Parts</div>
+          <div className="mb-2 text-xs text-[var(--color-text-muted)]">URL Parts</div>
           {/* Color-coded URL */}
           <div className="mb-2 break-all font-mono text-xs leading-relaxed">
             <span className="text-[var(--color-text-muted)]">{urlParts.protocol}//</span>

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -1012,7 +1012,8 @@ function XPathPane({
           value={xpath}
           onChange={(e) => onXPathChange(e.target.value)}
           placeholder="/catalog/book or //title"
-          className="w-full font-mono"
+          monospace
+          className="w-full"
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-auto p-3">

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -483,7 +483,8 @@ export default function YamlTools() {
                   value={query}
                   onChange={(event) => updateState({ query: event.target.value })}
                   placeholder="$.spec.template.spec.containers[*].name"
-                  className="min-w-0 flex-1 font-mono"
+                  monospace
+                  className="min-w-0 flex-1"
                 />
               </label>
               <output className="w-full font-mono text-xs text-[var(--color-text)]">


### PR DESCRIPTION
Two related passes over cockpit's chrome: first make the typography consistent, then stop tool settings from shoving the document around.

---

# Part 1 — `font-ui` becomes the inherited default, mono the opt-in

## The bug that started this

A tool title in system-ui, sitting beside its own status text in Source Code Pro, in the same toolbar row. The sidebar looked fine; titles, toolbars, toolbar options and status bars did not.

## Root cause

The design system says chrome is `font-ui` and only tool content is `font-mono`. The stylesheet said the opposite: `body` inherited `--font-mono`, so every label, button, badge, heading, status line and empty state had to *remember* an opt-in `font-ui` class or silently render monospace.

**Three of forty-six tool files remembered.**

Seven agents inventoried the tool groups independently and all seven landed on the same cause. Corroborating detail: `TextArea` already had a `monospace` prop defaulting to `false` — a no-op under the old default, and a fairly clear sign of the original intent.

## The fix

Invert the inherited default rather than add `font-ui` to a few hundred elements. Chrome outnumbers content by an order of magnitude in element count, while content is concentrated in a handful of identifiable places — so the correct default is the one needing the fewest exceptions.

- `html, body, #root` now inherit `var(--font-ui)`.
- `pre`, `code`, `kbd`, `samp` are monospace via a base rule, so output rendered in the obvious tag needs no class.
- `Input` gains a `monospace` prop mirroring `TextArea`'s, off by default. Applied where the value is read character by character: URLs, header values, JSONPath/XPath, identifiers, tokens, colour literals.
- 22 sites across 12 files where chrome carried an explicit, wrong `font-mono` drop it — section headings in API Client, JWT Decoder and CSS → Tailwind, the "URL Parts" label, the loading and drag-overlay strings. Numeric stat counts move to `tabular-nums`, which is what they actually wanted.
- API Client's response-header rows go the other way and become mono: that is what the server sent, not chrome.

## New `Checkbox` primitive

Six call sites had hand-rolled `<input type="checkbox" className="accent-[var(--color-accent)]">`, and no two agreed on the vertical nudge that follows (`mt-0.5`, `mt-1`, nothing) — because `accent-color` styles the OS checkbox and leaves its box metrics unknowable.

`Toggle` was not the answer: it is a `role="switch"`, means "this setting is on", and is twice as wide as a dense list row allows. So `Checkbox` keeps the native input for semantics, keyboard and form behaviour, makes it transparent, and stretches it over a box sized in the same tokens as every other control. Supports checked, indeterminate, disabled and focus-visible with no JS beyond setting `input.indeterminate`.

---

# Part 2 — tool settings move into a popover

## The problem

Four tools opened their options by pushing a **second row into the toolbar**. The editor underneath resized every time: the document jumped by the height of the row at the exact moment you went to change how it was formatted. Five hand-rolled floating surfaces existed across the app and no two agreed — one set used a raw `z-20`, another had no Escape handling, none returned focus.

## `Popover` — the primitive

Floats the surface over the content instead of displacing it.

- **Portalled to `document.body`**, so no toolbar can clip it.
- **Anchored without measuring.** For `align="end"` it writes `right: innerWidth - triggerRect.right`, so the surface grows leftward from a fixed trailing edge. No two-pass layout, no first paint at the wrong coordinates.
- **`max-height` + internal scroll, never a flip above.** A toolbar popover that flipped would cover the thing it configures.
- Escape (capture phase), outside-click and focus return are gated on `useIsInstanceActive()` — a background window must not eat them. A mousedown on the trigger is deliberately ignored, or the trigger would close the surface out from under its own click and never toggle off.
- Focus returns to the trigger only when `document.activeElement === document.body`, so closing by clicking into the editor doesn't yank focus back out.
- The trigger is a render prop, so `aria-expanded`, `aria-controls` and the anchor ref all land on one element — and `aria-controls` is only advertised while the surface is actually in the DOM.

## `SettingsPopover` — the settings shape

Header, optional description and footer, `SettingsSection`, and `SettingsRow`.

`SettingsRow` takes children in either form. A plain node makes the row itself a `<label>`, associating the control structurally with no id to keep in sync — the trade `Field` already makes. The render-prop form exists because a `role="switch"` is a `<button>`, which is not a labelable element, so no enclosing `<label>` can name it; it hands back a `labelId` instead, and `Toggle` gained `aria-labelledby` to receive it.

Hiding settings costs the toolbar its evidence that they changed. The trigger **badge** is what buys that back, so it's a contract, not decoration — and it has a test saying so.

## What moved, and what deliberately didn't

Migrated: **Code Formatter** (Style), **TS Playground** (Options), **HTML Validator** and **CSS Validator** (Rules).

Left alone on purpose, and written into the design system as carve-outs:

- **Diff Viewer** keeps its second row — ignore-whitespace, ignore-case and layout get cycled *while reading* a diff, and the row also holds Copy patch / Save patch. A settings surface with actions in it is a dialog in disguise.
- **CSV Tools** keeps its delimiter in the toolbar: it's the first thing you cycle when a paste won't parse.
- **Mermaid**'s export sub-options modify the adjacent Export action, not the document.

`Dialog`'s focus-trap internals moved to `src/lib/focus.ts`, so two floating surfaces can't drift on what counts as focusable.

---

## Verification

In the browser harness, not jsdom — jsdom can see neither a font nor a layout.

**Typography.** The reported defect is gone: the CSS Validator toolbar title and its status text now compute to the same family. App chrome computes to one family throughout; `<pre>`, `code`, `Kbd` and the Monaco gutter stay monospace. The sidebar is unchanged — what looked good still looks the same. `neon-brutalist`, which sets `--font-ui: var(--font-mono)` on purpose, still renders all-mono, precisely because chrome reads the token instead of naming a family.

**Popover.** The central claim holds: Monaco is **730px before and after** the Style popover opens, toolbar stays 44px, the surface floats over the editor. Right edges align with the trigger to the pixel, 6px gap, z-index 60. Escape closes and returns focus to "Style"; clicking the editor closes without stealing focus back. At 700×560 the surface still fits. The 30-rule HTML Validator popover is 384×662, fits the viewport, scrolls internally (796 > 559 content), and toggling a rule updates both the description and the trigger badge while staying open.

`npx tsc --noEmit` clean · `bun run lint` (eslint `--max-warnings 0` + design-system gate) clean · `bunx vitest run` **131 files / 1694 tests passing**.

One CSV Tools test timed out on an early full-suite run. That file is untouched by this branch; it passes in isolation (42/42) and on rerun. Pre-existing flake under parallel load.

`documentation/DESIGN_SYSTEM.md` documents both: § Typography for the new default and its four opt-out mechanisms in preference order, and § Floating surfaces for when to reach for `Dialog` vs `Popover` vs `SettingsPopover` — including the rule against hand-rolling `absolute right-0 top-full` plus a `mousedown` effect ever again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
