### PR TITLE
fix(cockpit): allow any host in the API Client, and stop laying icons out on half pixels

### DIFF
--- a/apps/cockpit/src-tauri/capabilities/default.json
+++ b/apps/cockpit/src-tauri/capabilities/default.json
@@ -23,14 +23,7 @@
     "fs:default",
     {
       "identifier": "http:default",
-      "allow": [
-        { "url": "https://github.com/**" },
-        { "url": "https://objects.githubusercontent.com/**" },
-        { "url": "https://raw.githubusercontent.com/**" },
-        { "url": "https://json.schemastore.org/**" },
-        { "url": "https://json-schema.org/**" },
-        { "url": "https://devdocs.io/**" }
-      ]
+      "allow": [{ "url": "http://*:*" }, { "url": "https://*:*" }]
     },
     "dialog:default",
     "fs:allow-read-text-file",

--- a/apps/cockpit/src/components/shared/SearchInput.tsx
+++ b/apps/cockpit/src/components/shared/SearchInput.tsx
@@ -18,10 +18,17 @@ export type SearchInputProps = Omit<
   className?: string
 }
 
-/** Icon geometry per size: magnifier px, clear glyph px, and the padding that clears them. */
+/**
+ * Icon geometry per size: magnifier px, clear glyph px, and the padding that clears them.
+ *
+ * All four are even on purpose. These glyphs are centred in an even-height box, so an odd size
+ * leaves an odd remainder to split and puts the icon on a half pixel, where it renders soft and
+ * reads as slightly low. The sizes were 13/11 and 15/13; a pixel either way is invisible, a half
+ * pixel of blur is not.
+ */
 const SIZES: Record<SearchInputSize, { icon: number; clear: number; padding: string }> = {
-  sm: { icon: 13, clear: 11, padding: 'pl-7 pr-7' },
-  md: { icon: 15, clear: 13, padding: 'pl-8 pr-8' },
+  sm: { icon: 12, clear: 10, padding: 'pl-7 pr-7' },
+  md: { icon: 16, clear: 12, padding: 'pl-8 pr-8' },
 }
 
 /**
@@ -46,7 +53,15 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     const geometry = SIZES[size]
 
     return (
-      <div className={`relative ${className}`}>
+      // `flex`, not the bare `relative` this used to be. An `<input>` is inline-block, so a block
+      // wrapper builds a line box around it and adds the strut's descender space underneath: the
+      // wrapper measured 24.5px around a 22px field. The magnifier is centred on the wrapper, so it
+      // sat 1.25px below the centre of the field it belongs to — the "magnifier isn't centred in the
+      // search box" you can see once you look for it. Flex blockifies the field, so the wrapper is
+      // exactly as tall as it is. It also stops the half-pixel leaking outward: the sidebar header
+      // holds one of these, so its fractional height was making the tool list's `flex-1` 733.5px and
+      // putting every icon below it on a half pixel too.
+      <div className={`relative flex ${className}`}>
         <MagnifyingGlassIcon
           size={geometry.icon}
           aria-hidden="true"

--- a/apps/cockpit/src/components/shell/TitleBar.tsx
+++ b/apps/cockpit/src/components/shell/TitleBar.tsx
@@ -76,7 +76,12 @@ export function TitleBar() {
 
   return (
     <div
-      className={`shell-chrome font-ui relative flex h-11 shrink-0 items-center border-b border-[var(--color-border)] bg-[var(--color-surface)] px-3`}
+      // The hairline is an inset shadow rather than `border-b` so this row's content box stays an
+      // even 44px. With a border it was 43px, and centring an even-sized icon in an odd box lands it
+      // on a half pixel — which is why every control up here (window buttons, notes, settings,
+      // shortcuts, and the palette's magnifier) rendered a touch soft and low. Shadow draws the same
+      // 1px line without taking a pixel out of the box.
+      className={`shell-chrome font-ui relative flex h-11 shrink-0 items-center bg-[var(--color-surface)] px-3 shadow-[inset_0_-1px_0_var(--color-border)]`}
     >
       <div
         data-tauri-drag-region

--- a/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
+++ b/apps/cockpit/src/components/shell/WorkspaceTabStrip.tsx
@@ -338,7 +338,10 @@ export function WorkspaceTabStrip() {
   const hasRight = contextTabIdx !== -1 && tabs.slice(contextTabIdx + 1).some((t) => !t.pinned)
 
   return (
-    <div className="font-ui relative flex h-9 shrink-0 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+    // Inset shadow rather than `border-b`, for the same reason as the title bar: the border ate a
+    // pixel out of `h-9`, leaving an odd 35px content box for the full-height tab buttons to centre
+    // their icons in.
+    <div className="font-ui relative flex h-9 shrink-0 bg-[var(--color-surface)] shadow-[inset_0_-1px_0_var(--color-border)]">
       {/* Scrollable tab row */}
       <div
         ref={scrollRef}

