### PR TITLE
feat(cockpit): redraw frog mascot with richer idle animation

### DIFF
--- a/apps/cockpit/src/components/shell/FrogMascot.tsx
+++ b/apps/cockpit/src/components/shell/FrogMascot.tsx
@@ -3,62 +3,62 @@ import { useId, useMemo } from 'react'
 /**
  * The devdrivr frog, idling.
  *
- * The source art (a 1408×768 traced SVG) is 37×27 logical pixels once the trace is resampled back
- * onto its own grid, so it is stored here as that grid rather than as the traced paths: a path
- * soup cannot be split into a head that blinks and a body that bobs, and it renders blurry at the
- * ~5× scale this is displayed at. Runs of identical pixels collapse into one `<rect>` per run,
- * which is ~120 rects instead of ~700 cells, and `shapeRendering="crispEdges"` keeps the edges
- * square at any zoom.
+ * The source art (a 1408×768 traced SVG) is resampled back onto its own logical pixel grid and
+ * stored here as that grid rather than as traced paths: a path soup cannot be split into a head
+ * that blinks and a body that bobs, and it renders blurry at the ~4× scale this is displayed at.
+ * Runs of identical pixels collapse into one `<rect>` per run, and `shapeRendering="crispEdges"`
+ * keeps the edges square at any zoom. Exported so the sprite-integrity test can hold the grid to
+ * rectangular and mirror-symmetric — the two ways hand-edited pixel art silently rots.
  *
  * Rule 12 in AGENTS.md ("Phosphor only, no inline SVG") governs *icons* — chrome that has to
  * restyle with the theme. A mascot is artwork with its own fixed palette, same as
- * `shared/Mascot.tsx`, and there is no Phosphor glyph for "frog doing a two-frame idle".
+ * `shared/Mascot.tsx`, and there is no Phosphor glyph for "frog doing a four-frame idle".
  *
  * Idle behaviour, in the spirit of a sidescroller's rest state: a two-frame breathing bob, a blink
- * on a slow cycle, and a hop roughly every seven seconds with the contact shadow tightening under
- * it. Every animation is authored so its 100% keyframe is the resting pose, because the app-wide
- * `prefers-reduced-motion` rule in index.css collapses animations to 0.01ms and one iteration —
+ * on a slow cycle, a vocal-sac croak roughly every ten seconds, and a hop roughly every seven
+ * seconds that squashes before takeoff and stretches mid-air while the contact shadow tightens
+ * under it. Every animation is authored so its 100% keyframe is the resting pose — for the croak,
+ * whose sac is invisible at rest, resting means fully hidden — because the app-wide
+ * `prefers-reduced-motion` rule in index.css collapses animations to 0.01ms and one iteration,
  * which lands the frog on that last keyframe and holds it there.
  */
 
