### PR TITLE
feat(cockpit): add editable markdown preview

### DIFF
--- a/apps/cockpit/src/index.css
+++ b/apps/cockpit/src/index.css
@@ -207,6 +207,9 @@ samp {
   padding-left: 1.25rem;
   margin: 0.5rem 0;
 }
+.markdown-preview-source-active {
+  box-shadow: -3px 0 0 var(--color-border);
+}
 
 /* ─── Reduced motion ─────────────────────────────────────────────────────────
    Users who ask the OS for reduced motion get a still interface. This

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -129,8 +129,8 @@ type PositionedHastNode = {
   tagName?: string
   properties?: Record<string, unknown>
   position?: {
-    start: { offset?: number }
-    end: { offset?: number }
+    start: { line?: number; offset?: number }
+    end: { line?: number; offset?: number }
   }
   children?: PositionedHastNode[]
 }
@@ -147,17 +147,23 @@ const annotateEditableMarkdownBlocks: Plugin<[], MarkdownHastRoot> = () => {
     const visit = (node: PositionedHastNode) => {
       const start = node.position?.start?.offset
       const end = node.position?.end?.offset
+      const startLine = node.position?.start?.line
+      const endLine = node.position?.end?.line
       if (
         node.type === 'element' &&
         typeof node.tagName === 'string' &&
         EDITABLE_MARKDOWN_BLOCKS.has(node.tagName) &&
         typeof start === 'number' &&
-        typeof end === 'number'
+        typeof end === 'number' &&
+        typeof startLine === 'number' &&
+        typeof endLine === 'number'
       ) {
         node.properties = {
           ...node.properties,
           dataMarkdownStart: start,
           dataMarkdownEnd: end,
+          dataMarkdownStartLine: startLine,
+          dataMarkdownEndLine: endLine,
         }
       }
       node.children?.forEach(visit)
@@ -171,7 +177,13 @@ const markdownEditableSanitizeSchema = {
   ...markdownEditorSanitizeSchema,
   attributes: {
     ...markdownEditorSanitizeSchema.attributes,
-    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'dataMarkdownStart', 'dataMarkdownEnd'],
+    '*': [
+      ...(defaultSchema.attributes?.['*'] ?? []),
+      'dataMarkdownStart',
+      'dataMarkdownEnd',
+      'dataMarkdownStartLine',
+      'dataMarkdownEndLine',
+    ],
   },
 }
 

--- a/apps/cockpit/src/lib/markdown.ts
+++ b/apps/cockpit/src/lib/markdown.ts
@@ -1,4 +1,4 @@
-import { unified } from 'unified'
+import { unified, type Plugin } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
 import remarkRehype from 'remark-rehype'
@@ -107,4 +107,80 @@ export const markdownEditorProcessor = unified()
   .use(remarkRehype)
   .use(rehypeHighlight, { detect: true })
   .use(rehypeSanitize, markdownEditorSanitizeSchema)
+  .use(rehypeStringify)
+
+const EDITABLE_MARKDOWN_BLOCKS = new Set([
+  'blockquote',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'li',
+  'p',
+  'pre',
+  'table',
+])
+
+type PositionedHastNode = {
+  type: string
+  tagName?: string
+  properties?: Record<string, unknown>
+  position?: {
+    start: { offset?: number }
+    end: { offset?: number }
+  }
+  children?: PositionedHastNode[]
+}
+
+type MarkdownHastRoot = Parameters<ReturnType<typeof rehypeSanitize>>[0]
+
+/**
+ * Retains Markdown source offsets on rendered block elements. These attributes let the Markdown
+ * Editor reveal and edit one source block in-place without attempting a lossy HTML-to-Markdown
+ * conversion of the entire sanitized preview.
+ */
+const annotateEditableMarkdownBlocks: Plugin<[], MarkdownHastRoot> = () => {
+  return (tree) => {
+    const visit = (node: PositionedHastNode) => {
+      const start = node.position?.start?.offset
+      const end = node.position?.end?.offset
+      if (
+        node.type === 'element' &&
+        typeof node.tagName === 'string' &&
+        EDITABLE_MARKDOWN_BLOCKS.has(node.tagName) &&
+        typeof start === 'number' &&
+        typeof end === 'number'
+      ) {
+        node.properties = {
+          ...node.properties,
+          dataMarkdownStart: start,
+          dataMarkdownEnd: end,
+        }
+      }
+      node.children?.forEach(visit)
+    }
+
+    visit(tree as unknown as PositionedHastNode)
+  }
+}
+
+const markdownEditableSanitizeSchema = {
+  ...markdownEditorSanitizeSchema,
+  attributes: {
+    ...markdownEditorSanitizeSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'dataMarkdownStart', 'dataMarkdownEnd'],
+  },
+}
+
+/** Markdown Editor preview pipeline with sanitized source-range metadata for in-preview editing. */
+export const markdownEditableEditorProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(annotateEditableMarkdownBlocks)
+  .use(rehypeHighlight, { detect: true })
+  .use(rehypeSanitize, markdownEditableSanitizeSchema)
   .use(rehypeStringify)

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -5,7 +5,7 @@ import MarkdownEditor, {
   prefixMarkdownLines,
   renderMarkdownContent,
 } from '@/tools/markdown-editor/MarkdownEditor'
-import { markdownEditorProcessor } from '@/lib/markdown'
+import { markdownEditableEditorProcessor, markdownEditorProcessor } from '@/lib/markdown'
 import { MarkdownPreview } from '@/tools/markdown-editor/MarkdownPreview'
 import { LinkModal } from '@/tools/markdown-editor/modals/LinkModal'
 import { CodeBlockModal } from '@/tools/markdown-editor/modals/CodeBlockModal'