--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -27,6 +27,13 @@
   --font-mono: 'Source Code Pro', monospace;
   --font-ui: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --text-2xs: 0.625rem;
+  /* Pair every font size with a line height that lands on a whole pixel. Without this, `text-2xs`
+     fell back to the ratio Tailwind derives for unpaired sizes and computed to 13.333px. A
+     fractional line box makes its element fractionally tall, and once one flex item in a row is
+     33.328px instead of 34px, every sibling centred against it — icons especially — is laid out on
+     a half pixel and renders soft and visibly off-centre. The ⌘K keycap in the title-bar search did
+     exactly that to the magnifier beside it. 10px x 1.4 = 14px. */
+  --text-2xs--line-height: 1.4;
 }
 
 *,


### PR DESCRIPTION
Two independent bugs, shipped together because both need a release build to reach users.

## The API Client could only reach six hosts

`http:default` in `src-tauri/capabilities/default.json` carried a scope list of the URLs the **app itself** fetches — GitHub releases, schemastore, devdocs. But `ApiClient.tsx` sends the user's requests through the same `@tauri-apps/plugin-http`, so that list was also the complete set of URLs the tool would talk to. Everything else came back as a bare "Request failed", including `https://api.github.com`.

Widened to `http://*:*` / `https://*:*`.

The port wildcard is not decoration. `tauri-plugin-http`'s `parse_url_pattern` defaults `search`, `hash` and `pathname` to `*` but leaves `port` as written, so `http://*` matches `http://example.com/x` and **denies** `http://localhost:8080` — which would have left the tool broken for local dev servers, the most common thing anyone points an API client at. Verified against a copy of the plugin's own parser before choosing the pattern.

## Icons rendered soft and a touch low

Most visibly the magnifier in the search box. 81 of the app's 84 icons were laid out on a fractional pixel. Three compounding causes:

- `--text-2xs` had no paired line height, so it computed to 13.333px. One fractional flex item makes its whole row fractional; the ⌘K keycap did this to the magnifier beside it.
- `SearchInput`'s wrapper was a block around an inline-block `<input>`, so the line box added the strut's descender space: 24.5px of wrapper around a 22px field, putting the magnifier 1.25px below the centre of the field it belongs to. This is the one you can see. `flex` blockifies the field.
- `border-b` on a `border-box` row takes a pixel out of the content box, and an even-sized icon centred in an odd-height box lands on `.5`. The title bar (`h-11` → 43px) and the tab strip (`h-9` → 35px) both did this to every control they hold. Both now draw the same hairline as an inset shadow, which does not consume a pixel.

Icon sizes in `SearchInput` went 13/11 and 15/13 → 12/10 and 16/12 for the same parity reason.

Down to 3 of 84, all horizontal offsets derived from variable text width rather than parity.

## Verification

- `bunx vitest run` — 131 files, 1696 tests, all pass
- `npx tsc --noEmit` — clean
- `bun run lint` + `lint:ds` — clean
- Fractional-position audit in the browser harness: 81/84 → 3/84

No `[skip ci]` — this is meant to cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)