-/** `.` transparent · `D` dark green · `L` body green · `K` eye · `W` highlight */
-const SPRITE = [
-  '......DDDDDD.............DDDDDD......',
-  '......DDDDDD.............DDDDDD......',
-  '.....DDDDDDDDD.........DDDDDDDDD.....',
-  '.....DDDWKKDDDDDDDDDDDDDDDWKKDDD.....',
-  '.....DDDKKKDDDDDDDDDDDDDDDKKKDDD.....',
-  '.....DDDKKKDDDDDDDDDDDDDDDKKKDDD.....',
-  '.....DDDDDDDDDDDDDDDDDDDDDDDDDDD.....',
-  '.....DDDDDDDDDDDDDDDDDDDDDDDDDDD.....',
-  '.....DDDDDDDDDDDDDDDDDDDDDDDDDDD.....',
-  '.....LLLLLLLLLLLLLLLLLLLLLLLLLLL.....',
-  '.....LLLLLLLLLLLLLLLLLLLLLLLLLLL.....',
-  '.....LLLLLLLLLLLLLLLLLLLLLLLLLLL.....',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  'DDDDDLLLLLLLLLLLLLLLLLLLLLLLLLLLDDDDD',
-  '..DDDDLLLDDDLLLLLLLLLLLLLDDDLLLDDDD..',
-  '..DDDDLLLDDDLLLLLLLLLLLLLDDDLLLDDDD..',
-  '...DDDDDDDDDLLLLLLLLLLLLLDDDDDDDDD...',
-  'DDDDDDDDWDDD.............DDDWDDDDDDDD',
-  'DDDDDDDDWDDD.............DDDWDDDDDDDD',
-  'DDDDDDDDWDDD.............DDDWDDDDDDDD',
-  '......DDDDDDDDD.......DDDDDDDDD......',
-  '......DDD...DDD.......DDD...DDD......',
-  '......DDD...DDD.......DDD...DDD......',
+/** `.` transparent · `D` outline/shade · `L` body · `B` belly · `C` cheeks · `K` eye/mouth · `W` highlight */
+export const SPRITE = [
+  '......DDDDD................DDDDD......',
+  '.....DDDDDDD..............DDDDDDD.....',
+  '.....DDKWKKD..............DKKWKDD.....',
+  '.....DDKKKKD..............DKKKKDD.....',
+  '...DDDDKKKKDDDDDDDDDDDDDDDDKKKKDDDD...',
+  '..DLLLLLWWLLLLLLLLLLLLLLLLLLWWLLLLLD..',
+  '..DLLLLLLLLLLLLKLLLLLLKLLLLLLLLLLLLD..',
+  '..DLLLLLLLLKLLLLLLLLLLLLLLKLLLLLLLLD..',
+  '..DLLLLCCLLLKKKKKKKKKKKKKKLLLCCLLLLD..',
+  '.DLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLD.',
+  '.DLLLLDDLLLLLLLLLLLLLLLLLLLLLLDDLLLLD.',
+  '.DLLLLLLLLBBBBBBBBBBBBBBBBBBLLLLLLLLD.',
+  '.DLDLLLLLBBBBBBBBBBBBBBBBBBBBLLLLLDLD.',
+  '.DLDLLLLBBBBBBBBBWWWWBBBBBBBBBLLLLDLD.',
+  '.DLDLLLLBBBBBBBBBBBBBBBBBBBBBBLLLLDLD.',
+  '.DLDLLLLLBBBBBBBBBBBBBBBBBBBBLLLLLDLD.',
+  '.DLDDDLLLLBBBBBBBBBBBBBBBBBBLLLLDDDLD.',
+  '.DDDDDDLLLBBBBBBBBBBBBBBBBBBLLLDDDDDD.',
+  '.DDDDDDDLBBBBBBBBBBBBBBBBBBBBLDDDDDDD.',
+  '.DDDDDDDDBBBBBBBBBBBBBBBBBBBBDDDDDDDD.',
+  '.DDDDDDDDDDBBBBBBBBBBBBBBBBDDDDDDDDDD.',
+  '.DDDDDDDDDDDDLLLLLLLLLLLLDDDDDDDDDDDD.',
+  '.DDD.DD.DDDDDDDDDDDDDDDDDDDDDD.DD.DDD.',
 ] as const
 
-const SPRITE_W = 37
-const SPRITE_H = 27
+const SPRITE_W = 38
+const SPRITE_H = 23
 
 /** Palette lifted from the source art; `W` is nudged off pure white so it reads as a highlight. */
 const PALETTE = {
   D: '#617d24',
   L: '#739230',
+  B: '#a9c46a',
+  C: '#cf8a52',
   K: '#12160c',
   W: '#f4f8ed',
 } as const
@@ -67,10 +67,23 @@ type PixelKey = keyof typeof PALETTE
 
 const isPixel = (ch: string | undefined): ch is PixelKey => ch !== undefined && ch in PALETTE
 
-/** Both eyes are 3×3, top-left corner here. Kept in one place so the lids cannot drift off them. */
+/**
+ * Each eye's pupil block, top-left corner here: 4×3, rows 2–4 of the sprite. Kept in one place so
+ * the lids cannot drift off them when the grid is edited elsewhere.
+ */
 const EYES = [
-  { x: 8, y: 3 },
-  { x: 26, y: 3 },
+  { x: 7, y: 2 },
+  { x: 27, y: 2 },
+] as const
+
+/**
+ * The vocal sac, drawn as an overlay rather than baked into the grid: it only exists mid-croak, so
+ * putting it in the sprite would need a second grid or per-pixel animation hooks.
+ */
+const SAC = [
+  { x: 15, y: 9, width: 8 },
+  { x: 14, y: 10, width: 10 },
+  { x: 15, y: 11, width: 8 },
 ] as const
 
 type Run = { x: number; y: number; width: number; fill: string }
@@ -141,6 +154,14 @@ export function FrogMascot({
           96%      { transform: translateY(1px); }
           98%, 100%{ transform: translateY(0px); }
         }
+        @keyframes ${scope}-squash {
+          0%, 82%   { transform: scale(1, 1); }
+          85%       { transform: scale(1.07, 0.9); }
+          88%       { transform: scale(0.93, 1.12); }
+          91%       { transform: scale(0.95, 1.09); }
+          94%       { transform: scale(1.04, 0.95); }
+          97%, 100% { transform: scale(1, 1); }
+        }
         @keyframes ${scope}-shadow {
           0%, 84%   { transform: scaleX(1); opacity: 0.28; }
           88%, 94%  { transform: scaleX(0.62); opacity: 0.14; }
@@ -151,19 +172,40 @@ export function FrogMascot({
           90%, 93%  { transform: scaleY(1); }
           95%, 100% { transform: scaleY(0); }
         }
+        @keyframes ${scope}-croak {
+          0%, 64%   { opacity: 0; transform: scale(1, 0.2); }
+          66%       { opacity: 1; transform: scale(1, 0.9); }
+          69%       { transform: scale(1.05, 1.35); }
+          72%       { transform: scale(0.98, 0.92); }
+          75%       { transform: scale(1.08, 1.42); }
+          79%       { transform: scale(1, 1.05); }
+          83%, 100% { opacity: 0; transform: scale(1, 0.2); }
+        }
         .${scope}-hop {
           animation: ${scope}-hop 7.2s steps(1, end) infinite;
+        }
+        .${scope}-squash {
+          animation: ${scope}-squash 7.2s steps(1, end) infinite;
+          /* Feet stay planted while the body deforms around them. */
+          transform-origin: 19px 22px;
+          transform-box: view-box;
         }
         .${scope}-bob {
           animation: ${scope}-bob 1.6s steps(1, end) infinite;
         }
         .${scope}-shadow {
           animation: ${scope}-shadow 7.2s steps(1, end) infinite;
-          transform-origin: 18.5px 28px;
+          transform-origin: 19px 23.5px;
           transform-box: view-box;
         }
         .${scope}-lid {
           animation: ${scope}-blink 5.4s steps(1, end) infinite;
+          transform-box: view-box;
+        }
+        .${scope}-sac {
+          animation: ${scope}-croak 9.6s steps(1, end) infinite;
+          /* Inflates downward out of the chin, not upward over the mouth. */
+          transform-origin: 19px 8.5px;
           transform-box: view-box;
         }
       `}</style>
@@ -172,41 +214,59 @@ export function FrogMascot({
       <ellipse
         className={`${scope}-shadow`}
         cx={SPRITE_W / 2}
-        cy={28}
-        rx={13}
-        ry={1.6}
+        cy={23.5}
+        rx={14}
+        ry={1.5}
         fill="#12160c"
         opacity={0.28}
       />
 
       <g className={`${scope}-hop`}>
-        <g className={`${scope}-bob`}>
-          {runs.map((run) => (
-            <rect
-              key={`${run.y}-${run.x}`}
-              x={run.x}
-              y={run.y}
-              width={run.width}
-              height={1}
-              fill={run.fill}
-            />
-          ))}
+        <g className={`${scope}-squash`}>
+          <g className={`${scope}-bob`}>
+            {runs.map((run) => (
+              <rect
+                key={`${run.y}-${run.x}`}
+                x={run.x}
+                y={run.y}
+                width={run.width}
+                height={1}
+                fill={run.fill}
+              />
+            ))}
 
-          {/* Eyelids: a green shutter that wipes down over the eye, with a dark lash line at its
-              edge so a closed eye still reads as an eye rather than as a hole in the head. */}
-          {EYES.map((eye) => (
-            <g
-              key={eye.x}
-              className={`${scope}-lid`}
-              // Per-eye origin, so the lid wipes down from its own top edge. It cannot live in the
-              // shared class, and `transform-box: fill-box` is not a substitute — the group's fill
-              // box is only as tall as the lid, which is what we are scaling to zero.
-              style={{ transformOrigin: `${eye.x + 1.5}px ${eye.y}px` }}
-            >
-              <rect x={eye.x} y={eye.y} width={3} height={3} fill={PALETTE.D} />
-              <rect x={eye.x} y={eye.y + 2} width={3} height={1} fill={PALETTE.K} />
+            {/* Vocal sac: belly-coloured bulge under the chin. Hidden at rest via its own
+                keyframes, so nothing shows until the croak starts. No dark rim — the L→B colour
+                step already draws the edge, and a rim mid-stretch reads as a floating bar. */}
+            <g className={`${scope}-sac`}>
+              {SAC.map((band) => (
+                <rect
+                  key={band.y}
+                  x={band.x}
+                  y={band.y}
+                  width={band.width}
+                  height={1}
+                  fill={PALETTE.B}
+                />
+              ))}
             </g>
-          ))}
+
+            {/* Eyelids: a green shutter that wipes down over the eye, with a dark lash line at its
+                edge so a closed eye still reads as an eye rather than as a hole in the head. */}
+            {EYES.map((eye) => (
+              <g
+                key={eye.x}
+                className={`${scope}-lid`}
+                // Per-eye origin, so the lid wipes down from its own top edge. It cannot live in the
+                // shared class, and `transform-box: fill-box` is not a substitute — the group's fill
+                // box is only as tall as the lid, which is what we are scaling to zero.
+                style={{ transformOrigin: `${eye.x + 2}px ${eye.y}px` }}
+              >
+                <rect x={eye.x} y={eye.y} width={4} height={3} fill={PALETTE.D} />
+                <rect x={eye.x} y={eye.y + 2} width={4} height={1} fill={PALETTE.K} />
+              </g>
+            ))}
+          </g>
         </g>
       </g>
     </svg>

--- a/apps/cockpit/src/components/shell/__tests__/FrogMascot.test.tsx
+++ b/apps/cockpit/src/components/shell/__tests__/FrogMascot.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
-import { FrogMascot } from '@/components/shell/FrogMascot'
+import { FrogMascot, SPRITE } from '@/components/shell/FrogMascot'
 
 afterEach(cleanup)
 
@@ -43,21 +43,34 @@ describe('FrogMascot', () => {
     const lids = container.querySelectorAll('[class*="-lid"]')
     expect(lids).toHaveLength(2)
 
-    // The eyes live at x=8 and x=26, y=3 in sprite coordinates. If the sprite is edited without
-    // moving EYES to match, the lid closes over the frog's forehead instead.
+    // The pupils live at x=7 and x=27, y=2 in sprite coordinates (4×3 blocks, rows 2–4). If the
+    // sprite is edited without moving EYES to match, the lid closes over the frog's forehead.
     const covered = [...lids].map((lid) => {
       const rect = lid.querySelector('rect')!
       return `${rect.getAttribute('x')},${rect.getAttribute('y')}`
     })
-    expect(covered).toEqual(['8,3', '26,3'])
+    expect(covered).toEqual(['7,2', '27,2'])
+  })
+
+  it('keeps the sprite grid rectangular and mirror-symmetric', () => {
+    // Hand-edited pixel art rots in exactly two ways: a row drifts off the grid width, or an edit
+    // lands on one side only. Both are cheap to assert against the exported grid directly.
+    const width = SPRITE[0]!.length
+    expect(width).toBeGreaterThan(0)
+    for (const [, row] of SPRITE.entries()) {
+      expect(row.length).toBe(width)
+      for (let c = 0; c < width; c++) {
+        expect(row[c]).toBe(row[width - 1 - c])
+      }
+    }
   })
 
   it('honours the size prop and keeps the sprite aspect ratio', () => {
     const { container } = render(<FrogMascot size={74} />)
     const svg = container.querySelector('svg')!
     expect(svg.getAttribute('width')).toBe('74')
-    // 27 sprite rows + 12 rows of headroom for the hop and shadow, over 37 columns.
-    expect(svg.getAttribute('height')).toBe(String(Math.round((74 / 37) * 39)))
-    expect(svg.getAttribute('viewBox')).toBe('0 -8 37 39')
+    // 23 sprite rows + 12 rows of headroom for the hop and shadow, over 38 columns.
+    expect(svg.getAttribute('height')).toBe(String(Math.round((74 / 38) * 35)))
+    expect(svg.getAttribute('viewBox')).toBe('0 -8 38 35')
   })
 })


### PR DESCRIPTION
## Summary
- Redrew the About-tab frog from a blocky blob into proper frog pixel art: bulbous eyes with sparkle highlights, nostrils, a wide smile, rosy cheeks, a pale belly with sheen, folded haunches, and webbed toes — still drawn on its logical pixel grid, mirror-symmetric, with crisp edges at any zoom.
- Extended the idle set: the existing breathing bob, blink, and hop stay, joined by a vocal-sac croak every ~10s and squash-and-stretch on the hop (crouch, launch stretch, landing splat) while the contact shadow tightens underneath.
- Every animation still ends on its resting pose (the croak's resting pose is hidden), so `prefers-reduced-motion` freezes the frog cleanly instead of stranding it mid-pose.

## Test plan
- [x] `bunx tsc --noEmit` — zero errors
- [x] `bunx vitest run` — 1697 passing, including updated eyelid-position and aspect-ratio assertions
- [x] New test holds the sprite grid rectangular and mirror-symmetric against future edits
- [x] `bun run lint` — zero errors, design-system check clean
- [x] Eyeballed idle and mid-croak poses in the Vite preview; verified croak duty cycle (~18% visible) via computed-style sampling