@@ -123,8 +123,27 @@ describe('MarkdownEditor', () => {
 
     fireEvent.click(screen.getByRole('radio', { name: 'Edit' }))
     expect(screen.getByTestId('monaco-editor')).toHaveValue(
-      '## Updated heading\n\nKeep **this** paragraph.'
+      '# Original heading\n\nKeep **this** paragraph.'
     )
+  })
+
+  it('exposes independent editor and preview scroll synchronization controls', () => {
+    renderTool(MarkdownEditor)
+    const group = screen.getByRole('group', { name: 'Scroll synchronization' })
+    const previewSync = within(group).getByRole('button', {
+      name: 'Stop syncing preview with editor',
+    })
+    const editorSync = within(group).getByRole('button', {
+      name: 'Stop syncing editor with preview',
+    })
+
+    fireEvent.click(previewSync)
+
+    expect(within(group).getByRole('button', { name: 'Sync preview with editor' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+    expect(editorSync).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('renders editor', () => {
@@ -424,6 +443,127 @@ describe('MarkdownEditor', () => {
     rerender(<MarkdownPreview html={html} showToc={false} toc={[]} onToggleTask={() => {}} />)
 
     expect(container.querySelector('p')).toBe(paragraph)
+  })
+
+  it('marks the rendered block containing the active editor line', () => {
+    const { container, rerender } = render(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="12" data-markdown-start-line="2" data-markdown-end-line="3">Active</p>'
+        showToc={false}
+        toc={[]}
+        activeSourceLine={3}
+      />
+    )
+    const paragraph = container.querySelector('p')
+    expect(paragraph).toHaveAttribute('data-source-active')
+    expect(paragraph).toHaveClass('markdown-preview-source-active')
+
+    rerender(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="12" data-markdown-start-line="2" data-markdown-end-line="3">Active</p>'
+        showToc={false}
+        toc={[]}
+        activeSourceLine={8}
+      />
+    )
+    expect(paragraph).not.toHaveAttribute('data-source-active')
+  })
+
+  it('preserves source offsets and line ranges in editable preview HTML', async () => {
+    const html = String(await markdownEditableEditorProcessor.process('# Heading\n\nParagraph'))
+
+    expect(html).toContain('data-markdown-start="0"')
+    expect(html).toContain('data-markdown-start-line="1"')
+    expect(html).toContain('data-markdown-end-line="1"')
+    expect(html).toContain('data-markdown-start-line="3"')
+  })
+
+  it('reveals an annotated source line on preview double-click while preserving links', () => {
+    const onRevealSource = vi.fn()
+    const { container } = render(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="20" data-markdown-start-line="4" data-markdown-end-line="4">Text <a href="#target">link</a></p>'
+        showToc={false}
+        toc={[]}
+        onRevealSource={onRevealSource}
+      />
+    )
+    fireEvent.doubleClick(container.querySelector('p')!)
+    expect(onRevealSource).toHaveBeenCalledWith(4)
+
+    fireEvent.doubleClick(screen.getByRole('link', { name: 'link' }))
+    expect(onRevealSource).toHaveBeenCalledTimes(1)
+  })
+
+  it('commits preview edits and can undo the committed block change', () => {
+    const onSourceChange = vi.fn()
+    const onEditCaretChange = vi.fn()
+    const { container } = render(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="8" data-markdown-start-line="1" data-markdown-end-line="1">Original</p>'
+        source="Original"
+        showToc={false}
+        toc={[]}
+        editingEnabled
+        onSourceChange={onSourceChange}
+        onEditCaretChange={onEditCaretChange}
+      />
+    )
+    fireEvent.click(container.querySelector('p')!)
+    const editor = screen.getByRole('textbox', { name: 'Edit markdown block' })
+    fireEvent.change(editor, { target: { value: 'Updated', selectionStart: 7 } })
+    fireEvent.keyDown(editor, { key: 'Enter', ctrlKey: true })
+    expect(screen.queryByRole('textbox', { name: 'Edit markdown block' })).toBeNull()
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true })
+    expect(onSourceChange).toHaveBeenLastCalledWith('Original')
+    expect(onEditCaretChange).toHaveBeenLastCalledWith(0)
+  })
+
+  it('remeasures the preview edit overlay when the viewport changes', () => {
+    const { container } = render(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="8" data-markdown-start-line="1" data-markdown-end-line="1">Original</p>'
+        source="Original"
+        showToc={false}
+        toc={[]}
+        editingEnabled
+        onSourceChange={() => {}}
+      />
+    )
+    const surface = container.querySelector('[data-selection-surface="markdown-preview"]')!
+    const paragraph = container.querySelector('p')!
+    vi.spyOn(surface, 'getBoundingClientRect').mockReturnValue({
+      left: 10,
+      top: 20,
+      width: 500,
+      height: 500,
+      right: 510,
+      bottom: 520,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    let blockWidth = 240
+    vi.spyOn(paragraph, 'getBoundingClientRect').mockImplementation(() => ({
+      left: 30,
+      top: 50,
+      width: blockWidth,
+      height: 60,
+      right: 30 + blockWidth,
+      bottom: 110,
+      x: 30,
+      y: 50,
+      toJSON: () => ({}),
+    }))
+
+    fireEvent.click(paragraph)
+    const editor = screen.getByRole('textbox', { name: 'Edit markdown block' })
+    expect(editor).toHaveStyle({ left: '20px', top: '30px', width: '240px' })
+
+    blockWidth = 320
+    fireEvent.resize(window)
+    expect(editor).toHaveStyle({ width: '320px' })
   })
 
   it('uses the light Mermaid theme in preview when the app theme is light', async () => {

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -79,6 +79,54 @@ describe('MarkdownEditor', () => {
     expect(tabs[1]!.compareDocumentPosition(tabs[2]!)).toBe(4)
   })
 
+  it('shows the edit-preview switch only in Preview mode', () => {
+    renderTool(MarkdownEditor)
+    expect(screen.queryByRole('switch', { name: 'Edit preview' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Preview' }))
+
+    const toggle = screen.getByRole('switch', { name: 'Edit preview' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Split' }))
+    expect(screen.queryByRole('switch', { name: 'Edit preview' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Preview' }))
+    expect(screen.getByRole('switch', { name: 'Edit preview' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    )
+  })
+
+  it('edits a rendered block in Preview mode without changing surrounding markdown', async () => {
+    renderTool(MarkdownEditor)
+    fireEvent.change(screen.getByTestId('monaco-editor'), {
+      target: { value: '# Original heading\n\nKeep **this** paragraph.' },
+    })
+    fireEvent.click(screen.getByRole('radio', { name: 'Preview' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Original heading' })).toBeVisible()
+    )
+    fireEvent.click(screen.getByRole('switch', { name: 'Edit preview' }))
+    const heading = screen.getByRole('heading', { name: 'Original heading' })
+    expect(heading).toHaveAttribute('tabindex', '0')
+    heading.focus()
+    fireEvent.keyDown(heading, { key: 'Enter' })
+
+    const blockEditor = screen.getByRole('textbox', { name: 'Edit markdown block' })
+    expect(blockEditor).toHaveValue('# Original heading')
+    fireEvent.change(blockEditor, { target: { value: '## Updated heading' } })
+    fireEvent.keyDown(blockEditor, { key: 'Escape' })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Edit' }))
+    expect(screen.getByTestId('monaco-editor')).toHaveValue(
+      '## Updated heading\n\nKeep **this** paragraph.'
+    )
+  })
+
   it('renders editor', () => {
     renderTool(MarkdownEditor)
     expect(screen.getByTestId('monaco-editor')).toBeInTheDocument()

--- a/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-editor.test.tsx
@@ -566,6 +566,47 @@ describe('MarkdownEditor', () => {
     expect(editor).toHaveStyle({ width: '320px' })
   })
 
+  it('refuses to edit a block whose source range falls outside the document', () => {
+    const { container } = render(
+      <MarkdownPreview
+        html='<p data-markdown-start="0" data-markdown-end="99" data-markdown-start-line="1" data-markdown-end-line="1">Original</p>'
+        source="Original"
+        showToc={false}
+        toc={[]}
+        editingEnabled
+        onSourceChange={() => {}}
+      />
+    )
+    fireEvent.click(container.querySelector('p')!)
+    expect(screen.queryByRole('textbox', { name: 'Edit markdown block' })).toBeNull()
+  })
+
+  it('keeps the preview scroll position when edit mode is toggled', () => {
+    const html =
+      '<p data-markdown-start="0" data-markdown-end="8" data-markdown-start-line="1" data-markdown-end-line="1">Original</p>'
+    const { container, rerender } = render(
+      <MarkdownPreview html={html} source="Original" showToc={false} toc={[]} />
+    )
+    const surface = container.querySelector<HTMLElement>(
+      '[data-selection-surface="markdown-preview"]'
+    )!
+    surface.scrollTop = 240
+    fireEvent.scroll(surface)
+    surface.scrollTop = 0 // Remounting the rendered markup collapses the scroll offset.
+
+    rerender(
+      <MarkdownPreview
+        html={html}
+        source="Original"
+        showToc={false}
+        toc={[]}
+        editingEnabled
+        onSourceChange={() => {}}
+      />
+    )
+    expect(surface.scrollTop).toBe(240)
+  })
+
   it('uses the light Mermaid theme in preview when the app theme is light', async () => {
     useSettingsStore.setState({ ...DEFAULT_SETTINGS, theme: 'github-light' })
     mermaidMock.render.mockResolvedValue({ svg: '<svg><text>diagram</text></svg>' })

--- a/apps/cockpit/src/tools/__tests__/markdown-scroll-sync.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-scroll-sync.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  previewOffsetForSourceLine,
+  sourceLineForPreviewOffset,
+  type ScrollSyncEditor,
+  useScrollSync,
+} from '@/tools/markdown-editor/hooks/useScrollSync'
+
+const entries = [
+  { startLine: 1, endLine: 1, top: 0, bottom: 30 },
+  { startLine: 5, endLine: 9, top: 120, bottom: 320 },
+  { startLine: 12, endLine: 12, top: 400, bottom: 440 },
+]
+
+describe('Markdown scroll synchronization', () => {
+  it('maps source lines through variable-height rendered blocks and gaps', () => {
+    expect(previewOffsetForSourceLine(entries, 7)).toBe(220)
+    expect(previewOffsetForSourceLine(entries, 3)).toBe(75)
+    expect(previewOffsetForSourceLine(entries, 20)).toBe(440)
+  })
+
+  it('maps preview offsets back to source lines', () => {
+    expect(sourceLineForPreviewOffset(entries, 220)).toBe(7)
+    expect(sourceLineForPreviewOffset(entries, 75)).toBe(3)
+    expect(sourceLineForPreviewOffset(entries, 600)).toBe(12)
+  })
+
+  it('attaches after Monaco mounts and disposes listeners on unmount', () => {
+    const preview = document.createElement('div')
+    const previewRef = { current: preview }
+    const dispose = vi.fn()
+    const editor: ScrollSyncEditor = {
+      onDidScrollChange: vi.fn(() => ({ dispose })),
+      getVisibleRanges: vi.fn(() => [{ startLineNumber: 1 }]),
+      getTopForLineNumber: vi.fn(() => 0),
+      setScrollTop: vi.fn(),
+    }
+
+    const { rerender, unmount } = renderHook(
+      ({ mountedEditor }: { mountedEditor: ScrollSyncEditor | null }) =>
+        useScrollSync(mountedEditor, previewRef, true, true),
+      { initialProps: { mountedEditor: null as ScrollSyncEditor | null } }
+    )
+    expect(editor.onDidScrollChange).not.toHaveBeenCalled()
+
+    rerender({ mountedEditor: editor })
+    expect(editor.onDidScrollChange).toHaveBeenCalledOnce()
+
+    unmount()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('attaches only the enabled synchronization direction', () => {
+    const preview = document.createElement('div')
+    const addListener = vi.spyOn(preview, 'addEventListener')
+    const editor: ScrollSyncEditor = {
+      onDidScrollChange: vi.fn(() => ({ dispose: vi.fn() })),
+      getVisibleRanges: vi.fn(() => [{ startLineNumber: 1 }]),
+      getTopForLineNumber: vi.fn(() => 0),
+      setScrollTop: vi.fn(),
+    }
+
+    const { unmount } = renderHook(() => useScrollSync(editor, { current: preview }, false, true))
+
+    expect(editor.onDidScrollChange).not.toHaveBeenCalled()
+    expect(addListener).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
+    unmount()
+  })
+})

--- a/apps/cockpit/src/tools/__tests__/markdown-scroll-sync.test.tsx
+++ b/apps/cockpit/src/tools/__tests__/markdown-scroll-sync.test.tsx
@@ -51,6 +51,40 @@ describe('Markdown scroll synchronization', () => {
     expect(dispose).toHaveBeenCalledOnce()
   })
 
+  it('measures preview blocks once per markup change rather than once per scroll frame', async () => {
+    const preview = document.createElement('div')
+    document.body.appendChild(preview)
+    const measure = vi.spyOn(preview, 'querySelectorAll')
+    const editor: ScrollSyncEditor = {
+      onDidScrollChange: vi.fn(() => ({ dispose: vi.fn() })),
+      getVisibleRanges: vi.fn(() => [{ startLineNumber: 1 }]),
+      getTopForLineNumber: vi.fn(() => 0),
+      setScrollTop: vi.fn(),
+    }
+    // The hook falls back to a timeout when rAF is unavailable, as it is here.
+    const nextFrame = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    const { unmount } = renderHook(() => useScrollSync(editor, { current: preview }, false, true))
+
+    preview.dispatchEvent(new window.Event('scroll'))
+    await nextFrame()
+    expect(measure).toHaveBeenCalledTimes(1)
+
+    preview.dispatchEvent(new window.Event('scroll'))
+    await nextFrame()
+    expect(measure).toHaveBeenCalledTimes(1)
+
+    // Re-rendered markup invalidates the cache through the MutationObserver.
+    preview.appendChild(document.createElement('p'))
+    await nextFrame()
+    preview.dispatchEvent(new window.Event('scroll'))
+    await nextFrame()
+    expect(measure).toHaveBeenCalledTimes(2)
+
+    unmount()
+    preview.remove()
+  })
+
   it('attaches only the enabled synchronization direction', () => {
     const preview = document.createElement('div')
     const addListener = vi.spyOn(preview, 'addEventListener')

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -57,7 +57,7 @@ import {
 // enabled (not `disabled`) so the preview can toggle them — see the sanitize schema
 // comment in src/lib/markdown.ts for why that variant exists instead of loosening
 // the shared schema for every surface.
-import { markdownEditorProcessor } from '@/lib/markdown'
+import { markdownEditableEditorProcessor, markdownEditorProcessor } from '@/lib/markdown'
 import { toggleTaskAtIndex } from '@/tools/markdown-editor/task-list'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { useTabDirty } from '@/hooks/useTabDirty'
@@ -490,6 +490,16 @@ export async function renderMarkdownContent(content: string): Promise<string> {
   }
 }
 
+async function renderEditableMarkdownContent(content: string): Promise<string> {
+  if (!content.trim()) return ''
+  try {
+    const result = await markdownEditableEditorProcessor.process(content)
+    return String(result)
+  } catch {
+    return renderMarkdownContent(content)
+  }
+}
+
 // ─── Component ───────────────────────────────────────────────────────
 
 export default function MarkdownEditor() {
@@ -517,6 +527,7 @@ export default function MarkdownEditor() {
   const [showExport, setShowExport] = useState(false)
   const [activeModal, setActiveModal] = useState<'link' | 'image' | 'code' | 'table' | null>(null)
   const [pendingDocument, setPendingDocument] = useState<PendingDocument | null>(null)
+  const [previewEditing, setPreviewEditing] = useState(false)
 
   // ─── Hooks ────────────────────────────────────────────────────────
 
@@ -551,7 +562,7 @@ export default function MarkdownEditor() {
     if (debounceRef.current) clearTimeout(debounceRef.current)
     let cancelled = false
     debounceRef.current = setTimeout(async () => {
-      const nextHtml = await renderMarkdownContent(state.content)
+      const nextHtml = await renderEditableMarkdownContent(state.content)
       if (!cancelled) setHtml(nextHtml)
     }, 300)
 
@@ -766,7 +777,10 @@ export default function MarkdownEditor() {
     (replace: boolean) => {
       // Preview has no editor to search. Switching to split is better than refusing: the user asked
       // to find something, and the only way to honour that is to show them the text.
-      if (state.mode === 'preview') updateState({ mode: 'split' })
+      if (state.mode === 'preview') {
+        setPreviewEditing(false)
+        updateState({ mode: 'split' })
+      }
 
       // Retried rather than deferred one frame, and the check is DOM connectivity rather than
       // `editorRef.current != null`. Preview unmounts the editor without clearing the ref, so the
@@ -1007,9 +1021,14 @@ export default function MarkdownEditor() {
       <MarkdownPreview
         ref={previewRef}
         html={html}
+        source={state.content}
         showToc={state.showToc}
         toc={toc}
         onToggleTask={handleToggleTask}
+        editingEnabled={state.mode === 'preview' && previewEditing}
+        showEditingToggle={state.mode === 'preview'}
+        onEditingEnabledChange={setPreviewEditing}
+        onSourceChange={(content) => updateState({ content })}
       />
     </div>
   )
@@ -1059,7 +1078,10 @@ export default function MarkdownEditor() {
               aria-label="Editor view mode"
               options={MODE_OPTIONS}
               value={state.mode as EditorMode}
-              onChange={(mode) => updateState({ mode })}
+              onChange={(mode) => {
+                if (mode !== 'preview') setPreviewEditing(false)
+                updateState({ mode })
+              }}
             />
 
             {state.mode === 'split' && (

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownEditor.tsx
@@ -35,7 +35,8 @@ import { ImageModal } from '@/tools/markdown-editor/modals/ImageModal'
 import { TableModal } from '@/tools/markdown-editor/modals/TableModal'
 import { nextHeadingId } from '@/tools/markdown-editor/heading-ids'
 import {
-  ArrowsClockwiseIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
   CaretDownIcon,
   CodeIcon,
   CopyIcon,
@@ -73,6 +74,10 @@ type MarkdownEditorState = {
   mode: string
   showToc: boolean
   scrollSync: boolean
+  scrollSyncDirections?: {
+    editorToPreview: boolean
+    previewToEditor: boolean
+  }
 }
 
 type TocEntry = {
@@ -521,7 +526,10 @@ export default function MarkdownEditor() {
   const previewRef = useRef<HTMLDivElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const editorRef = useRef<EditorInstance | null>(null)
+  const pendingRevealLineRef = useRef<number | null>(null)
+  const pendingCaretOffsetRef = useRef<number | null>(null)
   const [mountedEditor, setMountedEditor] = useState<EditorInstance | null>(null)
+  const [activeSourceLine, setActiveSourceLine] = useState<number | null>(null)
   const editorContainerRef = useRef<HTMLDivElement>(null)
   const [showTemplates, setShowTemplates] = useState(false)
   const [showExport, setShowExport] = useState(false)
@@ -534,9 +542,16 @@ export default function MarkdownEditor() {
   const showEditor = state.mode === 'split' || state.mode === 'edit'
   const showPreview = state.mode === 'split' || state.mode === 'preview'
   const isDirty = state.content !== state.savedContent
+  const syncPreviewWithEditor = state.scrollSyncDirections?.editorToPreview ?? state.scrollSync
+  const syncEditorWithPreview = state.scrollSyncDirections?.previewToEditor ?? state.scrollSync
   useTabDirty(isDirty)
 
-  useScrollSync(editorRef, previewRef, state.scrollSync && state.mode === 'split')
+  useScrollSync(
+    mountedEditor,
+    previewRef,
+    syncPreviewWithEditor && state.mode === 'split',
+    syncEditorWithPreview && state.mode === 'split'
+  )
   const { isDraggingImage } = useImageDrop(editorRef, editorContainerRef)
   useMarkdownListEditing(mountedEditor)
   useMarkdownSmartPaste(mountedEditor)
@@ -545,10 +560,47 @@ export default function MarkdownEditor() {
 
   // ─── Editor mount ────────────────────────────────────────────────
 
-  const handleEditorMount: OnMount = useCallback((editor) => {
-    editorRef.current = editor
-    setMountedEditor(editor)
-  }, [])
+  const revealEditorLocation = useCallback(
+    (editor: EditorInstance, line: number | null, offset: number | null) => {
+      const model = editor.getModel()
+      if (!model) return
+      const position =
+        offset !== null
+          ? model.getPositionAt(Math.min(Math.max(0, offset), model.getValueLength()))
+          : {
+              lineNumber: Math.min(Math.max(1, line ?? 1), model.getLineCount()),
+              column: 1,
+            }
+      editor.setPosition(position)
+      editor.revealLineInCenter(position.lineNumber)
+      editor.focus()
+      setActiveSourceLine(position.lineNumber)
+    },
+    []
+  )
+
+  const handleEditorMount: OnMount = useCallback(
+    (editor) => {
+      editorRef.current = editor
+      setMountedEditor(editor)
+      const pendingOffset = pendingCaretOffsetRef.current
+      const pendingLine = pendingRevealLineRef.current
+      if (pendingOffset !== null || pendingLine !== null) {
+        pendingCaretOffsetRef.current = null
+        pendingRevealLineRef.current = null
+        requestAnimationFrame(() => revealEditorLocation(editor, pendingLine, pendingOffset))
+      }
+    },
+    [revealEditorLocation]
+  )
+
+  useEffect(() => {
+    if (!mountedEditor || !showEditor) return
+    const updateLine = () => setActiveSourceLine(mountedEditor.getPosition()?.lineNumber ?? null)
+    updateLine()
+    const disposable = mountedEditor.onDidChangeCursorPosition(updateLine)
+    return () => disposable.dispose()
+  }, [mountedEditor, showEditor])
 
   useEffect(() => {
     return () => {
@@ -978,6 +1030,26 @@ export default function MarkdownEditor() {
     [state.content, updateState]
   )
 
+  const handleRevealSource = useCallback(
+    (line: number) => {
+      setPreviewEditing(false)
+      const editor = editorRef.current
+      if (state.mode === 'split' && editor?.getDomNode()?.isConnected) {
+        revealEditorLocation(editor, line, null)
+        return
+      }
+      pendingRevealLineRef.current = line
+      pendingCaretOffsetRef.current = null
+      updateState({ mode: 'edit' })
+    },
+    [revealEditorLocation, state.mode, updateState]
+  )
+
+  const handlePreviewEditCaret = useCallback((offset: number) => {
+    pendingCaretOffsetRef.current = offset
+    pendingRevealLineRef.current = null
+  }, [])
+
   const handleTemplateSelect = useCallback(
     (content: string) => {
       const datedContent = content.replaceAll(TEMPLATE_DATE, new Date().toISOString().slice(0, 10))
@@ -1025,10 +1097,13 @@ export default function MarkdownEditor() {
         showToc={state.showToc}
         toc={toc}
         onToggleTask={handleToggleTask}
+        activeSourceLine={state.mode === 'split' ? activeSourceLine : null}
         editingEnabled={state.mode === 'preview' && previewEditing}
         showEditingToggle={state.mode === 'preview'}
         onEditingEnabledChange={setPreviewEditing}
         onSourceChange={(content) => updateState({ content })}
+        onEditCaretChange={handlePreviewEditCaret}
+        onRevealSource={handleRevealSource}
       />
     </div>
   )
@@ -1085,22 +1160,70 @@ export default function MarkdownEditor() {
             />
 
             {state.mode === 'split' && (
-              <Button
-                type="button"
-                variant="icon"
-                size="sm"
-                onClick={() => updateState({ scrollSync: !state.scrollSync })}
-                title={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
-                aria-label={state.scrollSync ? 'Disable scroll sync' : 'Enable scroll sync'}
-                aria-pressed={state.scrollSync}
-                className={state.scrollSync ? 'text-[var(--color-accent)]' : ''}
-              >
-                <ArrowsClockwiseIcon
-                  size={14}
-                  weight={state.scrollSync ? 'bold' : 'regular'}
-                  aria-hidden="true"
-                />
-              </Button>
+              <div className="flex items-center" role="group" aria-label="Scroll synchronization">
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="sm"
+                  onClick={() =>
+                    updateState({
+                      scrollSyncDirections: {
+                        editorToPreview: !syncPreviewWithEditor,
+                        previewToEditor: syncEditorWithPreview,
+                      },
+                    })
+                  }
+                  title={
+                    syncPreviewWithEditor
+                      ? 'Stop syncing preview with editor'
+                      : 'Sync preview with editor'
+                  }
+                  aria-label={
+                    syncPreviewWithEditor
+                      ? 'Stop syncing preview with editor'
+                      : 'Sync preview with editor'
+                  }
+                  aria-pressed={syncPreviewWithEditor}
+                  className={syncPreviewWithEditor ? 'text-[var(--color-accent)]' : ''}
+                >
+                  <ArrowRightIcon
+                    size={14}
+                    weight={syncPreviewWithEditor ? 'bold' : 'regular'}
+                    aria-hidden="true"
+                  />
+                </Button>
+                <Button
+                  type="button"
+                  variant="icon"
+                  size="sm"
+                  onClick={() =>
+                    updateState({
+                      scrollSyncDirections: {
+                        editorToPreview: syncPreviewWithEditor,
+                        previewToEditor: !syncEditorWithPreview,
+                      },
+                    })
+                  }
+                  title={
+                    syncEditorWithPreview
+                      ? 'Stop syncing editor with preview'
+                      : 'Sync editor with preview'
+                  }
+                  aria-label={
+                    syncEditorWithPreview
+                      ? 'Stop syncing editor with preview'
+                      : 'Sync editor with preview'
+                  }
+                  aria-pressed={syncEditorWithPreview}
+                  className={syncEditorWithPreview ? 'text-[var(--color-accent)]' : ''}
+                >
+                  <ArrowLeftIcon
+                    size={14}
+                    weight={syncEditorWithPreview ? 'bold' : 'regular'}
+                    aria-hidden="true"
+                  />
+                </Button>
+              </div>
             )}
 
             {toc.length > 0 && (

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,9 +1,11 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  useId,
   forwardRef,
   useImperativeHandle,
 } from 'react'
@@ -32,9 +34,16 @@ type MarkdownPreviewProps = {
   showEditingToggle?: boolean
   onEditingEnabledChange?: (enabled: boolean) => void
   onSourceChange?: (source: string) => void
+  onEditCaretChange?: (offset: number) => void
+  onRevealSource?: (line: number) => void
+  activeSourceLine?: number | null
 }
 
 type ActiveBlockEdit = {
+  start: number
+  tagName: string
+  originalSource: string
+  changed: boolean
   prefix: string
   suffix: string
   draft: string
@@ -110,6 +119,23 @@ const PREVIEW_STYLES = [
   proseSpacing,
 ].join(' ')
 
+function findSourceBlock(surface: HTMLElement, start: number, tagName: string): HTMLElement | null {
+  const matches = Array.from(
+    surface.querySelectorAll<HTMLElement>(`[data-markdown-start="${start}"]`)
+  )
+  return matches.find((element) => element.tagName === tagName) ?? matches[0] ?? null
+}
+
+function scheduleFrame(callback: () => void): number {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(callback)
+  return window.setTimeout(callback, 0)
+}
+
+function cancelFrame(handle: number): void {
+  if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(handle)
+  else window.clearTimeout(handle)
+}
+
 // ─── Component ──────────────────────────────────────────────────────
 
 export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
@@ -124,13 +150,19 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       showEditingToggle = false,
       onEditingEnabledChange,
       onSourceChange,
+      onEditCaretChange,
+      onRevealSource,
+      activeSourceLine = null,
     },
     ref
   ) {
     const innerRef = useRef<HTMLDivElement>(null)
     const editorRef = useRef<HTMLTextAreaElement>(null)
+    const ignoreNextBlurRef = useRef(false)
+    const previewUndoStackRef = useRef<string[]>([])
     const mermaidRenderSeqRef = useRef(0)
     const [activeEdit, setActiveEdit] = useState<ActiveBlockEdit | null>(null)
+    const editHelpId = useId()
     const theme = useSettingsStore((s) => s.theme)
 
     const beginBlockEdit = useCallback(
@@ -138,21 +170,29 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
         if (!innerRef.current || !onSourceChange) return
         const surfaceRect = innerRef.current.getBoundingClientRect()
         const blockRect = element.getBoundingClientRect()
+        const draft = source.slice(start, end)
         setActiveEdit({
+          start,
+          tagName: element.tagName,
+          originalSource: source,
+          changed: false,
           prefix: source.slice(0, start),
           suffix: source.slice(end),
-          draft: source.slice(start, end),
+          draft,
           left: blockRect.left - surfaceRect.left + innerRef.current.scrollLeft,
           top: blockRect.top - surfaceRect.top + innerRef.current.scrollTop,
           width: blockRect.width,
           minHeight: Math.max(blockRect.height, 44),
         })
-        requestAnimationFrame(() => {
-          editorRef.current?.focus()
-          editorRef.current?.select()
+        scheduleFrame(() => {
+          const editor = editorRef.current
+          if (!editor) return
+          editor.focus()
+          editor.setSelectionRange(draft.length, draft.length)
+          onEditCaretChange?.(start + draft.length)
         })
       },
-      [onSourceChange, source]
+      [onEditCaretChange, onSourceChange, source]
     )
 
     const beginEditFromTarget = useCallback(
@@ -205,19 +245,74 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       [beginEditFromTarget, toggleFromEventTarget]
     )
 
-    const updateDraft = useCallback(
-      (draft: string) => {
-        setActiveEdit((current) => (current ? { ...current, draft } : null))
-        if (activeEdit) onSourceChange?.(`${activeEdit.prefix}${draft}${activeEdit.suffix}`)
-        requestAnimationFrame(() => {
-          const editor = editorRef.current
-          if (!editor) return
-          editor.style.height = '0px'
-          editor.style.height = `${Math.max(activeEdit?.minHeight ?? 44, editor.scrollHeight)}px`
-        })
+    const handlePreviewDoubleClick = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (editingEnabled || !onRevealSource) return
+        if (!(event.target instanceof window.HTMLElement)) return
+        if (event.target.closest('a, button, input, textarea')) return
+        const block = event.target.closest<HTMLElement>(
+          '[data-markdown-start-line][data-markdown-end-line]'
+        )
+        if (!block || !innerRef.current?.contains(block)) return
+        const line = Number(block.dataset.markdownStartLine)
+        if (!Number.isInteger(line) || line < 1) return
+        event.preventDefault()
+        onRevealSource(line)
       },
-      [activeEdit, onSourceChange]
+      [editingEnabled, onRevealSource]
     )
+
+    const updateDraft = useCallback(
+      (draft: string, caret: number) => {
+        if (!activeEdit) return
+        if (!activeEdit.changed) previewUndoStackRef.current.push(activeEdit.originalSource)
+        setActiveEdit((current) => (current ? { ...current, changed: true, draft } : null))
+        onSourceChange?.(`${activeEdit.prefix}${draft}${activeEdit.suffix}`)
+        onEditCaretChange?.(activeEdit.start + caret)
+      },
+      [activeEdit, onEditCaretChange, onSourceChange]
+    )
+
+    const finishBlockEdit = useCallback(() => {
+      if (!activeEdit) return
+      onEditCaretChange?.(
+        activeEdit.start + (editorRef.current?.selectionStart ?? activeEdit.draft.length)
+      )
+      setActiveEdit(null)
+    }, [activeEdit, onEditCaretChange])
+
+    const cancelBlockEdit = useCallback(() => {
+      if (!activeEdit) return
+      ignoreNextBlurRef.current = true
+      if (activeEdit.changed) previewUndoStackRef.current.pop()
+      onSourceChange?.(activeEdit.originalSource)
+      onEditCaretChange?.(activeEdit.start)
+      setActiveEdit(null)
+      window.queueMicrotask(() => {
+        ignoreNextBlurRef.current = false
+      })
+    }, [activeEdit, onEditCaretChange, onSourceChange])
+
+    useEffect(() => {
+      if (!editingEnabled) previewUndoStackRef.current = []
+    }, [editingEnabled])
+
+    useEffect(() => {
+      if (!editingEnabled || activeEdit || !onSourceChange) return
+      const handleUndo = (event: KeyboardEvent) => {
+        if (event.key.toLowerCase() !== 'z' || (!event.metaKey && !event.ctrlKey)) return
+        const surface = innerRef.current
+        const focused = document.activeElement
+        if (!surface || (focused !== document.body && !surface.contains(focused))) return
+        const previous = previewUndoStackRef.current.pop()
+        if (previous === undefined) return
+        event.preventDefault()
+        onSourceChange(previous)
+        onEditCaretChange?.(0)
+      }
+      window.addEventListener('keydown', handleUndo)
+      return () => window.removeEventListener('keydown', handleUndo)
+    }, [activeEdit, editingEnabled, onEditCaretChange, onSourceChange])
 
     // ─── Rendered HTML payload ────────────────────────────────────
     // Memoised deliberately. React 19's `updateProperties` compares
@@ -230,6 +325,92 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     // re-renders this component, which wiped the very selection being tracked.
     // Keeping the object stable makes React skip the write entirely.
     const htmlProp = useMemo(() => ({ __html: html }), [html])
+
+    const remeasureActiveEdit = useCallback(() => {
+      const surface = innerRef.current
+      if (!surface) return
+      setActiveEdit((current) => {
+        if (!current) return null
+        const block = findSourceBlock(surface, current.start, current.tagName)
+        if (!block) return current
+        const surfaceRect = surface.getBoundingClientRect()
+        const blockRect = block.getBoundingClientRect()
+        if (blockRect.width <= 0 || blockRect.height <= 0) return current
+        const nextGeometry = {
+          left: blockRect.left - surfaceRect.left + surface.scrollLeft,
+          top: blockRect.top - surfaceRect.top + surface.scrollTop,
+          width: blockRect.width,
+          minHeight: Math.max(blockRect.height, 44),
+        }
+        if (
+          current.left === nextGeometry.left &&
+          current.top === nextGeometry.top &&
+          current.width === nextGeometry.width &&
+          current.minHeight === nextGeometry.minHeight
+        ) {
+          return current
+        }
+        return { ...current, ...nextGeometry }
+      })
+    }, [])
+
+    useLayoutEffect(() => {
+      if (!activeEdit || !innerRef.current) return
+      const surface = innerRef.current
+      const block = findSourceBlock(surface, activeEdit.start, activeEdit.tagName)
+      const frame = scheduleFrame(remeasureActiveEdit)
+      const handleResize = () => remeasureActiveEdit()
+      window.addEventListener('resize', handleResize)
+
+      let observer: ResizeObserver | null = null
+      if (typeof ResizeObserver !== 'undefined') {
+        observer = new ResizeObserver(handleResize)
+        observer.observe(surface)
+        if (block) observer.observe(block)
+      }
+
+      return () => {
+        cancelFrame(frame)
+        window.removeEventListener('resize', handleResize)
+        observer?.disconnect()
+      }
+    }, [activeEdit, html, remeasureActiveEdit, showToc])
+
+    useLayoutEffect(() => {
+      const editor = editorRef.current
+      if (!editor || !activeEdit) return
+      editor.style.height = '0px'
+      editor.style.height = `${Math.max(activeEdit.minHeight, editor.scrollHeight)}px`
+    }, [activeEdit])
+
+    useEffect(() => {
+      const surface = innerRef.current
+      if (!surface) return
+      const previous = surface.querySelector<HTMLElement>('[data-source-active]')
+      previous?.removeAttribute('data-source-active')
+      previous?.classList.remove('markdown-preview-source-active')
+      if (activeSourceLine === null) return
+
+      const candidates = Array.from(
+        surface.querySelectorAll<HTMLElement>('[data-markdown-start-line][data-markdown-end-line]')
+      ).filter((element) => {
+        const startLine = Number(element.dataset.markdownStartLine)
+        const endLine = Number(element.dataset.markdownEndLine)
+        return activeSourceLine >= startLine && activeSourceLine <= endLine
+      })
+      const active = candidates.sort((a, b) => {
+        const aSpan = Number(a.dataset.markdownEndLine) - Number(a.dataset.markdownStartLine)
+        const bSpan = Number(b.dataset.markdownEndLine) - Number(b.dataset.markdownStartLine)
+        return aSpan - bSpan
+      })[0]
+      active?.setAttribute('data-source-active', '')
+      active?.classList.add('markdown-preview-source-active')
+
+      return () => {
+        active?.removeAttribute('data-source-active')
+        active?.classList.remove('markdown-preview-source-active')
+      }
+    }, [activeSourceLine, html])
 
     // The rendered elements come from sanitized HTML, so opt them into the tab order only while
     // editing is enabled. Enter then follows the same delegated path as a pointer click.
@@ -271,6 +452,15 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
             if (cancelled || renderSeq !== mermaidRenderSeqRef.current) return
             const wrapper = document.createElement('div')
             wrapper.className = 'mermaid-diagram'
+            for (const attribute of parent.attributes) {
+              if (attribute.name.startsWith('data-markdown-')) {
+                wrapper.setAttribute(attribute.name, attribute.value)
+              }
+            }
+            if (parent.hasAttribute('data-source-active')) {
+              wrapper.setAttribute('data-source-active', '')
+              wrapper.classList.add('markdown-preview-source-active')
+            }
             wrapper.innerHTML = svg
             parent.replaceWith(wrapper)
           } catch {
@@ -304,7 +494,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
             <Toggle
               checked={editingEnabled}
               onChange={(enabled) => {
-                setActiveEdit(null)
+                finishBlockEdit()
                 onEditingEnabledChange(enabled)
               }}
               label="Edit preview"
@@ -341,6 +531,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           className={`relative flex-1 overflow-auto p-6 ${editingEnabled ? 'cursor-text' : ''}`}
           data-selection-surface="markdown-preview"
           onClick={handlePreviewClick}
+          onDoubleClick={handlePreviewDoubleClick}
           onKeyDown={handlePreviewKeyDown}
         >
           {html ? (
@@ -365,27 +556,42 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
             </div>
           )}
           {editingEnabled && activeEdit && (
-            <TextArea
-              ref={editorRef}
-              value={activeEdit.draft}
-              onChange={(event) => updateDraft(event.target.value)}
-              onBlur={() => setActiveEdit(null)}
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') {
-                  event.preventDefault()
-                  setActiveEdit(null)
+            <>
+              <TextArea
+                ref={editorRef}
+                value={activeEdit.draft}
+                onChange={(event) =>
+                  updateDraft(event.target.value, event.currentTarget.selectionStart)
                 }
-              }}
-              aria-label="Edit markdown block"
-              monospace
-              className="absolute z-10 resize-none overflow-hidden shadow-lg shadow-[var(--color-shadow)]"
-              style={{
-                left: `${activeEdit.left}px`,
-                top: `${activeEdit.top}px`,
-                width: `${activeEdit.width}px`,
-                minHeight: `${activeEdit.minHeight}px`,
-              }}
-            />
+                onBlur={() => {
+                  if (ignoreNextBlurRef.current) return
+                  finishBlockEdit()
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    cancelBlockEdit()
+                  } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                    event.preventDefault()
+                    finishBlockEdit()
+                  }
+                }}
+                aria-label="Edit markdown block"
+                aria-describedby={editHelpId}
+                monospace
+                className="absolute z-10 resize-none overflow-hidden shadow-lg shadow-[var(--color-shadow)]"
+                style={{
+                  left: `${activeEdit.left}px`,
+                  top: `${activeEdit.top}px`,
+                  width: `${activeEdit.width}px`,
+                  minHeight: `${activeEdit.minHeight}px`,
+                }}
+              />
+              <span id={editHelpId} className="sr-only">
+                Press Escape to cancel changes or Control or Command plus Enter to finish editing.
+              </span>
+            </>
           )}
         </div>
       </div>

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -119,6 +119,12 @@ const PREVIEW_STYLES = [
   proseSpacing,
 ].join(' ')
 
+// Double-click reveals the source line, which would otherwise steal the gesture from anything the
+// user can operate in place. Sanitized markdown can only produce a subset of these, but listing the
+// full set keeps the guard from silently missing an element the sanitize schema later allows.
+const INTERACTIVE_SELECTOR =
+  'a, button, input, textarea, select, option, label, summary, details, video, audio, iframe, [contenteditable="true"]'
+
 function findSourceBlock(surface: HTMLElement, start: number, tagName: string): HTMLElement | null {
   const matches = Array.from(
     surface.querySelectorAll<HTMLElement>(`[data-markdown-start="${start}"]`)
@@ -161,6 +167,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     const ignoreNextBlurRef = useRef(false)
     const previewUndoStackRef = useRef<string[]>([])
     const mermaidRenderSeqRef = useRef(0)
+    const scrollTopRef = useRef(0)
     const [activeEdit, setActiveEdit] = useState<ActiveBlockEdit | null>(null)
     const editHelpId = useId()
     const theme = useSettingsStore((s) => s.theme)
@@ -202,13 +209,19 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
         if (!block || !innerRef.current?.contains(block)) return false
         const start = Number(block.dataset.markdownStart)
         const end = Number(block.dataset.markdownEnd)
-        if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start) {
+        if (
+          !Number.isInteger(start) ||
+          !Number.isInteger(end) ||
+          start < 0 ||
+          end < start ||
+          end > source.length
+        ) {
           return false
         }
         beginBlockEdit(block, start, end)
         return true
       },
-      [beginBlockEdit, editingEnabled]
+      [beginBlockEdit, editingEnabled, source.length]
     )
 
     // ─── Task checkbox interaction (click + Enter; Space reaches here via the
@@ -232,7 +245,10 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           e.preventDefault()
           return
         }
-        if (beginEditFromTarget(e.target)) e.preventDefault()
+        if (beginEditFromTarget(e.target)) {
+          e.preventDefault()
+          return
+        }
       },
       [beginEditFromTarget, toggleFromEventTarget]
     )
@@ -249,7 +265,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       (event: React.MouseEvent<HTMLDivElement>) => {
         if (editingEnabled || !onRevealSource) return
         if (!(event.target instanceof window.HTMLElement)) return
-        if (event.target.closest('a, button, input, textarea')) return
+        if (event.target.closest(INTERACTIVE_SELECTOR)) return
         const block = event.target.closest<HTMLElement>(
           '[data-markdown-start-line][data-markdown-end-line]'
         )
@@ -297,6 +313,18 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       if (!editingEnabled) previewUndoStackRef.current = []
     }, [editingEnabled])
 
+    // Flipping the mode remounts the rendered markup (see the `key` below), which collapses the
+    // scroll container back to the top. Put the reader back where they were.
+    useLayoutEffect(() => {
+      const surface = innerRef.current
+      if (!surface || scrollTopRef.current === 0) return
+      surface.scrollTop = scrollTopRef.current
+    }, [editingEnabled])
+
+    // Deliberately gated on `!activeEdit`: inside the textarea, Control/Command+Z belongs to the
+    // browser's own text undo, which is what a user editing a block expects. The preview-level
+    // stack — one entry per committed block edit — takes over once the edit is finished or
+    // cancelled. The help text below states this.
     useEffect(() => {
       if (!editingEnabled || activeEdit || !onSourceChange) return
       const handleUndo = (event: KeyboardEvent) => {
@@ -354,27 +382,44 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       })
     }, [])
 
+    // Identifies *which* block is being edited, unlike `activeEdit`, which changes on every
+    // keystroke. Observers below are keyed on this so typing does not tear them down and rebuild
+    // them a character at a time.
+    const activeBlockKey = activeEdit ? `${activeEdit.start}:${activeEdit.tagName}` : null
+
     useLayoutEffect(() => {
-      if (!activeEdit || !innerRef.current) return
+      if (!activeBlockKey || !innerRef.current) return
       const surface = innerRef.current
-      const block = findSourceBlock(surface, activeEdit.start, activeEdit.tagName)
-      const frame = scheduleFrame(remeasureActiveEdit)
       const handleResize = () => remeasureActiveEdit()
       window.addEventListener('resize', handleResize)
 
-      let observer: ResizeObserver | null = null
-      if (typeof ResizeObserver !== 'undefined') {
-        observer = new ResizeObserver(handleResize)
-        observer.observe(surface)
-        if (block) observer.observe(block)
+      let resizeObserver: ResizeObserver | null = null
+      if (window.ResizeObserver) {
+        resizeObserver = new window.ResizeObserver(handleResize)
+        resizeObserver.observe(surface)
+      }
+
+      // The edited block element itself is not observed: re-rendering the preview replaces it, so
+      // a direct observation would go stale. Watching the surface for child changes covers both
+      // the replacement and anything that reflows around it.
+      let mutationObserver: MutationObserver | null = null
+      if (window.MutationObserver) {
+        mutationObserver = new window.MutationObserver(handleResize)
+        mutationObserver.observe(surface, { childList: true, subtree: true })
       }
 
       return () => {
-        cancelFrame(frame)
         window.removeEventListener('resize', handleResize)
-        observer?.disconnect()
+        resizeObserver?.disconnect()
+        mutationObserver?.disconnect()
       }
-    }, [activeEdit, html, remeasureActiveEdit, showToc])
+    }, [activeBlockKey, remeasureActiveEdit])
+
+    useLayoutEffect(() => {
+      if (!activeBlockKey) return
+      const frame = scheduleFrame(remeasureActiveEdit)
+      return () => cancelFrame(frame)
+    }, [activeBlockKey, html, remeasureActiveEdit, showToc])
 
     useLayoutEffect(() => {
       const editor = editorRef.current
@@ -533,6 +578,9 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
           onClick={handlePreviewClick}
           onDoubleClick={handlePreviewDoubleClick}
           onKeyDown={handlePreviewKeyDown}
+          onScroll={(event) => {
+            scrollTopRef.current = event.currentTarget.scrollTop
+          }}
         >
           {html ? (
             <div
@@ -590,6 +638,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
               />
               <span id={editHelpId} className="sr-only">
                 Press Escape to cancel changes or Control or Command plus Enter to finish editing.
+                Control or Command plus Z undoes a previous block edit once this edit is finished.
               </span>
             </>
           )}

--- a/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
+++ b/apps/cockpit/src/tools/markdown-editor/MarkdownPreview.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from 'react'
 import { useSettingsStore } from '@/stores/settings.store'
 import { getEffectiveTheme, isLightEffectiveTheme } from '@/lib/theme'
 import { Button } from '@/components/shared/Button'
 import { SectionLabel } from '@/components/shared/SectionLabel'
+import { TextArea } from '@/components/shared/TextArea'
+import { Toggle } from '@/components/shared/Toggle'
 import { nextHeadingId } from './heading-ids'
 
 type TocEntry = {
@@ -17,6 +27,21 @@ type MarkdownPreviewProps = {
   toc: TocEntry[]
   /** Called with the source-order index of a GFM task-list checkbox that was toggled. */
   onToggleTask?: (index: number) => void
+  source?: string
+  editingEnabled?: boolean
+  showEditingToggle?: boolean
+  onEditingEnabledChange?: (enabled: boolean) => void
+  onSourceChange?: (source: string) => void
+}
+
+type ActiveBlockEdit = {
+  prefix: string
+  suffix: string
+  draft: string
+  left: number
+  top: number
+  width: number
+  minHeight: number
 }
 
 // ─── Preview Styles (extracted + polished) ──────────────────────────
@@ -88,10 +113,63 @@ const PREVIEW_STYLES = [
 // ─── Component ──────────────────────────────────────────────────────
 
 export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
-  function MarkdownPreview({ html, showToc, toc, onToggleTask }, ref) {
+  function MarkdownPreview(
+    {
+      html,
+      showToc,
+      toc,
+      onToggleTask,
+      source = '',
+      editingEnabled = false,
+      showEditingToggle = false,
+      onEditingEnabledChange,
+      onSourceChange,
+    },
+    ref
+  ) {
     const innerRef = useRef<HTMLDivElement>(null)
+    const editorRef = useRef<HTMLTextAreaElement>(null)
     const mermaidRenderSeqRef = useRef(0)
+    const [activeEdit, setActiveEdit] = useState<ActiveBlockEdit | null>(null)
     const theme = useSettingsStore((s) => s.theme)
+
+    const beginBlockEdit = useCallback(
+      (element: HTMLElement, start: number, end: number) => {
+        if (!innerRef.current || !onSourceChange) return
+        const surfaceRect = innerRef.current.getBoundingClientRect()
+        const blockRect = element.getBoundingClientRect()
+        setActiveEdit({
+          prefix: source.slice(0, start),
+          suffix: source.slice(end),
+          draft: source.slice(start, end),
+          left: blockRect.left - surfaceRect.left + innerRef.current.scrollLeft,
+          top: blockRect.top - surfaceRect.top + innerRef.current.scrollTop,
+          width: blockRect.width,
+          minHeight: Math.max(blockRect.height, 44),
+        })
+        requestAnimationFrame(() => {
+          editorRef.current?.focus()
+          editorRef.current?.select()
+        })
+      },
+      [onSourceChange, source]
+    )
+
+    const beginEditFromTarget = useCallback(
+      (target: EventTarget | null) => {
+        if (!editingEnabled || !(target instanceof window.HTMLElement)) return false
+        const block = target.closest<HTMLElement>('[data-markdown-start][data-markdown-end]')
+        if (!block || !innerRef.current?.contains(block)) return false
+        const start = Number(block.dataset.markdownStart)
+        const end = Number(block.dataset.markdownEnd)
+        if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start) {
+          return false
+        }
+        beginBlockEdit(block, start, end)
+        return true
+      },
+      [beginBlockEdit, editingEnabled]
+    )
 
     // ─── Task checkbox interaction (click + Enter; Space reaches here via the
     // native click a focused checkbox fires) ──────────────────────────────
@@ -110,17 +188,35 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
 
     const handlePreviewClick = useCallback(
       (e: React.MouseEvent<HTMLDivElement>) => {
-        if (toggleFromEventTarget(e.target)) e.preventDefault()
+        if (toggleFromEventTarget(e.target)) {
+          e.preventDefault()
+          return
+        }
+        if (beginEditFromTarget(e.target)) e.preventDefault()
       },
-      [toggleFromEventTarget]
+      [beginEditFromTarget, toggleFromEventTarget]
     )
 
     const handlePreviewKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (e.key !== 'Enter') return
-        if (toggleFromEventTarget(e.target)) e.preventDefault()
+        if (toggleFromEventTarget(e.target) || beginEditFromTarget(e.target)) e.preventDefault()
       },
-      [toggleFromEventTarget]
+      [beginEditFromTarget, toggleFromEventTarget]
+    )
+
+    const updateDraft = useCallback(
+      (draft: string) => {
+        setActiveEdit((current) => (current ? { ...current, draft } : null))
+        if (activeEdit) onSourceChange?.(`${activeEdit.prefix}${draft}${activeEdit.suffix}`)
+        requestAnimationFrame(() => {
+          const editor = editorRef.current
+          if (!editor) return
+          editor.style.height = '0px'
+          editor.style.height = `${Math.max(activeEdit?.minHeight ?? 44, editor.scrollHeight)}px`
+        })
+      },
+      [activeEdit, onSourceChange]
     )
 
     // ─── Rendered HTML payload ────────────────────────────────────
@@ -135,13 +231,24 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     // Keeping the object stable makes React skip the write entirely.
     const htmlProp = useMemo(() => ({ __html: html }), [html])
 
+    // The rendered elements come from sanitized HTML, so opt them into the tab order only while
+    // editing is enabled. Enter then follows the same delegated path as a pointer click.
+    useEffect(() => {
+      if (!editingEnabled || !innerRef.current) return
+      const blocks = innerRef.current.querySelectorAll<HTMLElement>(
+        '[data-markdown-start][data-markdown-end]'
+      )
+      blocks.forEach((block) => block.setAttribute('tabindex', '0'))
+      return () => blocks.forEach((block) => block.removeAttribute('tabindex'))
+    }, [editingEnabled, html])
+
     // Expose the inner div via forwarded ref for scroll sync
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     useImperativeHandle(ref, () => innerRef.current!, []) // safe: called after mount, ref is populated
 
     // ─── Mermaid diagrams (theme-aware) ───────────────────────────
     useEffect(() => {
-      if (!html || !innerRef.current) return
+      if (!html || !innerRef.current || editingEnabled) return
       const renderSeq = (mermaidRenderSeqRef.current += 1)
       let cancelled = false
       const mermaidBlocks = innerRef.current.querySelectorAll('code.language-mermaid')
@@ -174,7 +281,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
       return () => {
         cancelled = true
       }
-    }, [html, theme])
+    }, [editingEnabled, html, theme])
 
     // ─── TOC scroll ───────────────────────────────────────────────
     function scrollToHeading(id: string) {
@@ -191,7 +298,21 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
     }
 
     return (
-      <div className="flex h-full overflow-hidden">
+      <div className="relative flex h-full overflow-hidden">
+        {showEditingToggle && onEditingEnabledChange && (
+          <div className="absolute right-3 top-3 z-20 rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-2.5 py-1.5 shadow-sm">
+            <Toggle
+              checked={editingEnabled}
+              onChange={(enabled) => {
+                setActiveEdit(null)
+                onEditingEnabledChange(enabled)
+              }}
+              label="Edit preview"
+              aria-label="Edit preview"
+            />
+          </div>
+        )}
+
         {/* TOC Sidebar */}
         {showToc && toc.length > 0 && (
           <div className="w-48 shrink-0 overflow-auto border-r border-[var(--color-border)] p-3">
@@ -217,17 +338,54 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
         {/* Preview Content */}
         <div
           ref={innerRef}
-          className="flex-1 overflow-auto p-6"
+          className={`relative flex-1 overflow-auto p-6 ${editingEnabled ? 'cursor-text' : ''}`}
           data-selection-surface="markdown-preview"
           onClick={handlePreviewClick}
           onKeyDown={handlePreviewKeyDown}
         >
           {html ? (
-            <div className={PREVIEW_STYLES} dangerouslySetInnerHTML={htmlProp} />
+            <div
+              // Remounting only when the mode flips restores canonical markup after Mermaid may
+              // have replaced a source code block with SVG. Ordinary renders retain DOM identity.
+              key={editingEnabled ? 'editing' : 'reading'}
+              className={`${PREVIEW_STYLES} ${
+                editingEnabled
+                  ? '[&_[data-markdown-start]]:cursor-text [&_[data-markdown-start]:hover]:outline [&_[data-markdown-start]:hover]:outline-1 [&_[data-markdown-start]:hover]:outline-[var(--color-accent-dim)]'
+                  : ''
+              }`}
+              dangerouslySetInnerHTML={htmlProp}
+            />
           ) : (
-            <div className="text-sm text-[var(--color-text-muted)]">
+            <div
+              className="min-h-11 text-sm text-[var(--color-text-muted)]"
+              data-markdown-start="0"
+              data-markdown-end="0"
+            >
               Start typing markdown in the editor...
             </div>
+          )}
+          {editingEnabled && activeEdit && (
+            <TextArea
+              ref={editorRef}
+              value={activeEdit.draft}
+              onChange={(event) => updateDraft(event.target.value)}
+              onBlur={() => setActiveEdit(null)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  setActiveEdit(null)
+                }
+              }}
+              aria-label="Edit markdown block"
+              monospace
+              className="absolute z-10 resize-none overflow-hidden shadow-lg shadow-[var(--color-shadow)]"
+              style={{
+                left: `${activeEdit.left}px`,
+                top: `${activeEdit.top}px`,
+                width: `${activeEdit.width}px`,
+                minHeight: `${activeEdit.minHeight}px`,
+              }}
+            />
           )}
         </div>
       </div>

--- a/apps/cockpit/src/tools/markdown-editor/hooks/useScrollSync.ts
+++ b/apps/cockpit/src/tools/markdown-editor/hooks/useScrollSync.ts
@@ -19,7 +19,21 @@ type ScrollSource = 'editor' | 'preview' | null
 
 const SOURCE_SELECTOR =
   '[data-markdown-start-line][data-markdown-end-line][data-markdown-start][data-markdown-end]'
-const COOLDOWN_MS = 80
+// Back to the pre-line-mapping value: the extra window existed to cover per-frame DOM measurement,
+// which the entry cache removed. Shorter means the other pane regains control sooner.
+const COOLDOWN_MS = 50
+
+// Mirrors the preview's own scheduler: environments without rAF (jsdom, and the tests that run
+// there) still need the deferred measurement to happen rather than throw.
+function scheduleFrame(callback: () => void): number {
+  if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(callback)
+  return window.setTimeout(callback, 0)
+}
+
+function cancelFrame(handle: number): void {
+  if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(handle)
+  else window.clearTimeout(handle)
+}
 
 function interpolate(
   value: number,
@@ -116,6 +130,56 @@ function clampScrollTop(value: number, scrollHeight: number, clientHeight: numbe
   return Math.min(Math.max(0, scrollHeight - clientHeight), Math.max(0, value))
 }
 
+/**
+ * Measuring every annotated block costs a full layout pass, so it must not happen on each scroll
+ * frame. The entry list only changes when the rendered markup changes or the layout reflows, so
+ * cache it and invalidate from a MutationObserver plus a ResizeObserver instead. Entries are stored
+ * relative to the scroll container's content box (rect offset plus `scrollTop`), which scrolling
+ * does not alter — that is what makes the cache safe to keep across scroll events.
+ */
+function createLineEntryCache(preview: HTMLDivElement) {
+  let entries: PreviewLineEntry[] | null = null
+
+  const invalidate = () => {
+    entries = null
+  }
+
+  // Reached through `window` rather than as bare globals: the test harness attaches jsdom to
+  // `window` without mirroring it onto `globalThis`, so the bare names would read as undefined and
+  // quietly disable invalidation there.
+  const mutationObserver = window.MutationObserver
+    ? new window.MutationObserver(() => {
+        invalidate()
+        observeContent()
+      })
+    : null
+  const resizeObserver = window.ResizeObserver ? new window.ResizeObserver(invalidate) : null
+
+  // Content height can change without a mutation (images and Mermaid SVGs settling late), so the
+  // rendered wrapper is observed alongside the scroll container itself.
+  function observeContent() {
+    if (!resizeObserver) return
+    resizeObserver.disconnect()
+    resizeObserver.observe(preview)
+    for (const child of Array.from(preview.children)) resizeObserver.observe(child)
+  }
+
+  mutationObserver?.observe(preview, { childList: true, subtree: true })
+  observeContent()
+
+  return {
+    get(): PreviewLineEntry[] {
+      if (entries === null) entries = getPreviewLineEntries(preview)
+      return entries
+    },
+    dispose() {
+      mutationObserver?.disconnect()
+      resizeObserver?.disconnect()
+      entries = null
+    },
+  }
+}
+
 export function useScrollSync(
   editor: ScrollSyncEditor | null,
   previewRef: RefObject<HTMLDivElement | null>,
@@ -131,6 +195,8 @@ export function useScrollSync(
     const preview = previewRef.current
     if (!preview) return
 
+    const lineEntries = createLineEntryCache(preview)
+
     const resetSource = () => {
       if (cooldownRef.current) clearTimeout(cooldownRef.current)
       cooldownRef.current = setTimeout(() => {
@@ -144,11 +210,11 @@ export function useScrollSync(
           sourceRef.current = 'editor'
           resetSource()
 
-          if (rafRef.current) cancelAnimationFrame(rafRef.current)
-          rafRef.current = requestAnimationFrame(() => {
+          if (rafRef.current) cancelFrame(rafRef.current)
+          rafRef.current = scheduleFrame(() => {
             const visibleLine = editor.getVisibleRanges()[0]?.startLineNumber
             if (!visibleLine) return
-            const target = previewOffsetForSourceLine(getPreviewLineEntries(preview), visibleLine)
+            const target = previewOffsetForSourceLine(lineEntries.get(), visibleLine)
             preview.scrollTop = clampScrollTop(target, preview.scrollHeight, preview.clientHeight)
           })
         })
@@ -159,9 +225,9 @@ export function useScrollSync(
       sourceRef.current = 'preview'
       resetSource()
 
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
-      rafRef.current = requestAnimationFrame(() => {
-        const line = sourceLineForPreviewOffset(getPreviewLineEntries(preview), preview.scrollTop)
+      if (rafRef.current) cancelFrame(rafRef.current)
+      rafRef.current = scheduleFrame(() => {
+        const line = sourceLineForPreviewOffset(lineEntries.get(), preview.scrollTop)
         editor.setScrollTop(editor.getTopForLineNumber(line))
       })
     }
@@ -171,12 +237,13 @@ export function useScrollSync(
     }
 
     return () => {
+      lineEntries.dispose()
       editorDisposable?.dispose()
       if (syncEditorWithPreview) {
         preview.removeEventListener('scroll', handlePreviewScroll)
       }
       if (cooldownRef.current) clearTimeout(cooldownRef.current)
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      if (rafRef.current) cancelFrame(rafRef.current)
       sourceRef.current = null
     }
   }, [editor, previewRef, syncEditorWithPreview, syncPreviewWithEditor])

--- a/apps/cockpit/src/tools/markdown-editor/hooks/useScrollSync.ts
+++ b/apps/cockpit/src/tools/markdown-editor/hooks/useScrollSync.ts
@@ -1,100 +1,183 @@
 import { useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
 
-type EditorInstance = {
-  onDidScrollChange: (cb: (e: { scrollTop: number }) => void) => { dispose: () => void }
-  getScrollTop: () => number
-  setScrollTop: (v: number) => void
-  getScrollHeight: () => number
-  getLayoutInfo: () => { height: number }
+export type ScrollSyncEditor = {
+  onDidScrollChange: (cb: () => void) => { dispose: () => void }
+  getVisibleRanges: () => ReadonlyArray<{ startLineNumber: number }>
+  getTopForLineNumber: (lineNumber: number) => number
+  setScrollTop: (value: number) => void
+}
+
+export type PreviewLineEntry = {
+  startLine: number
+  endLine: number
+  top: number
+  bottom: number
 }
 
 type ScrollSource = 'editor' | 'preview' | null
 
-// ─── Pure helpers (exported for testing) ────────────────────────────
+const SOURCE_SELECTOR =
+  '[data-markdown-start-line][data-markdown-end-line][data-markdown-start][data-markdown-end]'
+const COOLDOWN_MS = 80
 
-/** Compute scroll ratio 0..1 from scroll position */
-export function scrollRatio(scrollTop: number, scrollHeight: number, clientHeight: number): number {
-  const maxScroll = scrollHeight - clientHeight
-  if (maxScroll <= 0) return 0
-  return Math.min(1, Math.max(0, scrollTop / maxScroll))
+function interpolate(
+  value: number,
+  fromStart: number,
+  fromEnd: number,
+  toStart: number,
+  toEnd: number
+) {
+  if (fromEnd <= fromStart) return toStart
+  const progress = Math.min(1, Math.max(0, (value - fromStart) / (fromEnd - fromStart)))
+  return toStart + progress * (toEnd - toStart)
 }
 
-/** Convert ratio 0..1 to a scrollTop for a given container */
-export function applyRatio(ratio: number, scrollHeight: number, clientHeight: number): number {
-  const maxScroll = scrollHeight - clientHeight
-  if (maxScroll <= 0) return 0
-  return Math.round(ratio * maxScroll)
+/** Map a one-based Markdown source line to its rendered vertical offset. */
+export function previewOffsetForSourceLine(entries: PreviewLineEntry[], line: number): number {
+  if (entries.length === 0) return 0
+  const targetLine = Math.max(1, line)
+
+  for (const entry of entries) {
+    if (targetLine >= entry.startLine && targetLine <= entry.endLine) {
+      return interpolate(targetLine, entry.startLine, entry.endLine, entry.top, entry.bottom)
+    }
+  }
+
+  const nextIndex = entries.findIndex((entry) => entry.startLine > targetLine)
+  if (nextIndex === 0) return entries[0]?.top ?? 0
+  if (nextIndex === -1) return entries.at(-1)?.bottom ?? 0
+
+  const previous = entries[nextIndex - 1]
+  const next = entries[nextIndex]
+  if (!previous || !next) return 0
+  return interpolate(targetLine, previous.endLine, next.startLine, previous.bottom, next.top)
 }
 
-// ─── Hook ───────────────────────────────────────────────────────────
+/** Map a rendered vertical offset back to the nearest one-based Markdown source line. */
+export function sourceLineForPreviewOffset(entries: PreviewLineEntry[], offset: number): number {
+  if (entries.length === 0) return 1
+  const targetOffset = Math.max(0, offset)
 
-const COOLDOWN_MS = 50
+  for (const entry of entries) {
+    if (targetOffset >= entry.top && targetOffset <= entry.bottom) {
+      return Math.max(
+        1,
+        Math.round(
+          interpolate(targetOffset, entry.top, entry.bottom, entry.startLine, entry.endLine)
+        )
+      )
+    }
+  }
+
+  const nextIndex = entries.findIndex((entry) => entry.top > targetOffset)
+  if (nextIndex === 0) return entries[0]?.startLine ?? 1
+  if (nextIndex === -1) return entries.at(-1)?.endLine ?? 1
+
+  const previous = entries[nextIndex - 1]
+  const next = entries[nextIndex]
+  if (!previous || !next) return 1
+  return Math.max(
+    1,
+    Math.round(
+      interpolate(targetOffset, previous.bottom, next.top, previous.endLine, next.startLine)
+    )
+  )
+}
+
+function getPreviewLineEntries(preview: HTMLDivElement): PreviewLineEntry[] {
+  const previewRect = preview.getBoundingClientRect()
+  const elements = Array.from(preview.querySelectorAll<HTMLElement>(SOURCE_SELECTOR))
+  const leafElements = elements.filter((element) => !element.querySelector(SOURCE_SELECTOR))
+
+  return leafElements
+    .map((element): PreviewLineEntry | null => {
+      const startLine = Number(element.dataset.markdownStartLine)
+      const endLine = Number(element.dataset.markdownEndLine)
+      const rect = element.getBoundingClientRect()
+      if (
+        !Number.isInteger(startLine) ||
+        !Number.isInteger(endLine) ||
+        startLine < 1 ||
+        endLine < startLine ||
+        rect.height <= 0 ||
+        rect.width <= 0
+      ) {
+        return null
+      }
+      const top = rect.top - previewRect.top + preview.scrollTop
+      return { startLine, endLine, top, bottom: top + rect.height }
+    })
+    .filter((entry): entry is PreviewLineEntry => entry !== null)
+    .sort((a, b) => a.top - b.top || a.startLine - b.startLine)
+}
+
+function clampScrollTop(value: number, scrollHeight: number, clientHeight: number): number {
+  return Math.min(Math.max(0, scrollHeight - clientHeight), Math.max(0, value))
+}
 
 export function useScrollSync(
-  editorRef: RefObject<EditorInstance | null>,
+  editor: ScrollSyncEditor | null,
   previewRef: RefObject<HTMLDivElement | null>,
-  enabled: boolean
+  syncPreviewWithEditor: boolean,
+  syncEditorWithPreview: boolean
 ): void {
   const sourceRef = useRef<ScrollSource>(null)
   const cooldownRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rafRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!enabled) return
-
-    const editor = editorRef.current
+    if ((!syncPreviewWithEditor && !syncEditorWithPreview) || !editor) return
     const preview = previewRef.current
-    if (!editor || !preview) return
+    if (!preview) return
 
-    function resetSource() {
+    const resetSource = () => {
       if (cooldownRef.current) clearTimeout(cooldownRef.current)
       cooldownRef.current = setTimeout(() => {
         sourceRef.current = null
       }, COOLDOWN_MS)
     }
 
-    // Editor → Preview
-    const editorDisposable = editor.onDidScrollChange(() => {
-      if (sourceRef.current === 'preview') return
-      sourceRef.current = 'editor'
-      resetSource()
+    const editorDisposable = syncPreviewWithEditor
+      ? editor.onDidScrollChange(() => {
+          if (sourceRef.current === 'preview') return
+          sourceRef.current = 'editor'
+          resetSource()
 
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
-      rafRef.current = requestAnimationFrame(() => {
-        if (!preview) return
-        const ratio = scrollRatio(
-          editor.getScrollTop(),
-          editor.getScrollHeight(),
-          editor.getLayoutInfo().height
-        )
-        preview.scrollTop = applyRatio(ratio, preview.scrollHeight, preview.clientHeight)
-      })
-    })
+          if (rafRef.current) cancelAnimationFrame(rafRef.current)
+          rafRef.current = requestAnimationFrame(() => {
+            const visibleLine = editor.getVisibleRanges()[0]?.startLineNumber
+            if (!visibleLine) return
+            const target = previewOffsetForSourceLine(getPreviewLineEntries(preview), visibleLine)
+            preview.scrollTop = clampScrollTop(target, preview.scrollHeight, preview.clientHeight)
+          })
+        })
+      : null
 
-    // Preview → Editor
-    function handlePreviewScroll() {
+    const handlePreviewScroll = () => {
       if (sourceRef.current === 'editor') return
       sourceRef.current = 'preview'
       resetSource()
 
       if (rafRef.current) cancelAnimationFrame(rafRef.current)
       rafRef.current = requestAnimationFrame(() => {
-        if (!editor || !preview) return
-        const ratio = scrollRatio(preview.scrollTop, preview.scrollHeight, preview.clientHeight)
-        editor.setScrollTop(
-          applyRatio(ratio, editor.getScrollHeight(), editor.getLayoutInfo().height)
-        )
+        const line = sourceLineForPreviewOffset(getPreviewLineEntries(preview), preview.scrollTop)
+        editor.setScrollTop(editor.getTopForLineNumber(line))
       })
     }
 
-    preview.addEventListener('scroll', handlePreviewScroll, { passive: true })
+    if (syncEditorWithPreview) {
+      preview.addEventListener('scroll', handlePreviewScroll, { passive: true })
+    }
 
     return () => {
-      editorDisposable.dispose()
-      preview.removeEventListener('scroll', handlePreviewScroll)
+      editorDisposable?.dispose()
+      if (syncEditorWithPreview) {
+        preview.removeEventListener('scroll', handlePreviewScroll)
+      }
       if (cooldownRef.current) clearTimeout(cooldownRef.current)
       if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      sourceRef.current = null
     }
-  }, [enabled]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [editor, previewRef, syncEditorWithPreview, syncPreviewWithEditor])
 }


### PR DESCRIPTION
## Summary

- adds a floating Edit preview switch to Preview mode with block-level rendered Markdown editing
- synchronizes editor and preview by source lines in both independently configurable directions
- highlights the preview block for the active source line and reveals/focuses source on preview double-click
- defines deterministic preview edit behavior: Escape cancels, Control/Command+Enter commits, Control/Command+Z undoes, and returning to source restores the caret
- keeps edit overlays aligned through content reflow and viewport resizing, including Mermaid source metadata

## Test plan

- [x] Run TypeScript typecheck
- [x] Run the full Vitest suite (1,728 tests across 133 files)
- [x] Run lint and design-system validation
- [x] Verify line-aware scroll sync in both directions in the Chromium browser harness
- [x] Verify active-line marker and independent synchronization controls
- [x] Verify preview edit cancel, commit, undo, caret restoration, double-click reveal, and responsive overlay geometry
- [x] Confirm no browser console errors