### PR TITLE
fix(cockpit): unify editor toolbar actions

### DIFF
--- a/apps/cockpit/src/app/__tests__/tool-registry.test.ts
+++ b/apps/cockpit/src/app/__tests__/tool-registry.test.ts
@@ -60,13 +60,15 @@ describe('tool capability flags', () => {
     for (const id of MONACO_TOOL_IDS) expect(toolIds.has(id)).toBe(true)
   })
 
-  it('OPEN_FILE_TOOL_IDS matches the audited set of 14', () => {
+  it('OPEN_FILE_TOOL_IDS matches the audited set of 16', () => {
     expect(OPEN_FILE_TOOL_IDS).toEqual(
       new Set([
         'api-client',
         'code-formatter',
+        'css-to-tailwind',
         'css-validator',
         'csv-tools',
+        'curl-to-fetch',
         'diff-viewer',
         'html-validator',
         'json-schema-validator',
@@ -81,13 +83,15 @@ describe('tool capability flags', () => {
     )
   })
 
-  it('SAVE_FILE_TOOL_IDS matches the audited set of 13', () => {
+  it('SAVE_FILE_TOOL_IDS matches the audited set of 15', () => {
     expect(SAVE_FILE_TOOL_IDS).toEqual(
       new Set([
         'api-client',
         'code-formatter',
+        'css-to-tailwind',
         'css-validator',
         'csv-tools',
+        'curl-to-fetch',
         'html-validator',
         'json-schema-validator',
         'json-tools',

--- a/apps/cockpit/src/app/tool-registry.ts
+++ b/apps/cockpit/src/app/tool-registry.ts
@@ -213,6 +213,8 @@ export const TOOLS: ToolDefinition[] = [
     icon: toolIcon(WindIcon),
     description: 'Convert CSS rules to Tailwind classes',
     component: CssToTailwind,
+    supportsOpenFile: true,
+    supportsSaveFile: true,
     usesMonaco: true,
   },
   // --- Convert ---
@@ -264,6 +266,8 @@ export const TOOLS: ToolDefinition[] = [
     icon: toolIcon(TerminalWindowIcon),
     description: 'Convert cURL to fetch, axios, ky, XHR, Node.js with syntax highlighting',
     component: CurlToFetch,
+    supportsOpenFile: true,
+    supportsSaveFile: true,
     usesMonaco: true,
   },
   {

--- a/apps/cockpit/src/components/shared/DocumentFileActions.tsx
+++ b/apps/cockpit/src/components/shared/DocumentFileActions.tsx
@@ -1,0 +1,59 @@
+import {
+  FilePlusIcon,
+  FloppyDiskBackIcon,
+  FloppyDiskIcon,
+  FolderOpenIcon,
+} from '@phosphor-icons/react'
+import { Button } from '@/components/shared/Button'
+import { ToolbarGroup } from '@/components/shared/Toolbar'
+
+type FileAction = {
+  onClick: () => void
+  label: string
+  title?: string
+  disabled?: boolean
+}
+
+type DocumentFileActionsProps = {
+  newDocument?: FileAction
+  open?: FileAction
+  save?: FileAction
+  saveAs?: FileAction
+  separated?: boolean
+}
+
+/** Canonical file-action order and icon treatment for document editor toolbars. */
+export function DocumentFileActions({
+  newDocument,
+  open,
+  save,
+  saveAs,
+  separated = true,
+}: DocumentFileActionsProps) {
+  const actions = [
+    newDocument && { ...newDocument, icon: FilePlusIcon },
+    open && { ...open, icon: FolderOpenIcon },
+    save && { ...save, icon: FloppyDiskIcon },
+    saveAs && { ...saveAs, icon: FloppyDiskBackIcon },
+  ].filter((action): action is FileAction & { icon: typeof FilePlusIcon } => Boolean(action))
+
+  if (actions.length === 0) return null
+
+  return (
+    <ToolbarGroup label="File actions" separated={separated}>
+      {actions.map(({ icon: Icon, label, title, onClick, disabled }) => (
+        <Button
+          key={label}
+          variant="icon"
+          size="sm"
+          onClick={onClick}
+          disabled={disabled}
+          title={title ?? label}
+          aria-label={label}
+        >
+          <Icon size={14} aria-hidden="true" />
+        </Button>
+      ))}
+    </ToolbarGroup>
+  )
+}

--- a/apps/cockpit/src/components/shared/__tests__/DocumentFileActions.test.tsx
+++ b/apps/cockpit/src/components/shared/__tests__/DocumentFileActions.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
+
+describe('DocumentFileActions', () => {
+  it('renders available actions in canonical order with accessible tooltips', () => {
+    const onOpen = vi.fn()
+    render(
+      <DocumentFileActions
+        newDocument={{ label: 'New document', onClick: vi.fn() }}
+        open={{ label: 'Open document', title: 'Open document (⌘O)', onClick: onOpen }}
+        save={{ label: 'Save document', onClick: vi.fn() }}
+        saveAs={{ label: 'Save document as', onClick: vi.fn() }}
+      />
+    )
+
+    expect(
+      screen.getAllByRole('button').map((button) => button.getAttribute('aria-label'))
+    ).toEqual(['New document', 'Open document', 'Save document', 'Save document as'])
+    expect(screen.getByRole('button', { name: 'Open document' })).toHaveAttribute(
+      'title',
+      'Open document (⌘O)'
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Open document' }))
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/cockpit/src/components/shell/CommandPalette.tsx
+++ b/apps/cockpit/src/components/shell/CommandPalette.tsx
@@ -396,6 +396,7 @@ export function CommandPalette() {
                   type: 'open-file',
                   content: result.content,
                   filename: result.filename,
+                  path: result.path,
                 })
                 addToast(`Opened ${result.filename}`, 'success')
               }

--- a/apps/cockpit/src/components/shell/Workspace.tsx
+++ b/apps/cockpit/src/components/shell/Workspace.tsx
@@ -91,12 +91,14 @@ export function Workspace() {
   const hasActivePane = mountedTabs.some((tab) => tab.id === activeTabId && getToolById(tab.toolId))
 
   const handleFileDrop = useCallback(
-    (content: string, filename: string) => {
+    (content: string, filename: string, path: string) => {
       if (!supportsToolFileAction(activeTool, 'open-file')) {
         addToast('File drop is not supported by the active tool', 'error')
         return
       }
-      dispatchToolAction({ type: 'open-file', content, filename })
+      // The path travels with the drop so the first ⌘S overwrites the dropped
+      // file instead of reopening a Save As dialog for a file we already know.
+      dispatchToolAction({ type: 'open-file', content, filename, path })
       addToast(`Loaded ${filename}`, 'success')
     },
     [activeTool, addToast]

--- a/apps/cockpit/src/hooks/__tests__/useFileDropZone.test.ts
+++ b/apps/cockpit/src/hooks/__tests__/useFileDropZone.test.ts
@@ -42,7 +42,11 @@ describe('useFileDropZone', () => {
       })
     })
 
-    await waitFor(() => expect(onDrop).toHaveBeenCalledWith('dropped content', 'example.json'))
+    // The absolute path rides along so the tool can overwrite the dropped file
+    // on ⌘S instead of falling back to Save As.
+    await waitFor(() =>
+      expect(onDrop).toHaveBeenCalledWith('dropped content', 'example.json', '/tmp/example.json')
+    )
     unmount()
     expect(mocks.unlisten).toHaveBeenCalledOnce()
   })

--- a/apps/cockpit/src/hooks/useFileDropZone.ts
+++ b/apps/cockpit/src/hooks/useFileDropZone.ts
@@ -3,7 +3,7 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { filenameFromPath, readSupportedTextFile } from '@/lib/file-io'
 
 export function useFileDropZone(
-  onDrop: (content: string, filename: string) => void,
+  onDrop: (content: string, filename: string, path: string) => void,
   onError?: (message: string) => void,
   enabled = true
 ) {
@@ -37,7 +37,7 @@ export function useFileDropZone(
             readSupportedTextFile(filePath)
               .then((content) => {
                 if (cancelled) return
-                onDropRef.current(content, filename)
+                onDropRef.current(content, filename, filePath)
               })
               .catch((err) => {
                 if (cancelled) return

--- a/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/code-formatter.test.tsx
@@ -130,11 +130,14 @@ describe('CodeFormatter', () => {
   it('saves current output and handles cancellation', async () => {
     vi.mocked(saveFileDialog).mockResolvedValueOnce('/tmp/formatted.js').mockResolvedValueOnce(null)
     renderTool(CodeFormatter)
+    typeCode('const value=1')
 
     act(() => dispatchToolAction({ type: 'save-file' }))
-    await waitFor(() => expect(saveFileDialog).toHaveBeenCalledWith('', 'formatted.js'))
+    await waitFor(() =>
+      expect(saveFileDialog).toHaveBeenCalledWith('const value=1', 'formatted.js')
+    )
 
-    act(() => dispatchToolAction({ type: 'save-file' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save code file as' }))
     await waitFor(() => expect(saveFileDialog).toHaveBeenCalledTimes(2))
     expect(useUiStore.getState().lastAction).toMatchObject({
       message: 'Save cancelled',
@@ -246,7 +249,8 @@ describe('CodeFormatter', () => {
     renderTool(CodeFormatter)
     expect(screen.getByRole('button', { name: /Format/ })).toBeDisabled()
     expect(screen.getByRole('button', { name: /Auto-detect/ })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Save to file' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save code file' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save code file as' })).toBeDisabled()
   })
 })
 

--- a/apps/cockpit/src/tools/__tests__/css-validator.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/css-validator.test.tsx
@@ -18,7 +18,7 @@ import {
   toggleRule,
   type CssIssue,
 } from '@/tools/css-validator/css-helpers'
-import { openFileDialog, saveFileDialog } from '@/lib/file-io'
+import { openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { dispatchToolAction, supportsToolFileAction } from '@/lib/tool-actions'
 import * as cssTree from 'css-tree'
 
@@ -31,6 +31,7 @@ vi.mock('@/hooks/useToolHistory', () => ({
 vi.mock('@/lib/file-io', () => ({
   openFileDialog: vi.fn(),
   saveFileDialog: vi.fn(),
+  saveFileToPath: vi.fn(),
   filenameFromPath: (path: string) => path.split(/[\\/]/).pop() || path,
 }))
 
@@ -429,20 +430,24 @@ describe('CssValidator', () => {
     expect(screen.getByTestId('monaco-editor')).toHaveValue('.a { color: red; } }')
   })
 
-  it('round trips a file through Open and Save', async () => {
+  it('opens a file and saves back to its known path', async () => {
     vi.mocked(openFileDialog).mockResolvedValue({
       content: '.opened { color: red; }',
       filename: 'site.css',
       path: '/tmp/site.css',
     })
-    vi.mocked(saveFileDialog).mockResolvedValue('/tmp/out.css')
+    vi.mocked(saveFileToPath).mockResolvedValue(undefined)
     renderTool(CssValidator)
 
     fireEvent.click(screen.getByRole('button', { name: /Open/ }))
     await waitFor(() => expect(screen.getByTestId('file-name')).toHaveTextContent('site.css'))
 
-    fireEvent.click(screen.getByRole('button', { name: /Save/ }))
-    await waitFor(() => expect(screen.getByTestId('file-name')).toHaveTextContent('out.css'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save stylesheet' }))
+    await waitFor(() =>
+      expect(saveFileToPath).toHaveBeenCalledWith('/tmp/site.css', '.opened { color: red; }')
+    )
+    expect(saveFileDialog).not.toHaveBeenCalled()
+    expect(screen.getByTestId('file-name')).toHaveTextContent('site.css')
     expect(screen.getByText('Saved')).toBeInTheDocument()
   })
 

--- a/apps/cockpit/src/tools/__tests__/curl-to-fetch.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/curl-to-fetch.test.tsx
@@ -173,6 +173,6 @@ describe('CurlToFetch — Load sample', () => {
       expect(output).toContain('Authorization')
       expect(output).toContain('body')
     })
-    expect(screen.queryByRole('button', { name: 'Load sample' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Load sample' })).toBeInTheDocument()
   })
 })

--- a/apps/cockpit/src/tools/__tests__/diff-viewer.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/diff-viewer.test.tsx
@@ -153,7 +153,7 @@ describe('DiffViewer', () => {
 
     openOptions()
     expect(screen.getByRole('button', { name: 'Copy patch' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Save patch/ })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Export patch' })).toBeEnabled()
   })
 
   it('reports the change counts as text and to screen readers', async () => {
@@ -238,7 +238,7 @@ describe('DiffViewer', () => {
 
     // Header-only patches used to leave a blank pane and an enabled Save button.
     await waitFor(() => expect(screen.getByText('No differences')).toBeInTheDocument())
-    expect(screen.getByRole('button', { name: /Save patch/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Export patch' })).toBeDisabled()
   })
 
   it('writes the patch out through the shared export helper', async () => {
@@ -248,7 +248,7 @@ describe('DiffViewer', () => {
     await waitFor(() => expect(screen.getByRole('region', { name: 'Diff result' })).toBeTruthy())
 
     openOptions()
-    fireEvent.click(screen.getByRole('button', { name: /Save patch/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Export patch' }))
 
     await waitFor(() => {
       expect(exportFile).toHaveBeenCalledWith(

--- a/apps/cockpit/src/tools/__tests__/html-validator.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/html-validator.test.tsx
@@ -420,7 +420,7 @@ describe('HtmlValidator', () => {
     typeHtml('<p>a</p>')
     expect(screen.getByText('Modified')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Save/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save HTML document' }))
     await waitFor(() => expect(screen.getByTestId('file-name')).toHaveTextContent('out.html'))
     expect(saveFileDialog).toHaveBeenCalledWith('<p>a</p>', 'page.html')
     expect(screen.getByText('Saved')).toBeInTheDocument()

--- a/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/json-tools.test.tsx
@@ -368,19 +368,18 @@ describe('JsonTools', () => {
     })
   })
 
-  // This bar wraps to two rows at 1024px. With view options first the wrap put Indent/Path/view
-  // mode on row one and buried every primary action beneath them, so the least important row has
-  // to be the one that sheds last. Save is labelled for the same reason Copy JSON is — an
-  // unlabelled floppy disk next to five labelled buttons reads as a different class of control.
-  it('leads the toolbar with document actions and trails with view options', () => {
+  it('orders file actions before document actions and view options', () => {
     renderTool(JsonTools)
+    const files = screen.getByRole('group', { name: 'File actions' })
     const actions = screen.getByRole('group', { name: 'Document actions' })
     const viewOptions = screen.getByRole('group', { name: 'View options' })
 
+    expect(files.compareDocumentPosition(actions) & files.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(
       actions.compareDocumentPosition(viewOptions) & actions.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
-    expect(within(actions).getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    expect(within(files).getByRole('button', { name: 'Save JSON file' })).toBeInTheDocument()
+    expect(within(files).getByRole('button', { name: 'Save JSON file as' })).toBeInTheDocument()
   })
 
   it('offers a sample only while the document is empty', () => {

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -103,16 +103,19 @@ describe('MarkdownEditor', () => {
     )
   })
 
-  it('File dropdown renders Open, Save, and Save As entries', () => {
+  it('renders canonical file actions in the toolbar', () => {
     renderTool(MarkdownEditor)
-    fireEvent.click(screen.getByText('File'))
-    const menu = within(screen.getByRole('menu'))
-    expect(menu.getByText('Open…')).toBeInTheDocument()
-    expect(menu.getByText('Save')).toBeInTheDocument()
-    expect(menu.getByText('Save As…')).toBeInTheDocument()
+    const files = screen.getByRole('group', { name: 'File actions' })
+    expect(within(files).getByRole('button', { name: 'Open markdown file' })).toBeInTheDocument()
+    expect(
+      within(files).getByRole('button', { name: 'Save markdown document' })
+    ).toBeInTheDocument()
+    expect(
+      within(files).getByRole('button', { name: 'Save markdown document as' })
+    ).toBeInTheDocument()
   })
 
-  it('File > Open… populates content, fileName, and filePath', async () => {
+  it('Open populates content, fileName, and filePath', async () => {
     vi.mocked(openFileDialog).mockResolvedValue({
       content: '# From disk',
       filename: 'notes.md',
@@ -120,14 +123,13 @@ describe('MarkdownEditor', () => {
     })
     renderTool(MarkdownEditor)
 
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(screen.getByText('Open…'))
+    fireEvent.click(screen.getByRole('button', { name: 'Open markdown file' }))
 
     await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
     expect(screen.getByTestId('file-name')).toHaveTextContent('notes.md')
   })
 
-  it('File > Save writes directly to a known filePath without opening the save dialog', async () => {
+  it('Save writes directly to a known filePath without opening the save dialog', async () => {
     vi.mocked(openFileDialog).mockResolvedValue({
       content: '# From disk',
       filename: 'notes.md',
@@ -136,26 +138,23 @@ describe('MarkdownEditor', () => {
     vi.mocked(saveFileToPath).mockResolvedValue(undefined)
     renderTool(MarkdownEditor)
 
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(screen.getByText('Open…'))
+    fireEvent.click(screen.getByRole('button', { name: 'Open markdown file' }))
     await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
 
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(within(screen.getByRole('menu')).getByText('Save'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save markdown document' }))
 
     await waitFor(() => expect(saveFileToPath).toHaveBeenCalledWith('/tmp/notes.md', '# From disk'))
     expect(saveFileDialog).not.toHaveBeenCalled()
   })
 
-  it('File > Save falls back to the Save As dialog when no filePath is known', async () => {
+  it('Save falls back to the Save As dialog when no filePath is known', async () => {
     vi.mocked(saveFileDialog).mockResolvedValue('/tmp/document.md')
     renderTool(MarkdownEditor)
 
     fireEvent.change(screen.getByTestId('monaco-editor'), {
       target: { value: '# Untitled' },
     })
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(within(screen.getByRole('menu')).getByText('Save'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save markdown document' }))
 
     await waitFor(() => expect(saveFileDialog).toHaveBeenCalledWith('# Untitled', 'document.md'))
     expect(saveFileToPath).not.toHaveBeenCalled()
@@ -170,8 +169,7 @@ describe('MarkdownEditor', () => {
     vi.mocked(saveFileToPath).mockResolvedValue(undefined)
     renderTool(MarkdownEditor)
 
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(screen.getByText('Open…'))
+    fireEvent.click(screen.getByRole('button', { name: 'Open markdown file' }))
     await waitFor(() => expect(screen.getByTestId('monaco-editor')).toHaveValue('# From disk'))
     expect(screen.getByTestId('file-name')).toHaveTextContent('notes.md')
     expect(screen.getByText('Saved')).toBeInTheDocument()
@@ -181,8 +179,7 @@ describe('MarkdownEditor', () => {
     })
     await waitFor(() => expect(screen.getByText('Modified')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByText('File'))
-    fireEvent.click(within(screen.getByRole('menu')).getByText('Save'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save markdown document' }))
 
     await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument())
   })
@@ -192,7 +189,7 @@ describe('MarkdownEditor', () => {
     const editor = screen.getByTestId('monaco-editor')
     fireEvent.change(editor, { target: { value: '# Keep me' } })
 
-    fireEvent.click(screen.getByRole('button', { name: 'New document' }))
+    fireEvent.click(screen.getByRole('button', { name: 'New markdown document' }))
 
     expect(screen.getByRole('dialog', { name: 'Replace unsaved changes?' })).toBeInTheDocument()
     expect(editor).toHaveValue('# Keep me')

--- a/apps/cockpit/src/tools/__tests__/ts-playground.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/ts-playground.test.tsx
@@ -60,7 +60,7 @@ describe('TsPlayground', () => {
     typeCode('')
 
     expect(screen.getByRole('button', { name: /Compile/ })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Save output to file' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Export JavaScript output' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: 'Load sample' }))
     expect(editors()[0]!.value).toContain('interface User')

--- a/apps/cockpit/src/tools/api-client/ApiClient.tsx
+++ b/apps/cockpit/src/tools/api-client/ApiClient.tsx
@@ -58,6 +58,9 @@ import {
   CopyIcon,
   DownloadSimpleIcon,
   FilePlusIcon,
+  FloppyDiskBackIcon,
+  FloppyDiskIcon,
+  FolderOpenIcon,
   GearSixIcon,
   LinkIcon,
   ListBulletsIcon,
@@ -1429,7 +1432,45 @@ export default function ApiClient() {
                   <FilePlusIcon size={16} aria-hidden="true" />
                 </Button>
 
-                <ToolbarGroup>
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="sm"
+                  onClick={() => setShowImportModal(true)}
+                  title="Open or import an API specification"
+                  aria-label="Open API specification"
+                >
+                  <FolderOpenIcon size={16} aria-hidden="true" />
+                </Button>
+
+                <ToolbarGroup label="Request file actions" separated>
+                  <Button
+                    type="button"
+                    variant={dirty ? 'primary' : 'secondary'}
+                    size="sm"
+                    loading={saving}
+                    disabled={!dirty && !!state.activeRequestId}
+                    onClick={() => void handleSave()}
+                    title="Save request"
+                    className="gap-1"
+                  >
+                    <FloppyDiskIcon size={14} aria-hidden="true" />
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleSaveAs}
+                    title="Save request as a new library entry"
+                    className="gap-1"
+                  >
+                    <FloppyDiskBackIcon size={14} aria-hidden="true" />
+                    Save As
+                  </Button>
+                </ToolbarGroup>
+
+                <ToolbarGroup label="Environment" separated>
                   <Select
                     value={activeEnvironmentId || ''}
                     onChange={(e) => setActiveEnvironmentId(e.target.value || null)}
@@ -1453,23 +1494,6 @@ export default function ApiClient() {
                     aria-label="Manage environments"
                   >
                     <GearSixIcon size={16} aria-hidden="true" />
-                  </Button>
-                </ToolbarGroup>
-
-                <ToolbarGroup>
-                  <Button
-                    type="button"
-                    variant={dirty ? 'primary' : 'secondary'}
-                    size="sm"
-                    loading={saving}
-                    disabled={!dirty && !!state.activeRequestId}
-                    onClick={() => void handleSave()}
-                    title="Save request"
-                  >
-                    Save
-                  </Button>
-                  <Button type="button" variant="secondary" size="sm" onClick={handleSaveAs}>
-                    Save As
                   </Button>
                 </ToolbarGroup>
               </Toolbar>

--- a/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
+++ b/apps/cockpit/src/tools/code-formatter/CodeFormatter.tsx
@@ -2,11 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor, { DiffEditor, type OnMount } from '@monaco-editor/react'
 import {
   ArrowCounterClockwiseIcon,
+  BroomIcon,
+  CheckIcon,
   CheckCircleIcon,
   CodeBlockIcon,
-  FloppyDiskIcon,
+  GitDiffIcon,
   MagicWandIcon,
   PencilSimpleIcon,
+  XIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
@@ -16,12 +19,14 @@ import { Kbd } from '@/components/shared/Kbd'
 import { useUiStore } from '@/stores/ui.store'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
-import { saveFileDialog } from '@/lib/file-io'
+import { dispatchToolAction } from '@/lib/tool-actions'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { Button } from '@/components/shared/Button'
 import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { SettingsPopover, SettingsRow, SettingsSection } from '@/components/shared/SettingsPopover'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -41,6 +46,7 @@ import { ProblemsList, type ProblemItem } from '@/components/shared/ProblemsList
 type CodeFormatterState = {
   input: string
   fileName: string | null
+  filePath: string | null
   language: string
   tabWidth: number
   useTabs: boolean
@@ -83,6 +89,7 @@ export default function CodeFormatter() {
   const [state, updateState] = useToolState<CodeFormatterState>('code-formatter', {
     input: '',
     fileName: null,
+    filePath: null,
     language: 'javascript',
     tabWidth: 2,
     useTabs: false,
@@ -253,14 +260,46 @@ export default function CodeFormatter() {
     }
   }, [formatter, updateState, setLastAction])
 
-  const handleSave = useCallback(() => {
+  const handleSaveAs = useCallback(async () => {
+    if (!inputRef.current.trim()) {
+      setLastAction('Nothing to save yet', 'info')
+      return
+    }
     const defaultName = state.fileName ?? `formatted.${extensionForLanguage(state.language)}`
-    void saveFileDialog(inputRef.current, defaultName).then(
-      (path) => setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-      (err: unknown) =>
-        setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-    )
-  }, [state.fileName, state.language, setLastAction])
+    try {
+      const path = await saveFileDialog(inputRef.current, defaultName)
+      if (!path) {
+        setLastAction('Save cancelled', 'info')
+        return
+      }
+      updateState({ filePath: path, fileName: filenameFromPath(path) })
+      setLastAction(`Saved ${path}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.fileName, state.language, setLastAction, updateState])
+
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, inputRef.current)
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction])
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
 
   useToolAction((action) => {
     if (action.type === 'open-file') {
@@ -271,6 +310,7 @@ export default function CodeFormatter() {
       updateState({
         input: action.content,
         fileName: action.filename,
+        filePath: action.path ?? null,
         lastFormat: null,
         ...(fromName ? { language: fromName } : {}),
       })
@@ -291,7 +331,7 @@ export default function CodeFormatter() {
           })
       }
     }
-    if (action.type === 'save-file') handleSave()
+    if (action.type === 'save-file') void handleSave()
   })
 
   useKeyboardShortcut(
@@ -312,6 +352,7 @@ export default function CodeFormatter() {
         <DocumentToolbar border aria-label="Code formatting actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled'}
             icon={
               <CodeBlockIcon
                 size={16}
@@ -331,6 +372,25 @@ export default function CodeFormatter() {
                 <PencilSimpleIcon size={12} aria-hidden="true" className="shrink-0" />
               ) : undefined
             }
+          />
+
+          <DocumentFileActions
+            open={{
+              label: 'Open code file',
+              title: `Open a code file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+            save={{
+              label: 'Save code file',
+              title: `Save the code (${formatShortcut('mod+s')})`,
+              onClick: () => void handleSave(),
+              disabled: !hasCode,
+            }}
+            saveAs={{
+              label: 'Save code file as',
+              onClick: () => void handleSaveAs(),
+              disabled: !hasCode,
+            }}
           />
 
           {stats && (
@@ -471,6 +531,7 @@ export default function CodeFormatter() {
               loading={isFormatting}
               title={`Format the code (${formatShortcut('mod+enter')})`}
             >
+              <BroomIcon size={14} aria-hidden="true" />
               Format
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
@@ -493,11 +554,13 @@ export default function CodeFormatter() {
               aria-pressed={previewOpen}
               title="Compare the source before and after formatting"
             >
+              <GitDiffIcon size={14} aria-hidden="true" />
               Diff
             </Button>
             {pendingFormat && (
               <>
-                <Button variant="primary" size="sm" onClick={handleAcceptPreview}>
+                <Button variant="primary" size="sm" onClick={handleAcceptPreview} className="gap-1">
+                  <CheckIcon size={14} aria-hidden="true" />
                   Apply format
                 </Button>
                 <Button
@@ -508,23 +571,12 @@ export default function CodeFormatter() {
                     setPreviewOpen(false)
                   }}
                 >
+                  <XIcon size={14} aria-hidden="true" />
                   Discard preview
                 </Button>
               </>
             )}
             <CopyButton text={input} />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleSave}
-              disabled={!hasCode}
-              title={`Save to a file (${formatShortcut('mod+s')})`}
-              aria-label="Save to file"
-              className="gap-1"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
-            </Button>
           </ToolbarGroup>
         </DocumentToolbar>
       }
@@ -574,7 +626,13 @@ export default function CodeFormatter() {
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => updateState({ input: CODE_FORMATTER_SAMPLES[state.language] ?? '' })}
+                onClick={() =>
+                  updateState({
+                    input: CODE_FORMATTER_SAMPLES[state.language] ?? '',
+                    fileName: null,
+                    filePath: null,
+                  })
+                }
                 className="pointer-events-auto"
               >
                 Load {languageLabel(state.language)} sample

--- a/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
+++ b/apps/cockpit/src/tools/css-to-tailwind/CssToTailwind.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import Editor from '@monaco-editor/react'
-import { WindIcon } from '@phosphor-icons/react'
+import { DownloadSimpleIcon, WindIcon } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
@@ -10,11 +10,20 @@ import { PaneHeader } from '@/components/shared/PaneHeader'
 import { SplitPane } from '@/components/shared/SplitPane'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ToolLayout } from '@/components/shared/ToolLayout'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
+import { useToolAction } from '@/hooks/useToolAction'
+import { useUiStore } from '@/stores/ui.store'
+import { dispatchToolAction } from '@/lib/tool-actions'
+import { buildExportFilename, exportFile, openFileDialog } from '@/lib/file-io'
+import { formatShortcut } from '@/lib/shortcut-label'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import * as cssTree from 'css-tree'
 
 type CssToTailwindState = {
   input: string
+  fileName: string | null
   version: '3' | '4'
 }
 
@@ -490,8 +499,11 @@ export default function CssToTailwind() {
   const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CssToTailwindState>('css-to-tailwind', {
     input: '',
+    fileName: null,
     version: '4',
   })
+  const setLastAction = useUiStore((s) => s.setLastAction)
+  const copy = useCopyToClipboard()
   const result = useMemo(() => {
     if (!state.input.trim()) return null
     return convertCssToTailwind(state.input, state.version)
@@ -499,8 +511,80 @@ export default function CssToTailwind() {
 
   const classString = result?.classes.join(' ') ?? ''
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
+  const handleExport = useCallback(async () => {
+    if (!classString) {
+      setLastAction('Nothing to export yet', 'info')
+      return
+    }
+    try {
+      const base = state.fileName?.replace(/\.[^.]+$/, '') ?? 'tailwind-classes'
+      const path = await exportFile(classString, buildExportFilename(base, 'txt'))
+      setLastAction(path ? `Exported ${path}` : 'Export cancelled', path ? 'success' : 'info')
+    } catch (err) {
+      setLastAction(`Export failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [classString, state.fileName, setLastAction])
+
+  useToolAction((action) => {
+    if (action.type === 'open-file') {
+      updateState({ input: action.content, fileName: action.filename })
+      setLastAction(`Opened ${action.filename}`, 'success')
+    }
+    if (action.type === 'save-file') void handleExport()
+    if (action.type === 'copy-output' && classString) {
+      void copy(classString, { success: 'Tailwind classes copied', failure: 'Copy failed' })
+    }
+  })
+
   return (
-    <ToolLayout fullBleed>
+    <ToolLayout
+      fullBleed
+      toolbar={
+        <DocumentToolbar aria-label="CSS to Tailwind actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled CSS'}
+            icon={
+              <WindIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            status={classString ? `${result?.classes.length ?? 0} utilities` : 'Nothing converted'}
+          />
+          <DocumentFileActions
+            open={{
+              label: 'Open CSS file',
+              title: `Open a CSS file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+          />
+          <ToolbarGroup label="Converted output" separated>
+            <CopyButton text={classString} label="Copy Tailwind classes" />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleExport()}
+              disabled={!classString}
+              title={`Export Tailwind classes (${formatShortcut('mod+s')})`}
+              className="gap-1"
+            >
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
+              Export
+            </Button>
+          </ToolbarGroup>
+        </DocumentToolbar>
+      }
+    >
       <SplitPane storageKey="css-to-tailwind" aria-label="Resize CSS input and Tailwind output">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <PaneHeader
@@ -532,10 +616,7 @@ export default function CssToTailwind() {
           </div>
         </div>
         <div className="flex min-h-0 flex-1 flex-col">
-          <PaneHeader
-            title="Tailwind Output"
-            actions={classString ? <CopyButton text={classString} /> : undefined}
-          />
+          <PaneHeader title="Tailwind Output" />
           <div className="flex-1 overflow-auto p-4">
             {result ? (
               <div className="flex flex-col gap-4">

--- a/apps/cockpit/src/tools/css-validator/CssValidator.tsx
+++ b/apps/cockpit/src/tools/css-validator/CssValidator.tsx
@@ -3,11 +3,10 @@ import Editor, { type OnMount } from '@monaco-editor/react'
 import {
   CaretDownIcon,
   CaretUpIcon,
+  BroomIcon,
   CheckCircleIcon,
   FileCssIcon,
-  FilePlusIcon,
-  FloppyDiskIcon,
-  FolderOpenIcon,
+  FilesIcon,
   InfoIcon,
   WarningCircleIcon,
   WarningIcon,
@@ -31,9 +30,10 @@ import { Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { Checkbox } from '@/components/shared/Checkbox'
 import { useUiStore } from '@/stores/ui.store'
-import { openFileDialog, saveFileDialog, filenameFromPath } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -409,7 +409,7 @@ export default function CssValidator() {
     }
   }, [requestDocument, setLastAction])
 
-  const handleSave = useCallback(async () => {
+  const handleSaveAs = useCallback(async () => {
     const snapshot = inputRef.current
     if (!snapshot.trim()) {
       setLastAction('Nothing to save yet', 'info')
@@ -427,6 +427,25 @@ export default function CssValidator() {
       setLastAction(err instanceof Error ? err.message : 'Save failed', 'error')
     }
   }, [state.fileName, state.syntax, updateState, setLastAction])
+
+  const handleSave = useCallback(async () => {
+    const snapshot = inputRef.current
+    if (!snapshot.trim()) {
+      setLastAction('Nothing to save yet', 'info')
+      return
+    }
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, snapshot)
+      updateState({ savedContent: snapshot })
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(err instanceof Error ? err.message : 'Save failed', 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction, updateState])
 
   // --- Format ----------------------------------------------------------
 
@@ -563,37 +582,28 @@ export default function CssValidator() {
           }
         />
 
-        <ToolbarGroup label="Document actions" separated>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={handleNew}
-            title="New stylesheet"
-            aria-label="New stylesheet"
-          >
-            <FilePlusIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={() => void handleOpen()}
-            title={`Open a .css file (${formatShortcut('mod+o')})`}
-            aria-label="Open CSS file"
-          >
-            <FolderOpenIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={() => void handleSave()}
-            title={`Save the stylesheet (${formatShortcut('mod+s')})`}
-            aria-label="Save stylesheet"
-          >
-            <FloppyDiskIcon size={14} aria-hidden="true" />
-          </Button>
-        </ToolbarGroup>
+        <DocumentFileActions
+          newDocument={{ label: 'New stylesheet', onClick: handleNew }}
+          open={{
+            label: 'Open CSS file',
+            title: `Open a .css file (${formatShortcut('mod+o')})`,
+            onClick: () => void handleOpen(),
+          }}
+          save={{
+            label: 'Save stylesheet',
+            title: `Save the stylesheet (${formatShortcut('mod+s')})`,
+            onClick: () => void handleSave(),
+            disabled: !hasInput,
+          }}
+          saveAs={{
+            label: 'Save stylesheet as',
+            title: 'Save the stylesheet to a new file',
+            onClick: () => void handleSaveAs(),
+            disabled: !hasInput,
+          }}
+        />
 
-        <ToolbarGroup label="Template actions" separated>
+        <ToolbarGroup label="Input options" separated>
           <Select
             aria-label="Stylesheet syntax"
             value={state.syntax}
@@ -605,6 +615,9 @@ export default function CssValidator() {
             <option value="scss">SCSS</option>
             <option value="less">Less</option>
           </Select>
+        </ToolbarGroup>
+
+        <ToolbarGroup label="Template actions" separated>
           <Select
             aria-label="Starter template"
             value={state.templateId}
@@ -616,7 +629,14 @@ export default function CssValidator() {
               </option>
             ))}
           </Select>
-          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleLoadTemplate}
+            title="Load the selected stylesheet template"
+            className="gap-1"
+          >
+            <FilesIcon size={14} aria-hidden="true" />
             Load
           </Button>
         </ToolbarGroup>
@@ -630,6 +650,7 @@ export default function CssValidator() {
             loading={isFormatting}
             title={`Reformat the stylesheet (${formatShortcut('mod+enter')})`}
           >
+            <BroomIcon size={14} aria-hidden="true" />
             Format
             <Kbd keys="mod+enter" variant="inline" className="ml-1" />
           </Button>

--- a/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
+++ b/apps/cockpit/src/tools/csv-tools/CsvTools.tsx
@@ -2,15 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import {
   ArrowUUpLeftIcon,
+  BracketsCurlyIcon,
   CheckCircleIcon,
   CrosshairSimpleIcon,
+  DownloadSimpleIcon,
   FileCsvIcon,
-  FloppyDiskIcon,
+  ShieldCheckIcon,
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
@@ -20,9 +23,10 @@ import { Select } from '@/components/shared/Select'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { SplitPane } from '@/components/shared/SplitPane'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { openFileDialog, saveFileDialog } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import CsvTable from './CsvTable'
 import CsvConvert from './CsvConvert'
@@ -306,6 +310,15 @@ export default function CsvTools() {
     )
   }, [currentOutput, activeExtension, state.fileName, setLastAction])
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
   const handleLoadSample = useCallback(() => {
     const sample = TOOL_SAMPLES['csv-tools']
     if (!sample) return
@@ -388,6 +401,13 @@ export default function CsvTools() {
               ) : undefined
             }
           />
+          <DocumentFileActions
+            open={{
+              label: 'Open CSV or JSON file',
+              title: `Open a data file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+          />
           {issues.length > 0 && issues[0] && (
             <Button
               variant="ghost"
@@ -401,7 +421,7 @@ export default function CsvTools() {
             </Button>
           )}
 
-          <ToolbarGroup className="gap-3">
+          <ToolbarGroup label="CSV options and output" separated className="gap-3">
             <SegmentedControl
               aria-label="Input format"
               value={inputMode}
@@ -470,6 +490,7 @@ export default function CsvTools() {
               disabled={!rows.length}
               title="Open the current rows in JSON Tools"
             >
+              <BracketsCurlyIcon size={14} aria-hidden="true" />
               JSON
             </Button>
             <Button
@@ -484,6 +505,7 @@ export default function CsvTools() {
               disabled={!rows.length}
               title="Validate the current rows against an inferred JSON Schema"
             >
+              <ShieldCheckIcon size={14} aria-hidden="true" />
               Validate schema
             </Button>
             <Button
@@ -491,12 +513,12 @@ export default function CsvTools() {
               size="sm"
               onClick={handleSave}
               disabled={!hasInput}
-              title={`Save the current view to a file (${formatShortcut('mod+s')})`}
-              aria-label="Save output to file"
+              title={`Export the current view (${formatShortcut('mod+s')})`}
+              aria-label="Export current view"
               className="gap-1"
             >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
+              Export
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
+++ b/apps/cockpit/src/tools/curl-to-fetch/CurlToFetch.tsx
@@ -10,16 +10,23 @@ import { Button } from '@/components/shared/Button'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { sendToTool } from '@/lib/tool-handoff'
 import { ToolLayout } from '@/components/shared/ToolLayout'
-import { Toolbar, ToolbarSpacer } from '@/components/shared/Toolbar'
+import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { TextArea } from '@/components/shared/TextArea'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
-import { TerminalWindowIcon } from '@phosphor-icons/react'
+import { DownloadSimpleIcon, FilesIcon, PlayIcon, TerminalWindowIcon } from '@phosphor-icons/react'
 import { Alert } from '@/components/shared/Alert'
-import { PlayIcon } from '@phosphor-icons/react'
+import { useToolAction } from '@/hooks/useToolAction'
+import { useUiStore } from '@/stores/ui.store'
+import { dispatchToolAction } from '@/lib/tool-actions'
+import { buildExportFilename, exportFile, openFileDialog } from '@/lib/file-io'
+import { formatShortcut } from '@/lib/shortcut-label'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 
 type CurlToFetchState = {
   input: string
+  fileName: string | null
   outputTab: string
 }
 
@@ -297,8 +304,11 @@ export default function CurlToFetch() {
   const { theme: monacoTheme, options: monacoOptions } = useMonaco()
   const [state, updateState] = useToolState<CurlToFetchState>('curl-to-fetch', {
     input: '',
+    fileName: null,
     outputTab: 'fetch',
   })
+  const setLastAction = useUiStore((s) => s.setLastAction)
+  const copy = useCopyToClipboard()
 
   const parseResult = useMemo(() => parseCurl(state.input), [state.input])
   const parsed = parseResult.parsed
@@ -354,12 +364,66 @@ export default function CurlToFetch() {
     })
   }, [parsed])
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
+  const handleExport = useCallback(async () => {
+    if (!output) {
+      setLastAction('Nothing to export yet', 'info')
+      return
+    }
+    try {
+      const path = await exportFile(output, buildExportFilename(`${state.outputTab}-request`, 'js'))
+      setLastAction(path ? `Exported ${path}` : 'Export cancelled', path ? 'success' : 'info')
+    } catch (err) {
+      setLastAction(`Export failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [output, state.outputTab, setLastAction])
+
+  const handleLoadSample = useCallback(() => {
+    updateState({ input: TOOL_SAMPLES['curl-to-fetch'] ?? '', fileName: null })
+  }, [updateState])
+
+  useToolAction((action) => {
+    if (action.type === 'open-file') {
+      updateState({ input: action.content, fileName: action.filename })
+      setLastAction(`Opened ${action.filename}`, 'success')
+    }
+    if (action.type === 'save-file') void handleExport()
+    if (action.type === 'copy-output' && output) {
+      void copy(output, { success: 'Generated request copied', failure: 'Copy failed' })
+    }
+  })
+
   return (
     <ToolLayout
       fullBleed
       toolbar={
-        parsed && (
-          <Toolbar className="gap-x-3" aria-label="Parsed request">
+        <DocumentToolbar aria-label="cURL conversion actions">
+          <DocumentIdentity
+            title={state.fileName ?? 'Untitled cURL command'}
+            icon={
+              <TerminalWindowIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+            status={
+              parsed
+                ? `${parsed.url} · ${headerCount} header${headerCount === 1 ? '' : 's'}${parsed.body ? ` · ${parsed.body.length} body chars` : ''}`
+                : state.input.trim()
+                  ? 'Invalid cURL command'
+                  : 'Nothing converted'
+            }
+          />
+          {parsed && (
             <span
               className="rounded px-2 py-0.5 text-xs font-bold"
               style={{
@@ -369,32 +433,54 @@ export default function CurlToFetch() {
             >
               {parsed.method}
             </span>
-            <span className="min-w-0 truncate font-mono text-xs text-[var(--color-text)]">
-              {parsed.url}
-            </span>
-            {headerCount > 0 && (
-              <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
-                {headerCount} header{headerCount !== 1 ? 's' : ''}
-              </span>
-            )}
-            {parsed.body && (
-              <span className="shrink-0 text-2xs text-[var(--color-text-muted)]">
-                body: {parsed.body.length} chars
-              </span>
-            )}
-            <ToolbarSpacer />
+          )}
+          <DocumentFileActions
+            open={{
+              label: 'Open cURL command',
+              title: `Open a cURL command (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+          />
+          <ToolbarGroup label="Template actions" separated>
             <Button
-              variant="ghost"
-              size="xs"
-              onClick={handleTestInApiClient}
-              title="Open this request in API Client"
-              className="shrink-0 gap-1"
+              variant="secondary"
+              size="sm"
+              onClick={handleLoadSample}
+              disabled={!TOOL_SAMPLES['curl-to-fetch']}
+              title="Load a sample cURL command"
+              className="gap-1"
             >
-              <PlayIcon size={12} />
-              Test in API Client
+              <FilesIcon size={14} aria-hidden="true" />
+              Load sample
             </Button>
-          </Toolbar>
-        )
+          </ToolbarGroup>
+          <ToolbarGroup label="Converted output" separated>
+            <CopyButton text={output} label="Copy generated request" />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleExport()}
+              disabled={!output}
+              title={`Export generated request (${formatShortcut('mod+s')})`}
+              className="gap-1"
+            >
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
+              Export
+            </Button>
+            {parsed && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleTestInApiClient}
+                title="Open this request in API Client"
+                className="gap-1"
+              >
+                <PlayIcon size={14} aria-hidden="true" />
+                Test in API Client
+              </Button>
+            )}
+          </ToolbarGroup>
+        </DocumentToolbar>
       }
     >
       <SplitPane
@@ -424,7 +510,6 @@ export default function CurlToFetch() {
               activeTab={state.outputTab}
               onTabChange={(id) => updateState({ outputTab: id })}
             />
-            <CopyButton text={output} className="mr-2" />
           </div>
           {parsed ? (
             <div className="min-h-0 flex-1 overflow-hidden">
@@ -446,17 +531,6 @@ export default function CurlToFetch() {
                 size="sm"
                 title="Paste a cURL command on the left"
                 description="Copy as cURL from any browser's network panel. The command is parsed here — nothing is sent."
-                action={
-                  TOOL_SAMPLES['curl-to-fetch'] ? (
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => updateState({ input: TOOL_SAMPLES['curl-to-fetch'] ?? '' })}
-                    >
-                      Load sample
-                    </Button>
-                  ) : undefined
-                }
               />
             </div>
           )}

--- a/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
+++ b/apps/cockpit/src/tools/diff-viewer/DiffViewer.tsx
@@ -8,6 +8,7 @@ import {
   CaretDownIcon,
   CaretUpIcon,
   CheckCircleIcon,
+  DownloadSimpleIcon,
   GitDiffIcon,
   SlidersHorizontalIcon,
   TrashIcon,
@@ -28,7 +29,8 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Toolbar, ToolbarGroup, ToolbarSpacer } from '@/components/shared/Toolbar'
-import { buildExportFilename, exportFile } from '@/lib/file-io'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
+import { buildExportFilename, exportFile, openFileDialog } from '@/lib/file-io'
 import { extensionForLanguage } from '@/tools/code-formatter/languages'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -37,6 +39,7 @@ import type { DiffWorker } from '@/workers/diff.worker'
 import DiffWorkerFactory from '@/workers/diff.worker?worker'
 import { formatShortcut } from '@/lib/shortcut-label'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { languageFromFilename } from '@/tools/code-formatter/languages'
 
 const { sanitize } = DOMPurify
@@ -468,6 +471,15 @@ export default function DiffViewer() {
     )
   }, [rawPatch, setLastAction, state.language])
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
   const loadSample = useCallback(() => {
     updateState({ left: DIFF_VIEWER_SAMPLE.left, right: DIFF_VIEWER_SAMPLE.right })
   }, [updateState])
@@ -586,6 +598,15 @@ export default function DiffViewer() {
               )}
             </span>
 
+            <DocumentFileActions
+              separated={false}
+              open={{
+                label: 'Open comparison file',
+                title: `Open the next comparison file (${formatShortcut('mod+o')})`,
+                onClick: () => void handleOpen(),
+              }}
+            />
+
             <ToolbarSpacer />
 
             <ToolbarGroup>
@@ -619,8 +640,22 @@ export default function DiffViewer() {
                 loading={isComparing}
                 title={`Compare both sides (${formatShortcut('mod+enter')})`}
               >
+                <GitDiffIcon size={14} aria-hidden="true" />
                 Compare
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
+              </Button>
+              <CopyButton text={rawPatch} label="Copy patch" />
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleSavePatch}
+                disabled={!rawPatch || identical}
+                title="Export the unified patch"
+                aria-label="Export patch"
+                className="gap-1"
+              >
+                <DownloadSimpleIcon size={14} aria-hidden="true" />
+                Export
               </Button>
             </ToolbarGroup>
           </Toolbar>
@@ -685,19 +720,6 @@ export default function DiffViewer() {
                 checked={state.jsonMode}
                 onChange={(checked) => updateState({ jsonMode: checked })}
               />
-              <ToolbarSpacer />
-              <ToolbarGroup>
-                <CopyButton text={rawPatch} label="Copy patch" />
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleSavePatch}
-                  disabled={!rawPatch || identical}
-                  title="Save the unified patch to a file"
-                >
-                  Save patch…
-                </Button>
-              </ToolbarGroup>
             </Toolbar>
           )}
         </div>

--- a/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
+++ b/apps/cockpit/src/tools/html-validator/HtmlValidator.tsx
@@ -3,11 +3,10 @@ import Editor, { type OnMount } from '@monaco-editor/react'
 import {
   CaretDownIcon,
   CaretUpIcon,
+  BroomIcon,
   CheckCircleIcon,
   FileHtmlIcon,
-  FilePlusIcon,
-  FloppyDiskIcon,
-  FolderOpenIcon,
+  FilesIcon,
   FrameCornersIcon,
   InfoIcon,
   ListBulletsIcon,
@@ -33,8 +32,9 @@ import { Select } from '@/components/shared/Input'
 import { SegmentedControl, type SegmentedControlOption } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
-import { openFileDialog, saveFileDialog, filenameFromPath } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -417,7 +417,7 @@ export default function HtmlValidator() {
     }
   }, [requestDocument, setLastAction])
 
-  const handleSave = useCallback(async () => {
+  const handleSaveAs = useCallback(async () => {
     const snapshot = inputRef.current
     if (!snapshot.trim()) {
       setLastAction('Nothing to save yet', 'info')
@@ -435,6 +435,25 @@ export default function HtmlValidator() {
       setLastAction(err instanceof Error ? err.message : 'Save failed', 'error')
     }
   }, [state.fileName, updateState, setLastAction])
+
+  const handleSave = useCallback(async () => {
+    const snapshot = inputRef.current
+    if (!snapshot.trim()) {
+      setLastAction('Nothing to save yet', 'info')
+      return
+    }
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, snapshot)
+      updateState({ savedContent: snapshot })
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(err instanceof Error ? err.message : 'Save failed', 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction, updateState])
 
   // --- Format ----------------------------------------------------------
 
@@ -639,6 +658,27 @@ export default function HtmlValidator() {
           }
         />
 
+        <DocumentFileActions
+          newDocument={{ label: 'New HTML document', onClick: handleNew }}
+          open={{
+            label: 'Open HTML file',
+            title: `Open an .html file (${formatShortcut('mod+o')})`,
+            onClick: () => void handleOpen(),
+          }}
+          save={{
+            label: 'Save HTML document',
+            title: `Save the document (${formatShortcut('mod+s')})`,
+            onClick: () => void handleSave(),
+            disabled: !hasInput,
+          }}
+          saveAs={{
+            label: 'Save HTML document as',
+            title: 'Save the HTML document to a new file',
+            onClick: () => void handleSaveAs(),
+            disabled: !hasInput,
+          }}
+        />
+
         <ToolbarGroup label="View controls" separated>
           <SegmentedControl
             aria-label="View mode"
@@ -646,36 +686,6 @@ export default function HtmlValidator() {
             value={viewMode}
             onChange={(next) => updateState({ viewMode: next })}
           />
-        </ToolbarGroup>
-
-        <ToolbarGroup label="Document actions" separated>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={handleNew}
-            title="New HTML document"
-            aria-label="New HTML document"
-          >
-            <FilePlusIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={() => void handleOpen()}
-            title={`Open an .html file (${formatShortcut('mod+o')})`}
-            aria-label="Open HTML file"
-          >
-            <FolderOpenIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            variant="icon"
-            size="sm"
-            onClick={() => void handleSave()}
-            title={`Save the document (${formatShortcut('mod+s')})`}
-            aria-label="Save HTML document"
-          >
-            <FloppyDiskIcon size={14} aria-hidden="true" />
-          </Button>
         </ToolbarGroup>
 
         <ToolbarGroup label="Template actions" separated>
@@ -690,7 +700,14 @@ export default function HtmlValidator() {
               </option>
             ))}
           </Select>
-          <Button variant="secondary" size="sm" onClick={handleLoadTemplate}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleLoadTemplate}
+            title="Load the selected HTML template"
+            className="gap-1"
+          >
+            <FilesIcon size={14} aria-hidden="true" />
             Load
           </Button>
         </ToolbarGroup>
@@ -704,6 +721,7 @@ export default function HtmlValidator() {
             loading={isFormatting}
             title={`Reformat the markup (${formatShortcut('mod+enter')})`}
           >
+            <BroomIcon size={14} aria-hidden="true" />
             Format
             <Kbd keys="mod+enter" variant="inline" className="ml-1" />
           </Button>

--- a/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
+++ b/apps/cockpit/src/tools/json-schema-validator/JsonSchemaValidator.tsx
@@ -3,10 +3,12 @@ import Editor, { type OnMount } from '@monaco-editor/react'
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http'
 import {
   ArrowUUpLeftIcon,
+  ArticleIcon,
+  BroomIcon,
   CheckCircleIcon,
   CrosshairSimpleIcon,
   DownloadSimpleIcon,
-  FloppyDiskIcon,
+  FilesIcon,
   MagicWandIcon,
   ShieldCheckIcon,
   WarningCircleIcon,
@@ -14,6 +16,7 @@ import {
 import { useToolState } from '@/hooks/useToolState'
 import { useToolHistory } from '@/hooks/useToolHistory'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useMonaco } from '@/hooks/useMonaco'
 import { Button } from '@/components/shared/Button'
@@ -23,8 +26,9 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { Input, Select } from '@/components/shared/Input'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentToolbar } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { openFileDialog, saveFileDialog } from '@/lib/file-io'
 import {
   MAX_ISSUES,
   generateSample,
@@ -383,6 +387,15 @@ export default function JsonSchemaValidator() {
     [state.dataFileName, state.schemaFileName, setLastAction]
   )
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
   // --- Schema from a URL -----------------------------------------------
 
   const fetchIdRef = useRef(0)
@@ -564,6 +577,14 @@ export default function JsonSchemaValidator() {
             )}
           </div>
 
+          <DocumentFileActions
+            open={{
+              label: 'Open JSON data or schema',
+              title: `Open JSON data or schema (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+          />
+
           <div className="ml-auto flex flex-wrap items-center gap-2">
             <Select
               aria-label="Template"
@@ -588,6 +609,7 @@ export default function JsonSchemaValidator() {
               onClick={() => loadTemplate(templateKey)}
               title="Replace both panes with this template and its sample"
             >
+              <FilesIcon size={14} aria-hidden="true" />
               Load template
             </Button>
             <Button
@@ -605,7 +627,9 @@ export default function JsonSchemaValidator() {
               size="sm"
               onClick={handleGenerateSample}
               title="Replace the data with a sample the schema accepts"
+              className="gap-1"
             >
+              <ArticleIcon size={14} aria-hidden="true" />
               Sample data
             </Button>
             <Button
@@ -618,6 +642,7 @@ export default function JsonSchemaValidator() {
                 strict ? 'border-[var(--color-warning)] text-[var(--color-warning)]' : undefined
               }
             >
+              <ShieldCheckIcon size={14} aria-hidden="true" />
               Strict
             </Button>
             {undoBuffer && (
@@ -861,7 +886,14 @@ function EditorPane({
         actions={
           <>
             {headerExtras}
-            <Button variant="ghost" size="xs" onClick={onFormat} disabled={!value.trim()}>
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onFormat}
+              disabled={!value.trim()}
+              className="gap-1"
+            >
+              <BroomIcon size={14} aria-hidden="true" />
               Format
             </Button>
             <CopyButton text={value} label={copyLabel} className="min-w-0" />
@@ -870,12 +902,12 @@ function EditorPane({
               size="xs"
               onClick={onSave}
               disabled={!value.trim()}
-              aria-label={`Save ${title.toLowerCase()} to file`}
-              title={`Save to a file (${formatShortcut('mod+s')})`}
+              aria-label={`Export ${title.toLowerCase()}`}
+              title={`Export to a file (${formatShortcut('mod+s')})`}
               className="gap-1"
             >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
+              Export
             </Button>
           </>
         }

--- a/apps/cockpit/src/tools/json-tools/JsonTools.tsx
+++ b/apps/cockpit/src/tools/json-tools/JsonTools.tsx
@@ -6,13 +6,14 @@ import {
   ArrowsOutLineVerticalIcon,
   ArrowUUpLeftIcon,
   BracketsCurlyIcon,
+  BroomIcon,
   CaretDownIcon,
   CaretUpIcon,
   CheckCircleIcon,
   CrosshairSimpleIcon,
-  FloppyDiskIcon,
   MagnifyingGlassIcon,
   SortAscendingIcon,
+  TreeStructureIcon,
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -21,6 +22,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { Button } from '@/components/shared/Button'
@@ -32,8 +34,9 @@ import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -51,6 +54,7 @@ type JsonView = 'source' | 'tree' | 'table'
 type JsonToolsState = {
   input: string
   fileName: string | null
+  filePath: string | null
   /**
    * Tree and Table used to be tabs that replaced the editor, so inspecting a
    * document meant leaving it: every fix was "switch tab, edit, switch back".
@@ -367,6 +371,7 @@ export default function JsonTools() {
   const [state, updateState] = useToolState<JsonToolsState>('json-tools', {
     input: '',
     fileName: null,
+    filePath: null,
     view: 'source',
     query: '',
     queryOpen: false,
@@ -489,13 +494,41 @@ export default function JsonTools() {
     setLastAction(`Undid ${undoBuffer.label.toLowerCase()}`, 'info')
   }, [setLastAction, undoBuffer, updateState])
 
-  const handleSave = useCallback(() => {
-    void saveFileDialog(inputRef.current, state.fileName ?? 'data.json').then(
-      (path) => setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-      (err: unknown) =>
-        setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-    )
-  }, [state.fileName, setLastAction])
+  const handleSaveAs = useCallback(async () => {
+    try {
+      const path = await saveFileDialog(inputRef.current, state.fileName ?? 'data.json')
+      if (!path) {
+        setLastAction('Save cancelled', 'info')
+        return
+      }
+      updateState({ filePath: path, fileName: filenameFromPath(path) })
+      setLastAction(`Saved ${path}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.fileName, setLastAction, updateState])
+
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, inputRef.current)
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction])
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
 
   // The parse error knows where it is; without this the user has to count
   // characters to find `position 428`.
@@ -514,6 +547,7 @@ export default function JsonTools() {
       updateState({
         input: action.content,
         fileName: action.filename,
+        filePath: action.path ?? null,
         allowComments: action.filename.toLowerCase().endsWith('.jsonc'),
       })
       setError(null)
@@ -524,7 +558,7 @@ export default function JsonTools() {
         setLastAction('Nothing to save yet', 'info')
         return
       }
-      handleSave()
+      void handleSave()
     }
   })
 
@@ -582,7 +616,13 @@ export default function JsonTools() {
                   <Button
                     variant="secondary"
                     size="sm"
-                    onClick={() => updateState({ input: TOOL_SAMPLES['json-tools'] ?? '' })}
+                    onClick={() =>
+                      updateState({
+                        input: TOOL_SAMPLES['json-tools'] ?? '',
+                        fileName: null,
+                        filePath: null,
+                      })
+                    }
                   >
                     Load sample
                   </Button>
@@ -603,6 +643,7 @@ export default function JsonTools() {
           <DocumentToolbar aria-label="JSON document actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}
+              titleTooltip={state.filePath ?? state.fileName ?? 'Untitled'}
               icon={
                 <BracketsCurlyIcon
                   size={16}
@@ -626,6 +667,24 @@ export default function JsonTools() {
                   />
                 ) : undefined
               }
+            />
+            <DocumentFileActions
+              open={{
+                label: 'Open JSON file',
+                title: `Open a JSON file (${formatShortcut('mod+o')})`,
+                onClick: () => void handleOpen(),
+              }}
+              save={{
+                label: 'Save JSON file',
+                title: `Save the JSON (${formatShortcut('mod+s')})`,
+                onClick: () => void handleSave(),
+                disabled: !hasInput,
+              }}
+              saveAs={{
+                label: 'Save JSON file as',
+                onClick: () => void handleSaveAs(),
+                disabled: !hasInput,
+              }}
             />
             {parsed.status === 'invalid' && parsed.location && (
               <Button
@@ -654,10 +713,18 @@ export default function JsonTools() {
                 loading={isFormatting}
                 title={`Format the document (${formatShortcut('mod+enter')})`}
               >
+                <BroomIcon size={14} aria-hidden="true" />
                 Format
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
-              <Button variant="secondary" size="sm" onClick={handleMinify} disabled={!isValid}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleMinify}
+                disabled={!isValid}
+                className="gap-1"
+              >
+                <ArrowsInLineVerticalIcon size={14} aria-hidden="true" />
                 Minify
               </Button>
               <Button
@@ -677,20 +744,6 @@ export default function JsonTools() {
                 </Button>
               )}
               <CopyButton text={input} label="Copy JSON" />
-              {/* Labelled, like every other button in this group. As a bare icon it was the only
-                  unlabelled control on the row and the dimmest thing on it, which read as
-                  disabled rather than as an action. */}
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSave}
-                disabled={!hasInput}
-                title={`Save to a file (${formatShortcut('mod+s')})`}
-                className="gap-1"
-              >
-                <FloppyDiskIcon size={14} aria-hidden="true" />
-                Save
-              </Button>
               <Button
                 variant="ghost"
                 size="sm"
@@ -698,6 +751,7 @@ export default function JsonTools() {
                 disabled={!hasInput}
                 title="Open this JSON in YAML Tools"
               >
+                <TreeStructureIcon size={14} aria-hidden="true" />
                 YAML
               </Button>
             </ToolbarGroup>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -1066,8 +1066,16 @@ export default function MarkdownEditor() {
 
           <DocumentFileActions
             newDocument={{ label: 'New markdown document', onClick: handleNewDocument }}
-            open={{ label: 'Open markdown file', onClick: () => void handleOpen() }}
-            save={{ label: 'Save markdown document', onClick: () => void handleSave() }}
+            open={{
+              label: 'Open markdown file',
+              title: `Open a markdown file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+            save={{
+              label: 'Save markdown document',
+              title: `Save the document (${formatShortcut('mod+s')})`,
+              onClick: () => void handleSave(),
+            }}
             saveAs={{ label: 'Save markdown document as', onClick: () => void handleSaveAs() }}
           />
 

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -9,6 +9,7 @@ import { SelectionContextToolbar } from '@/components/shared/SelectionContextToo
 import { SplitPane } from '@/components/shared/SplitPane'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
 import { useToolAction } from '@/hooks/useToolAction'
 import { useIsInstanceActive } from '@/app/tool-instance'
@@ -37,9 +38,9 @@ import {
   CaretDownIcon,
   CodeIcon,
   CopyIcon,
-  FilePlusIcon,
-  FloppyDiskIcon,
-  FolderOpenIcon,
+  DownloadSimpleIcon,
+  FileMdIcon,
+  FilesIcon,
   ImageIcon,
   LinkIcon,
   MagnifyingGlassIcon,
@@ -513,12 +514,10 @@ export default function MarkdownEditor() {
   const editorContainerRef = useRef<HTMLDivElement>(null)
   const [showTemplates, setShowTemplates] = useState(false)
   const [showExport, setShowExport] = useState(false)
-  const [showFileMenu, setShowFileMenu] = useState(false)
   const [activeModal, setActiveModal] = useState<'link' | 'image' | 'code' | 'table' | null>(null)
   const [pendingDocument, setPendingDocument] = useState<PendingDocument | null>(null)
   const templatesRef = useRef<HTMLDivElement>(null)
   const exportRef = useRef<HTMLDivElement>(null)
-  const fileMenuRef = useRef<HTMLDivElement>(null)
 
   // ─── Hooks ────────────────────────────────────────────────────────
 
@@ -637,17 +636,6 @@ export default function MarkdownEditor() {
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
   }, [showExport])
-
-  useEffect(() => {
-    if (!showFileMenu) return
-    const handler = (e: MouseEvent) => {
-      if (fileMenuRef.current && !fileMenuRef.current.contains(e.target as Node)) {
-        setShowFileMenu(false)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [showFileMenu])
 
   // ─── Formatting insertion ────────────────────────────────────────
 
@@ -1067,6 +1055,20 @@ export default function MarkdownEditor() {
             // The path is context, not a result — announcing it on every open
             // would talk over the Modified/Saved indicator that matters.
             statusLive={false}
+            icon={
+              <FileMdIcon
+                size={16}
+                aria-hidden="true"
+                className="shrink-0 text-[var(--color-text-muted)]"
+              />
+            }
+          />
+
+          <DocumentFileActions
+            newDocument={{ label: 'New markdown document', onClick: handleNewDocument }}
+            open={{ label: 'Open markdown file', onClick: () => void handleOpen() }}
+            save={{ label: 'Save markdown document', onClick: () => void handleSave() }}
+            saveAs={{ label: 'Save markdown document as', onClick: () => void handleSaveAs() }}
           />
 
           <ToolbarGroup label="View options" separated>
@@ -1138,108 +1140,6 @@ export default function MarkdownEditor() {
             </Button>
           </ToolbarGroup>
 
-          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-[var(--color-border)]" />
-          <Button
-            type="button"
-            variant="icon"
-            size="sm"
-            onClick={handleNewDocument}
-            title="New document"
-            aria-label="New document"
-          >
-            <FilePlusIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant="icon"
-            size="sm"
-            onClick={() => void handleOpen()}
-            title="Open markdown file"
-            aria-label="Open markdown file"
-          >
-            <FolderOpenIcon size={14} aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={() => void handleSave()}
-            className="gap-1.5"
-          >
-            <FloppyDiskIcon size={14} aria-hidden="true" /> Save
-          </Button>
-
-          <div ref={fileMenuRef} className="relative">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowFileMenu(!showFileMenu)}
-              className={
-                showFileMenu ? 'bg-[var(--color-accent-dim)] text-[var(--color-accent)]' : ''
-              }
-              aria-expanded={showFileMenu}
-              aria-haspopup="menu"
-            >
-              File <CaretDownIcon size={12} aria-hidden="true" className="ml-1" />
-            </Button>
-            {showFileMenu && (
-              <div
-                role="menu"
-                className="absolute right-0 top-full z-20 mt-1 min-w-36 rounded border border-[var(--color-border)] bg-[var(--color-bg)] py-1 shadow-lg"
-              >
-                <Button
-                  role="menuitem"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    handleNewDocument()
-                    setShowFileMenu(false)
-                  }}
-                  className="w-full justify-start"
-                >
-                  New
-                </Button>
-                <Button
-                  role="menuitem"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    void handleOpen()
-                    setShowFileMenu(false)
-                  }}
-                  className="w-full justify-start"
-                >
-                  Open…
-                </Button>
-                <Button
-                  role="menuitem"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    void handleSave()
-                    setShowFileMenu(false)
-                  }}
-                  className="w-full justify-start"
-                >
-                  Save
-                </Button>
-                <Button
-                  role="menuitem"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    void handleSaveAs()
-                    setShowFileMenu(false)
-                  }}
-                  className="w-full justify-start"
-                >
-                  Save As…
-                </Button>
-              </div>
-            )}
-          </div>
-
           <div ref={templatesRef} className="relative">
             <Button
               type="button"
@@ -1252,6 +1152,7 @@ export default function MarkdownEditor() {
               aria-expanded={showTemplates}
               aria-haspopup="menu"
             >
+              <FilesIcon size={14} aria-hidden="true" />
               Templates
             </Button>
             {showTemplates && (
@@ -1285,6 +1186,7 @@ export default function MarkdownEditor() {
               aria-expanded={showExport}
               aria-haspopup="menu"
             >
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
               Export <CaretDownIcon size={12} aria-hidden="true" />
             </Button>
             {showExport && (

--- a/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
+++ b/apps/cockpit/src/tools/mermaid-editor/MermaidEditor.tsx
@@ -4,9 +4,7 @@ import {
   ArrowRightIcon,
   CopyIcon,
   DownloadSimpleIcon,
-  FilePlusIcon,
-  FloppyDiskIcon,
-  FolderOpenIcon,
+  FilesIcon,
   GraphIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -21,6 +19,7 @@ import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { SplitPane } from '@/components/shared/SplitPane'
 import { Select } from '@/components/shared/Select'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { Toggle } from '@/components/shared/Toggle'
 import { useUiStore } from '@/stores/ui.store'
@@ -629,6 +628,25 @@ export default function MermaidEditor() {
             status={statusText}
           />
 
+          <DocumentFileActions
+            newDocument={{ label: 'New diagram', onClick: handleNewDiagram }}
+            open={{
+              label: 'Open Mermaid file',
+              title: `Open a .mmd file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+            save={{
+              label: 'Save Mermaid source',
+              title: `Save the source (${formatShortcut('mod+s')})`,
+              onClick: () => void handleSave(),
+            }}
+            saveAs={{
+              label: 'Save Mermaid source as',
+              title: 'Save the source to a new file',
+              onClick: () => void handleSaveAs(),
+            }}
+          />
+
           <ToolbarGroup label="View controls" separated>
             <SegmentedControl
               aria-label="Editor view mode"
@@ -636,36 +654,6 @@ export default function MermaidEditor() {
               value={mode}
               onChange={(next) => updateState({ mode: next })}
             />
-          </ToolbarGroup>
-
-          <ToolbarGroup label="Document actions" separated>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={handleNewDiagram}
-              title="New diagram"
-              aria-label="New diagram"
-            >
-              <FilePlusIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleOpen()}
-              title={`Open a .mmd file (${formatShortcut('mod+o')})`}
-              aria-label="Open Mermaid file"
-            >
-              <FolderOpenIcon size={14} aria-hidden="true" />
-            </Button>
-            <Button
-              variant="icon"
-              size="sm"
-              onClick={() => void handleSave()}
-              title={`Save the source (${formatShortcut('mod+s')})`}
-              aria-label="Save Mermaid source"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-            </Button>
           </ToolbarGroup>
 
           <ToolbarGroup label="Template actions" separated>
@@ -680,7 +668,14 @@ export default function MermaidEditor() {
                 </option>
               ))}
             </Select>
-            <Button variant="secondary" size="sm" onClick={() => handleLoadTemplate()}>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleLoadTemplate()}
+              title="Load the selected diagram template"
+              className="gap-1"
+            >
+              <FilesIcon size={14} aria-hidden="true" />
               Load
             </Button>
           </ToolbarGroup>
@@ -738,15 +733,17 @@ export default function MermaidEditor() {
             </Button>
           </ToolbarGroup>
 
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => void handleCopySource()}
-            className="gap-1"
-          >
-            <CopyIcon size={14} aria-hidden="true" />
-            Copy source
-          </Button>
+          <ToolbarGroup label="Source output" separated>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleCopySource()}
+              className="gap-1"
+            >
+              <CopyIcon size={14} aria-hidden="true" />
+              Copy source
+            </Button>
+          </ToolbarGroup>
         </DocumentToolbar>
       </header>
 

--- a/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
+++ b/apps/cockpit/src/tools/refactoring-toolkit/RefactoringToolkit.tsx
@@ -3,8 +3,9 @@ import Editor, { DiffEditor } from '@monaco-editor/react'
 import {
   ArrowCounterClockwiseIcon,
   ArrowsClockwiseIcon,
+  CheckIcon,
   CheckCircleIcon,
-  FloppyDiskIcon,
+  MagicWandIcon,
   MagnifyingGlassIcon,
   SlidersHorizontalIcon,
   WarningCircleIcon,
@@ -14,6 +15,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
@@ -22,9 +24,10 @@ import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { Checkbox } from '@/components/shared/Checkbox'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { REFACTORING_SAMPLE } from '@/lib/tool-samples'
 import type { RefactoringWorker } from '@/workers/refactoring.worker'
 import RefactoringWorkerFactory from '@/workers/refactoring.worker?worker'
@@ -47,6 +50,7 @@ type RefactoringView = 'source' | 'diff'
 type RefactoringState = {
   input: string
   fileName: string | null
+  filePath: string | null
   selectedTransforms: string[]
   language: string
   /** The transform list is a disclosure so an 800px-wide window still has an editor. */
@@ -126,6 +130,7 @@ export default function RefactoringToolkit() {
   const [state, updateState] = useToolState<RefactoringState>('refactoring-toolkit', {
     input: '',
     fileName: null,
+    filePath: null,
     selectedTransforms: [],
     language: 'javascript',
     panelOpen: true,
@@ -307,14 +312,42 @@ export default function RefactoringToolkit() {
     [visibleTransforms, state.selectedTransforms, updateState]
   )
 
-  const handleSave = useCallback(() => {
+  const handleSaveAs = useCallback(async () => {
     const defaultName = state.fileName ?? `refactored.${EXTENSION[language] ?? 'js'}`
-    void saveFileDialog(input, defaultName).then(
-      (path) => setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-      (err: unknown) =>
-        setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-    )
-  }, [state.fileName, language, input, setLastAction])
+    try {
+      const path = await saveFileDialog(input, defaultName)
+      if (!path) {
+        setLastAction('Save cancelled', 'info')
+        return
+      }
+      updateState({ filePath: path, fileName: filenameFromPath(path) })
+      setLastAction(`Saved ${path}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.fileName, language, input, setLastAction, updateState])
+
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, input)
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.fileName, input, handleSaveAs, setLastAction])
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
 
   useToolAction((action) => {
     if (action.type === 'open-file') {
@@ -322,6 +355,7 @@ export default function RefactoringToolkit() {
       updateState({
         input: action.content,
         fileName: action.filename,
+        filePath: action.path ?? null,
         selectedTransforms: [],
         view: 'source',
         lastApply: null,
@@ -338,7 +372,7 @@ export default function RefactoringToolkit() {
         setLastAction('Nothing to save yet', 'info')
         return
       }
-      handleSave()
+      void handleSave()
     }
     if (action.type === 'copy-output' && hasCode) {
       void copy(copyText, { success: 'Code copied', failure: 'Copy failed' })
@@ -366,6 +400,7 @@ export default function RefactoringToolkit() {
         <DocumentToolbar aria-label="Refactoring actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled'}
             icon={
               <ArrowsClockwiseIcon
                 size={16}
@@ -389,6 +424,25 @@ export default function RefactoringToolkit() {
                 />
               ) : undefined
             }
+          />
+
+          <DocumentFileActions
+            open={{
+              label: 'Open code file',
+              title: `Open a code file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+            save={{
+              label: 'Save code file',
+              title: `Save the code (${formatShortcut('mod+s')})`,
+              onClick: () => void handleSave(),
+              disabled: !hasCode,
+            }}
+            saveAs={{
+              label: 'Save code file as',
+              onClick: () => void handleSaveAs(),
+              disabled: !hasCode,
+            }}
           />
 
           <ToolbarGroup label="Refactoring options" separated>
@@ -453,6 +507,7 @@ export default function RefactoringToolkit() {
                   : `Apply the transforms to the buffer (${formatShortcut('mod+enter')})`
               }
             >
+              <CheckIcon size={14} aria-hidden="true" />
               {hasDestructive ? 'Apply (removes code)' : 'Apply'}
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
@@ -475,19 +530,8 @@ export default function RefactoringToolkit() {
               disabled={!hasCode}
               title="Open the current code in Code Formatter"
             >
+              <MagicWandIcon size={14} aria-hidden="true" />
               Format
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleSave}
-              disabled={!hasCode}
-              title={`Save the code to a file (${formatShortcut('mod+s')})`}
-              aria-label="Save code to file"
-              className="gap-1"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>
@@ -683,6 +727,7 @@ export default function RefactoringToolkit() {
                   updateState({
                     input: REFACTORING_SAMPLE,
                     fileName: null,
+                    filePath: null,
                     lastApply: null,
                     applyHistory: [],
                     customFind: '',

--- a/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
+++ b/apps/cockpit/src/tools/ts-playground/TsPlayground.tsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import {
   CheckCircleIcon,
+  DownloadSimpleIcon,
   FileTsIcon,
-  FloppyDiskIcon,
+  MagicWandIcon,
+  PlayIcon,
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -11,6 +13,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { Alert } from '@/components/shared/Alert'
@@ -20,9 +23,10 @@ import { Select } from '@/components/shared/Input'
 import { Toggle } from '@/components/shared/Toggle'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { SettingsPopover, SettingsRow, SettingsSection } from '@/components/shared/SettingsPopover'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { openFileDialog, saveFileDialog } from '@/lib/file-io'
 import { TS_PLAYGROUND_SAMPLE } from '@/lib/tool-samples'
 import type { Diagnostic } from '@/workers/typescript.api'
 import type { TypeScriptWorker } from '@/workers/typescript.worker'
@@ -248,6 +252,15 @@ export default function TsPlayground() {
     )
   }, [output, state.fileName, setLastAction])
 
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
+
   const loadExample = useCallback(() => {
     updateState({ input: TS_PLAYGROUND_SAMPLE, fileName: null })
   }, [updateState])
@@ -326,6 +339,14 @@ export default function TsPlayground() {
             }
           />
 
+          <DocumentFileActions
+            open={{
+              label: 'Open TypeScript file',
+              title: `Open a TypeScript file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+          />
+
           <ToolbarGroup label="Playground actions" separated>
             <SettingsPopover
               label="Options"
@@ -388,6 +409,7 @@ export default function TsPlayground() {
               // then disable the very button that requests an announced one.
               title={`Compile now (${formatShortcut('mod+enter')})`}
             >
+              <PlayIcon size={14} aria-hidden="true" />
               Compile
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
@@ -401,6 +423,7 @@ export default function TsPlayground() {
               }
               title="Open the compiled JavaScript in Code Formatter"
             >
+              <MagicWandIcon size={14} aria-hidden="true" />
               Format output
             </Button>
             <Button
@@ -408,12 +431,12 @@ export default function TsPlayground() {
               size="sm"
               onClick={handleSave}
               disabled={!output}
-              title={`Save the JavaScript output to a file (${formatShortcut('mod+s')})`}
-              aria-label="Save output to file"
+              title={`Export the JavaScript output (${formatShortcut('mod+s')})`}
+              aria-label="Export JavaScript output"
               className="gap-1"
             >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
+              <DownloadSimpleIcon size={14} aria-hidden="true" />
+              Export
             </Button>
           </ToolbarGroup>
         </DocumentToolbar>

--- a/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
+++ b/apps/cockpit/src/tools/xml-tools/XmlTools.tsx
@@ -4,9 +4,9 @@ import {
   ArrowsInLineVerticalIcon,
   ArrowsOutLineVerticalIcon,
   BracketsAngleIcon,
+  BroomIcon,
   CheckCircleIcon,
   CrosshairSimpleIcon,
-  FloppyDiskIcon,
   WarningCircleIcon,
 } from '@phosphor-icons/react'
 import { useToolState } from '@/hooks/useToolState'
@@ -15,6 +15,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker, type WorkerRpc } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
@@ -25,8 +26,9 @@ import { Input, Select } from '@/components/shared/Input'
 import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import type { XmlWorker } from '@/workers/xml.worker'
 import type { XmlInspection, XmlIssue, XmlTreeNode } from '@/workers/xml.api'
@@ -42,6 +44,7 @@ type XmlView = 'source' | 'tree' | 'json' | 'xpath'
 type XmlToolsState = {
   input: string
   fileName: string | null
+  filePath: string | null
   /**
    * Tree, JSON and XPath used to be tabs that replaced the editor, so every
    * "look at the document, fix the document" loop cost two tab switches. They
@@ -118,6 +121,7 @@ export default function XmlTools() {
   const [state, updateState] = useToolState<XmlToolsState>('xml-tools', {
     input: '',
     fileName: null,
+    filePath: null,
     view: 'source',
     xpath: '',
     indent: 2,
@@ -238,13 +242,41 @@ export default function XmlTools() {
     [worker, indent, updateState, setLastAction, recordRun]
   )
 
-  const handleSave = useCallback(() => {
-    void saveFileDialog(inputRef.current, state.fileName ?? 'document.xml').then(
-      (path) => setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-      (err: unknown) =>
-        setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-    )
-  }, [state.fileName, setLastAction])
+  const handleSaveAs = useCallback(async () => {
+    try {
+      const path = await saveFileDialog(inputRef.current, state.fileName ?? 'document.xml')
+      if (!path) {
+        setLastAction('Save cancelled', 'info')
+        return
+      }
+      updateState({ filePath: path, fileName: filenameFromPath(path) })
+      setLastAction(`Saved ${path}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.fileName, setLastAction, updateState])
+
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, inputRef.current)
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction])
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
 
   // The parser knows where it went wrong; without this the user reads a line
   // number and then scrolls to find it by hand.
@@ -263,7 +295,11 @@ export default function XmlTools() {
 
   useToolAction((action) => {
     if (action.type === 'open-file') {
-      updateState({ input: action.content, fileName: action.filename })
+      updateState({
+        input: action.content,
+        fileName: action.filename,
+        filePath: action.path ?? null,
+      })
       setError(null)
       setLastAction(`Opened ${action.filename}`, 'success')
     }
@@ -272,7 +308,7 @@ export default function XmlTools() {
         setLastAction('Nothing to save yet', 'info')
         return
       }
-      handleSave()
+      void handleSave()
     }
     if (action.type === 'copy-output' && inputRef.current.trim()) {
       void copy(inputRef.current, { success: 'Copied XML' })
@@ -293,6 +329,7 @@ export default function XmlTools() {
         <DocumentToolbar aria-label="XML document actions">
           <DocumentIdentity
             title={state.fileName ?? 'Untitled'}
+            titleTooltip={state.filePath ?? state.fileName ?? 'Untitled'}
             icon={
               <BracketsAngleIcon
                 size={16}
@@ -316,6 +353,24 @@ export default function XmlTools() {
                 />
               ) : undefined
             }
+          />
+          <DocumentFileActions
+            open={{
+              label: 'Open XML file',
+              title: `Open an XML file (${formatShortcut('mod+o')})`,
+              onClick: () => void handleOpen(),
+            }}
+            save={{
+              label: 'Save XML file',
+              title: `Save the XML (${formatShortcut('mod+s')})`,
+              onClick: () => void handleSave(),
+              disabled: !hasInput,
+            }}
+            saveAs={{
+              label: 'Save XML file as',
+              onClick: () => void handleSaveAs(),
+              disabled: !hasInput,
+            }}
           />
           {blockingIssue?.line !== undefined && (
             <Button
@@ -359,6 +414,7 @@ export default function XmlTools() {
               loading={isBusy}
               title={`Format the document (${formatShortcut('mod+enter')})`}
             >
+              <BroomIcon size={14} aria-hidden="true" />
               Format
               <Kbd keys="mod+enter" variant="inline" className="ml-1" />
             </Button>
@@ -368,21 +424,10 @@ export default function XmlTools() {
               onClick={() => void runTransform('minify')}
               disabled={!hasInput || isBusy}
             >
+              <ArrowsInLineVerticalIcon size={14} aria-hidden="true" />
               Minify
             </Button>
             <CopyButton text={input} label="Copy XML" />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleSave}
-              disabled={!hasInput}
-              title={`Save to a file (${formatShortcut('mod+s')})`}
-              aria-label="Save XML to file"
-              className="gap-1"
-            >
-              <FloppyDiskIcon size={14} aria-hidden="true" />
-              Save
-            </Button>
           </ToolbarGroup>
         </DocumentToolbar>
       }
@@ -443,7 +488,13 @@ export default function XmlTools() {
                       <Button
                         variant="secondary"
                         size="sm"
-                        onClick={() => updateState({ input: TOOL_SAMPLES['xml-tools'] ?? '' })}
+                        onClick={() =>
+                          updateState({
+                            input: TOOL_SAMPLES['xml-tools'] ?? '',
+                            fileName: null,
+                            filePath: null,
+                          })
+                        }
                       >
                         Load sample
                       </Button>

--- a/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
+++ b/apps/cockpit/src/tools/yaml-tools/YamlTools.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import {
   ArrowsInLineVerticalIcon,
   ArrowsOutLineVerticalIcon,
   ArrowUUpLeftIcon,
+  BracketsCurlyIcon,
+  BroomIcon,
   CheckCircleIcon,
   CrosshairSimpleIcon,
   FileCodeIcon,
-  FloppyDiskIcon,
   MagnifyingGlassIcon,
   SortAscendingIcon,
   WarningCircleIcon,
@@ -18,6 +19,7 @@ import { useMonaco } from '@/hooks/useMonaco'
 import { useWorker } from '@/hooks/useWorker'
 import { useKeyboardShortcut } from '@/hooks/useKeyboardShortcut'
 import { useToolAction } from '@/hooks/useToolAction'
+import { dispatchToolAction } from '@/lib/tool-actions'
 import { CopyButton } from '@/components/shared/CopyButton'
 import { Kbd } from '@/components/shared/Kbd'
 import { PaneHeader } from '@/components/shared/PaneHeader'
@@ -29,8 +31,9 @@ import { SegmentedControl } from '@/components/shared/SegmentedControl'
 import { Input, Select } from '@/components/shared/Input'
 import { ToolLayout } from '@/components/shared/ToolLayout'
 import { DocumentIdentity, DocumentToolbar, ToolbarGroup } from '@/components/shared/Toolbar'
+import { DocumentFileActions } from '@/components/shared/DocumentFileActions'
 import { useUiStore } from '@/stores/ui.store'
-import { saveFileDialog } from '@/lib/file-io'
+import { filenameFromPath, openFileDialog, saveFileDialog, saveFileToPath } from '@/lib/file-io'
 import { TOOL_SAMPLES } from '@/lib/tool-samples'
 import type { FormatterWorker } from '@/workers/formatter.worker'
 import FormatterWorkerFactory from '@/workers/formatter.worker?worker'
@@ -56,6 +59,7 @@ type YamlView = 'source' | 'tree' | 'table' | 'json'
 type YamlToolsState = {
   input: string
   fileName: string | null
+  filePath: string | null
   /**
    * Tree and JSON used to be tabs that replaced the editor, so inspecting a
    * document meant leaving it, and the conversion tab kept its own second
@@ -103,6 +107,7 @@ export default function YamlTools() {
   const [state, updateState] = useToolState<YamlToolsState>('yaml-tools', {
     input: '',
     fileName: null,
+    filePath: null,
     view: 'source',
     tabWidth: 2,
     query: '',
@@ -116,6 +121,7 @@ export default function YamlTools() {
   )
 
   const setLastAction = useUiStore((s) => s.setLastAction)
+  const queryId = useId()
   const copy = useCopyToClipboard()
   const [error, setError] = useState<string | null>(null)
   const [isFormatting, setIsFormatting] = useState(false)
@@ -292,13 +298,41 @@ export default function YamlTools() {
     setLastAction('Reverted', 'info')
   }, [undoBuffer, updateState, setLastAction])
 
-  const handleSave = useCallback(() => {
-    void saveFileDialog(inputRef.current, state.fileName ?? 'document.yaml').then(
-      (path) => setLastAction(path ? `Saved ${path}` : 'Save cancelled', path ? 'success' : 'info'),
-      (err: unknown) =>
-        setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
-    )
-  }, [state.fileName, setLastAction])
+  const handleSaveAs = useCallback(async () => {
+    try {
+      const path = await saveFileDialog(inputRef.current, state.fileName ?? 'document.yaml')
+      if (!path) {
+        setLastAction('Save cancelled', 'info')
+        return
+      }
+      updateState({ filePath: path, fileName: filenameFromPath(path) })
+      setLastAction(`Saved ${path}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.fileName, setLastAction, updateState])
+
+  const handleSave = useCallback(async () => {
+    if (!state.filePath) {
+      await handleSaveAs()
+      return
+    }
+    try {
+      await saveFileToPath(state.filePath, inputRef.current)
+      setLastAction(`Saved ${state.fileName ?? filenameFromPath(state.filePath)}`, 'success')
+    } catch (err) {
+      setLastAction(`Save failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [state.filePath, state.fileName, handleSaveAs, setLastAction])
+
+  const handleOpen = useCallback(async () => {
+    try {
+      const opened = await openFileDialog()
+      if (opened) dispatchToolAction({ type: 'open-file', ...opened })
+    } catch (err) {
+      setLastAction(`Open failed: ${err instanceof Error ? err.message : String(err)}`, 'error')
+    }
+  }, [setLastAction])
 
   // The parse error knows where it is; without this the user reads the line
   // number and then scrolls to find it by hand.
@@ -314,7 +348,11 @@ export default function YamlTools() {
 
   useToolAction((action) => {
     if (action.type === 'open-file') {
-      updateState({ input: action.content, fileName: action.filename })
+      updateState({
+        input: action.content,
+        fileName: action.filename,
+        filePath: action.path ?? null,
+      })
       setError(null)
       setUndoBuffer(null)
       setJsonDraft(null)
@@ -325,7 +363,7 @@ export default function YamlTools() {
         setLastAction('Nothing to save yet', 'info')
         return
       }
-      handleSave()
+      void handleSave()
     }
     if (action.type === 'copy-output') {
       void copy(inputRef.current, { success: 'Copied YAML' })
@@ -349,6 +387,7 @@ export default function YamlTools() {
           <DocumentToolbar aria-label="YAML document actions">
             <DocumentIdentity
               title={state.fileName ?? 'Untitled'}
+              titleTooltip={state.filePath ?? state.fileName ?? 'Untitled'}
               icon={
                 <FileCodeIcon
                   size={16}
@@ -372,6 +411,24 @@ export default function YamlTools() {
                   />
                 ) : undefined
               }
+            />
+            <DocumentFileActions
+              open={{
+                label: 'Open YAML file',
+                title: `Open a YAML file (${formatShortcut('mod+o')})`,
+                onClick: () => void handleOpen(),
+              }}
+              save={{
+                label: 'Save YAML file',
+                title: `Save the YAML (${formatShortcut('mod+s')})`,
+                onClick: () => void handleSave(),
+                disabled: !hasInput,
+              }}
+              saveAs={{
+                label: 'Save YAML file as',
+                onClick: () => void handleSaveAs(),
+                disabled: !hasInput,
+              }}
             />
             {parsed.status === 'invalid' && parsed.location && (
               <Button
@@ -398,6 +455,7 @@ export default function YamlTools() {
                 size="sm"
                 onClick={() => updateState({ queryOpen: !state.queryOpen })}
                 aria-expanded={state.queryOpen}
+                aria-controls={queryId}
                 className="gap-1"
               >
                 <MagnifyingGlassIcon size={14} aria-hidden="true" />
@@ -426,6 +484,7 @@ export default function YamlTools() {
                 loading={isFormatting}
                 title={`Format the document (${formatShortcut('mod+enter')})`}
               >
+                <BroomIcon size={14} aria-hidden="true" />
                 Format
                 <Kbd keys="mod+enter" variant="inline" className="ml-1" />
               </Button>
@@ -439,7 +498,14 @@ export default function YamlTools() {
                 <SortAscendingIcon size={14} aria-hidden="true" />
                 Sort keys
               </Button>
-              <Button variant="secondary" size="sm" onClick={handleCompact} disabled={!hasInput}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleCompact}
+                disabled={!hasInput}
+                className="gap-1"
+              >
+                <ArrowsInLineVerticalIcon size={14} aria-hidden="true" />
                 Compact
               </Button>
               {undoBuffer && (
@@ -458,24 +524,16 @@ export default function YamlTools() {
                 disabled={!isValid}
                 title="Open this YAML as JSON"
               >
+                <BracketsCurlyIcon size={14} aria-hidden="true" />
                 JSON
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleSave}
-                disabled={!hasInput}
-                title={`Save to a file (${formatShortcut('mod+s')})`}
-                aria-label="Save YAML to file"
-                className="gap-1"
-              >
-                <FloppyDiskIcon size={14} aria-hidden="true" />
-                Save
               </Button>
             </ToolbarGroup>
           </DocumentToolbar>
           {state.queryOpen && (
-            <div className="flex flex-wrap items-center gap-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2">
+            <div
+              id={queryId}
+              className="flex flex-wrap items-center gap-2 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2"
+            >
               <label className="flex min-w-0 flex-1 items-center gap-2 text-2xs text-[var(--color-text-muted)]">
                 Path
                 <Input
@@ -546,7 +604,13 @@ export default function YamlTools() {
                       <Button
                         variant="secondary"
                         size="sm"
-                        onClick={() => updateState({ input: TOOL_SAMPLES['yaml-tools'] ?? '' })}
+                        onClick={() =>
+                          updateState({
+                            input: TOOL_SAMPLES['yaml-tools'] ?? '',
+                            fileName: null,
+                            filePath: null,
+                          })
+                        }
                       >
                         Load sample
                       </Button>


### PR DESCRIPTION
## Summary

- standardize Monaco editor file controls and toolbar ordering with consistent Phosphor icons and accessible tooltips
- make Save overwrite known files, expose Save As separately, and label generated artifacts as Export
- add missing Open, export, and template actions where appropriate while preserving autosaved library behavior

## Validation

- [x] TypeScript: bunx tsc --noEmit
- [x] Tests: bunx vitest run
- [x] Lint and design-system checks: bun run lint
- [x] Formatting: prettier --check src/app src/components/shared src/tools
- [x] Architecture drift review
- [x] Staged secret scan